### PR TITLE
Arc fix

### DIFF
--- a/KicadModTree/KicadFileHandler.py
+++ b/KicadModTree/KicadFileHandler.py
@@ -126,7 +126,7 @@ class KicadFileHandler(FileHandler):
 
     def serialize_Arc(self, node):
         render_strings = ['fp_arc']
-        render_strings.append(node.getRealPosition(node.start_pos).render('(center {x} {y})'))
+        render_strings.append(node.getRealPosition(node.start_pos).render('(start {x} {y})'))
         render_strings.append(node.getRealPosition(node.end_pos).render('(end {x} {y})'))
         render_strings.append('(angle {angle})'.format(angle=node.angle))
         render_strings.append('(layer {layer})'.format(layer=node.layer))

--- a/KicadModTree/nodes/base/Arc.py
+++ b/KicadModTree/nodes/base/Arc.py
@@ -22,7 +22,7 @@ from KicadModTree.nodes.Node import Node
 class Arc(Node):
     def __init__(self, **kwargs):
         Node.__init__(self)
-        self.start_pos = Point(kwargs['start'])
+        self.start_pos = Point(kwargs['center'])
         self.end_pos = Point(kwargs['end'])
         self.angle = kwargs['angle']
 

--- a/KicadModTree/nodes/base/Arc.py
+++ b/KicadModTree/nodes/base/Arc.py
@@ -39,7 +39,7 @@ class Arc(Node):
 
     def _getRenderTreeText(self):
         render_strings = ['fp_arc']
-        render_strings.append(self.start_pos.render('(center {x} {y})'))
+        render_strings.append(self.start_pos.render('(start {x} {y})'))
         render_strings.append(self.end_pos.render('(end {x} {y})'))
         render_strings.append('(angle {angle})'.format(angle=self.angle))
         render_strings.append('(layer {layer})'.format(layer=self.layer))


### PR DESCRIPTION
Fix to the Arc node type, text rendering had 'center' instead of 'start'