### PR TITLE
JST PH scripts: Corrected drill size, pad numbering and klc issues

### DIFF
--- a/scripts/JST/connectors_jst_ph_smd_side.py
+++ b/scripts/JST/connectors_jst_ph_smd_side.py
@@ -13,9 +13,12 @@ LAYERS_THT = ['*.Cu','*.Mask']
 LAYERS_NPTH = ['*.Cu', '*.Mask']
 
 output_dir = os.getcwd()
-_3dshapes = "Connectors_JST.3dshapes"+os.sep
+_3dshapes = "${KISYS3DMOD}/Connectors_JST.3dshapes"+os.sep
 ref_on_ffab = False
 main_ref_on_silk = True
+
+allow_silk_below_part = True
+
 fab_line_width = 0.1
 silk_line_width = 0.12
 value_fontsize = [1,1]
@@ -43,39 +46,57 @@ def round_to(n, precision):
 def round_crty_point(point):
     return [round_to(point[0],CrtYd_grid),round_to(point[1],CrtYd_grid)]
 
+config_to_use = "KLCv2.0"
+
 if len(sys.argv) > 1:
-    if sys.argv[1] == "TERA":
-        ref_on_ffab = True
-        main_ref_on_silk = False
-        fab_line_width = 0.05
-        silk_line_width = 0.15
-        _3dshapes = "tera_Connectors_JST.3dshapes"+os.sep
-        value_fontsize = [0.6,0.6]
-        value_fontwidth = 0.1
-        fab_pin1_marker_type = 2
-        value_inside = True
-    elif sys.argv[1] == "KLCv1.1":
-        _3dshapes = "Connectors_JST.3dshapes"+os.sep
-        ref_on_ffab = False
-        main_ref_on_silk = True
-        fab_line_width = 0.1
-        silk_line_width = 0.15
-        value_fontsize = [1,1]
-        value_fontwidth=0.15
-        value_inside = False
-    elif sys.argv[1] == "KLCv1.2":
-        _3dshapes = "Connectors_JST.3dshapes"+os.sep
-        ref_on_ffab = True
-        main_ref_on_silk = True
-        fab_line_width = 0.1
-        silk_line_width = 0.12
-        value_fontsize = [1,1]
-        value_fontwidth = 0.15
-        value_inside = False
-        silk_reference_fontsize=[1,1]
-        silk_reference_fontwidth=0.15
-        fab_reference_fontsize=[1,1]
-        fab_reference_fontwidth=0.15
+    if sys.argv[1].lower() == "tera":
+        config_to_use = "TERA"
+    elif sys.argv[1].lower() == "klcv1.1":
+        config_to_use = "KLCv1.1"
+    elif sys.argv[1].lower() == "klcv2.0":
+        config_to_use = "KLCv2.0"
+
+print("Used configuration: " + config_to_use)
+
+
+if config_to_use == "TERA":
+    ref_on_ffab = True
+    main_ref_on_silk = False
+    fab_line_width = 0.05
+    silk_line_width = 0.15
+    _3dshapes = "${KISYS3DMOD}/tera_Connectors_JST.3dshapes"+os.sep
+    value_fontsize = [0.6,0.6]
+    value_fontwidth = 0.1
+    fab_pin1_marker_type = 2
+    value_inside = True
+    allow_silk_below_part = True
+elif config_to_use == "KLCv1.1":
+    _3dshapes = "${KISYS3DMOD}/Connectors_JST.3dshapes"+os.sep
+    ref_on_ffab = False
+    main_ref_on_silk = True
+    fab_line_width = 0.1
+    silk_line_width = 0.15
+    value_fontsize = [1,1]
+    value_fontwidth=0.15
+    value_inside = False
+    allow_silk_below_part = True
+elif config_to_use == "KLCv2.0":
+    _3dshapes = "${KISYS3DMOD}/Connectors_JST.3dshapes"+os.sep
+    ref_on_ffab = True
+    main_ref_on_silk = True
+    fab_line_width = 0.1
+    silk_line_width = 0.12
+    value_fontsize = [1,1]
+    value_fontwidth = 0.15
+    value_inside = False
+    silk_reference_fontsize=[1,1]
+    silk_reference_fontwidth=0.15
+    fab_reference_fontsize=[1,1]
+    fab_reference_fontwidth=0.15
+    allow_silk_below_part = False
+else:
+    print("Programming error: Unknown config!")
+    exit(-1)
 
 out_dir="Connectors_JST.pretty"+os.sep
 if len(sys.argv) > 2:
@@ -216,25 +237,26 @@ for pincount in range (2,16):
     ]
     kicad_mod.append(PolygoneLine(polygone=poly_silk_outline_top_right, layer='F.SilkS', width=silk_line_width))
 
-    poly_big_cutout=[
-        {'x':x_min+dx_big_cutout_to_side, 'y':silk_y_max},
-        {'x':x_min+dx_big_cutout_to_side, 'y':y_min_big_cutout},
-        {'x':x_max-dx_big_cutout_to_side, 'y':y_min_big_cutout},
-        {'x':x_max-dx_big_cutout_to_side, 'y':silk_y_max}
-    ]
-    kicad_mod.append(PolygoneLine(polygone=poly_big_cutout, layer='F.SilkS', width=silk_line_width))
-
-    kicad_mod.append(Line(start=[silk_x_min, silk_y_main_min], end=[tmp_x1, silk_y_main_min], layer='F.SilkS', width=silk_line_width))
-    kicad_mod.append(Line(start=[silk_x_max, silk_y_main_min], end=[tmp_x2, silk_y_main_min], layer='F.SilkS', width=silk_line_width))
-
     kicad_mod.append(Line(start=[x_left_mount_pad+mount_pad_size[0]/2.0+pad_to_silk, silk_y_max],
         end=[-x_left_mount_pad-mount_pad_size[0]/2.0-pad_to_silk, silk_y_max],
         layer='F.SilkS', width=silk_line_width))
 
-    kicad_mod.append(RectLine(start=[x_min+1.75, -0.7], end=[x_min+2.75, 2.7],
-        layer='F.SilkS', width=silk_line_width))
-    kicad_mod.append(RectLine(start=[x_max-1.75, -0.7], end=[x_max-2.75, 2.7],
-        layer='F.SilkS', width=silk_line_width))
+    if allow_silk_below_part:
+        poly_big_cutout=[
+            {'x':x_min+dx_big_cutout_to_side, 'y':silk_y_max},
+            {'x':x_min+dx_big_cutout_to_side, 'y':y_min_big_cutout},
+            {'x':x_max-dx_big_cutout_to_side, 'y':y_min_big_cutout},
+            {'x':x_max-dx_big_cutout_to_side, 'y':silk_y_max}
+        ]
+        kicad_mod.append(PolygoneLine(polygone=poly_big_cutout, layer='F.SilkS', width=silk_line_width))
+
+        kicad_mod.append(Line(start=[silk_x_min, silk_y_main_min], end=[tmp_x1, silk_y_main_min], layer='F.SilkS', width=silk_line_width))
+        kicad_mod.append(Line(start=[silk_x_max, silk_y_main_min], end=[tmp_x2, silk_y_main_min], layer='F.SilkS', width=silk_line_width))
+
+        kicad_mod.append(RectLine(start=[x_min+1.75, -0.7], end=[x_min+2.75, 2.7],
+            layer='F.SilkS', width=silk_line_width))
+        kicad_mod.append(RectLine(start=[x_max-1.75, -0.7], end=[x_max-2.75, 2.7],
+            layer='F.SilkS', width=silk_line_width))
 
     #Pin 1 Marker
     kicad_mod.append(Line(start=[first_pad_x-pad_size[0]/2.0-pad_to_silk, silk_y_main_min],
@@ -263,7 +285,7 @@ for pincount in range (2,16):
         Y = pad_pos_y
         X = first_pad_x + p * pitch
 
-        num = p
+        num = p+1
         kicad_mod.append(Pad(number=num, type=Pad.TYPE_SMT, shape=Pad.SHAPE_RECT,
                             at=[X, Y], size=pad_size, layers=LAYERS_SMT))
 

--- a/scripts/JST/connectors_jst_ph_smd_top.py
+++ b/scripts/JST/connectors_jst_ph_smd_top.py
@@ -13,7 +13,7 @@ LAYERS_THT = ['*.Cu','*.Mask']
 LAYERS_NPTH = ['*.Cu', '*.Mask']
 
 output_dir = os.getcwd()
-_3dshapes = "Connectors_JST.3dshapes"+os.sep
+_3dshapes = "${KISYS3DMOD}/Connectors_JST.3dshapes"+os.sep
 ref_on_ffab = False
 main_ref_on_silk = True
 fab_line_width = 0.1
@@ -25,6 +25,8 @@ silk_reference_fontsize=[1,1]
 silk_reference_fontwidth=0.15
 fab_reference_fontsize=[0.6,0.6]
 fab_reference_fontwidth=0.1
+
+allow_silk_below_part = True
 
 CrtYd_offset = 0.5
 CrtYd_linewidth = 0.05
@@ -43,39 +45,57 @@ def round_to(n, precision):
 def round_crty_point(point):
     return [round_to(point[0],CrtYd_grid),round_to(point[1],CrtYd_grid)]
 
+config_to_use = "KLCv2.0"
+
 if len(sys.argv) > 1:
-    if sys.argv[1] == "TERA":
-        ref_on_ffab = True
-        main_ref_on_silk = False
-        fab_line_width = 0.05
-        silk_line_width = 0.15
-        _3dshapes = "tera_Connectors_JST.3dshapes"+os.sep
-        value_fontsize = [0.6,0.6]
-        value_fontwidth = 0.1
-        fab_pin1_marker_type = 2
-        value_inside = True
-    elif sys.argv[1] == "KLCv1.1":
-        _3dshapes = "Connectors_JST.3dshapes"+os.sep
-        ref_on_ffab = False
-        main_ref_on_silk = True
-        fab_line_width = 0.1
-        silk_line_width = 0.15
-        value_fontsize = [1,1]
-        value_fontwidth=0.15
-        value_inside = False
-    elif sys.argv[1] == "KLCv1.2":
-        _3dshapes = "Connectors_JST.3dshapes"+os.sep
-        ref_on_ffab = True
-        main_ref_on_silk = True
-        fab_line_width = 0.1
-        silk_line_width = 0.12
-        value_fontsize = [1,1]
-        value_fontwidth = 0.15
-        value_inside = False
-        silk_reference_fontsize=[1,1]
-        silk_reference_fontwidth=0.15
-        fab_reference_fontsize=[1,1]
-        fab_reference_fontwidth=0.15
+    if sys.argv[1].lower() == "tera":
+        config_to_use = "TERA"
+    elif sys.argv[1].lower() == "klcv1.1":
+        config_to_use = "KLCv1.1"
+    elif sys.argv[1].lower() == "klcv2.0":
+        config_to_use = "KLCv2.0"
+
+print("Used configuration: " + config_to_use)
+
+
+if config_to_use == "TERA":
+    ref_on_ffab = True
+    main_ref_on_silk = False
+    fab_line_width = 0.05
+    silk_line_width = 0.15
+    _3dshapes = "${KISYS3DMOD}/tera_Connectors_JST.3dshapes"+os.sep
+    value_fontsize = [0.6,0.6]
+    value_fontwidth = 0.1
+    fab_pin1_marker_type = 2
+    value_inside = True
+    allow_silk_below_part = True
+elif config_to_use == "KLCv1.1":
+    _3dshapes = "${KISYS3DMOD}/Connectors_JST.3dshapes"+os.sep
+    ref_on_ffab = False
+    main_ref_on_silk = True
+    fab_line_width = 0.1
+    silk_line_width = 0.15
+    value_fontsize = [1,1]
+    value_fontwidth=0.15
+    value_inside = False
+    allow_silk_below_part = True
+elif config_to_use == "KLCv2.0":
+    _3dshapes = "${KISYS3DMOD}/Connectors_JST.3dshapes"+os.sep
+    ref_on_ffab = True
+    main_ref_on_silk = True
+    fab_line_width = 0.1
+    silk_line_width = 0.12
+    value_fontsize = [1,1]
+    value_fontwidth = 0.15
+    value_inside = False
+    silk_reference_fontsize=[1,1]
+    silk_reference_fontwidth=0.15
+    fab_reference_fontsize=[1,1]
+    fab_reference_fontwidth=0.15
+    allow_silk_below_part = False
+else:
+    print("Programming error: Unknown config!")
+    exit(-1)
 
 out_dir="Connectors_JST.pretty"+os.sep
 if len(sys.argv) > 2:
@@ -196,24 +216,24 @@ for pincount in range (2,17):
         {'x':-first_pad_x+pad_size[0]/2.0+pad_to_silk, 'y':silk_y_max}
     ]
     kicad_mod.append(PolygoneLine(polygone=poly_silk_bottom_right, layer='F.SilkS', width=silk_line_width))
+    if allow_silk_below_part:
+        poly_silk_inner_left = [
+            {'x':silk_x_min+3.5, 'y':silk_y_min},
+            {'x':silk_x_min+3.5, 'y':silk_y_min+0.7},
+            {'x':silk_x_min+1.8, 'y':silk_y_min+0.7},
+            {'x':silk_x_min+1.8, 'y':silk_y_max-0.8},
+            {'x':first_pad_x-pad_size[0]/2.0-pad_to_silk, 'y':silk_y_max-0.8}
+        ]
+        kicad_mod.append(PolygoneLine(polygone=poly_silk_inner_left, layer='F.SilkS', width=silk_line_width))
 
-    poly_silk_inner_left = [
-        {'x':silk_x_min+3.5, 'y':silk_y_min},
-        {'x':silk_x_min+3.5, 'y':silk_y_min+0.7},
-        {'x':silk_x_min+1.8, 'y':silk_y_min+0.7},
-        {'x':silk_x_min+1.8, 'y':silk_y_max-0.8},
-        {'x':first_pad_x-pad_size[0]/2.0-pad_to_silk, 'y':silk_y_max-0.8}
-    ]
-    kicad_mod.append(PolygoneLine(polygone=poly_silk_inner_left, layer='F.SilkS', width=silk_line_width))
-
-    poly_silk_inner_right = [
-        {'x':silk_x_max-3.5, 'y':silk_y_min},
-        {'x':silk_x_max-3.5, 'y':silk_y_min+0.7},
-        {'x':silk_x_max-1.8, 'y':silk_y_min+0.7},
-        {'x':silk_x_max-1.8, 'y':silk_y_max-0.8},
-        {'x':-first_pad_x+pad_size[0]/2.0+pad_to_silk, 'y':silk_y_max-0.8}
-    ]
-    kicad_mod.append(PolygoneLine(polygone=poly_silk_inner_right, layer='F.SilkS', width=silk_line_width))
+        poly_silk_inner_right = [
+            {'x':silk_x_max-3.5, 'y':silk_y_min},
+            {'x':silk_x_max-3.5, 'y':silk_y_min+0.7},
+            {'x':silk_x_max-1.8, 'y':silk_y_min+0.7},
+            {'x':silk_x_max-1.8, 'y':silk_y_max-0.8},
+            {'x':-first_pad_x+pad_size[0]/2.0+pad_to_silk, 'y':silk_y_max-0.8}
+        ]
+        kicad_mod.append(PolygoneLine(polygone=poly_silk_inner_right, layer='F.SilkS', width=silk_line_width))
 
     #Fab outline
     kicad_mod.append(RectLine(start=[x_min, y_min], end=[x_max, y_max],
@@ -246,7 +266,7 @@ for pincount in range (2,17):
         Y = pad_pos_y
         X = first_pad_x + p * pitch
 
-        num = p
+        num = p+1
         kicad_mod.append(Pad(number=num, type=Pad.TYPE_SMT, shape=Pad.SHAPE_RECT,
                             at=[X, Y], size=pad_size, layers=LAYERS_SMT))
 

--- a/scripts/JST/connectors_jst_ph_tht_side.py
+++ b/scripts/JST/connectors_jst_ph_tht_side.py
@@ -12,7 +12,7 @@ LAYERS_THT = ['*.Cu','*.Mask']
 LAYERS_NPTH = ['*.Cu', '*.Mask']
 
 output_dir = os.getcwd()
-_3dshapes = "Connectors_JST.3dshapes"+os.sep
+_3dshapes = "${KISYS3DMOD}/Connectors_JST.3dshapes"+os.sep
 ref_on_ffab = False
 main_ref_on_silk = True
 fab_line_width = 0.1
@@ -36,6 +36,7 @@ silk_pin1_marker_type = 1
 
 pad_to_silk = 0.2
 pad_size=[1.2, 1.7]
+drill_size = 0.75 #Datasheet: 0.7 +0.1/-0.0 => It might be better to assume 0.75 +/-0.05mm
 
 def round_to(n, precision):
     correction = 0.5 if n >= 0 else -0.5
@@ -44,41 +45,56 @@ def round_to(n, precision):
 def round_crty_point(point):
     return [round_to(point[0],CrtYd_grid),round_to(point[1],CrtYd_grid)]
 
+config_to_use = "KLCv2.0"
+
 if len(sys.argv) > 1:
-    if sys.argv[1] == "TERA":
-        ref_on_ffab = True
-        main_ref_on_silk = False
-        fab_line_width = 0.05
-        silk_line_width = 0.15
-        _3dshapes = "tera_Connectors_JST.3dshapes"+os.sep
-        value_fontsize = [0.6,0.6]
-        value_fontwidth = 0.1
-        fab_pin1_marker_type = 2
-        value_inside = True
-    elif sys.argv[1] == "KLCv1.1":
-        _3dshapes = "Connectors_JST.3dshapes"+os.sep
-        ref_on_ffab = False
-        main_ref_on_silk = True
-        fab_line_width = 0.1
-        silk_line_width = 0.15
-        value_fontsize = [1,1]
-        value_fontwidth=0.15
-        value_inside = False
-    elif sys.argv[1] == "KLCv1.2":
-        _3dshapes = "Connectors_JST.3dshapes"+os.sep
-        ref_on_ffab = True
-        main_ref_on_silk = True
-        fab_line_width = 0.1
-        silk_line_width = 0.12
-        value_fontsize = [1,1]
-        value_fontwidth = 0.15
-        value_inside = False
-        silk_reference_fontsize=[1,1]
-        silk_reference_fontwidth=0.15
-        fab_reference_fontsize=[1,1]
-        fab_reference_fontwidth=0.15
-        fab_pin1_marker_type = 3
-        silk_pin1_marker_type = 2
+    if sys.argv[1].lower() == "tera":
+        config_to_use = "TERA"
+    elif sys.argv[1].lower() == "klcv1.1":
+        config_to_use = "KLCv1.1"
+    elif sys.argv[1].lower() == "klcv2.0":
+        config_to_use = "KLCv2.0"
+
+print("Used configuration: " + config_to_use)
+
+if config_to_use == "TERA":
+    ref_on_ffab = True
+    main_ref_on_silk = False
+    fab_line_width = 0.05
+    silk_line_width = 0.15
+    _3dshapes = "${KISYS3DMOD}/tera_Connectors_JST.3dshapes"+os.sep
+    value_fontsize = [0.6,0.6]
+    value_fontwidth = 0.1
+    fab_pin1_marker_type = 2
+    value_inside = True
+    drill_size = 0.8 # A bit bigger for hand soldering
+elif config_to_use == "KLCv1.1":
+    _3dshapes = "${KISYS3DMOD}/Connectors_JST.3dshapes"+os.sep
+    ref_on_ffab = False
+    main_ref_on_silk = True
+    fab_line_width = 0.1
+    silk_line_width = 0.15
+    value_fontsize = [1,1]
+    value_fontwidth=0.15
+    value_inside = False
+elif config_to_use == "KLCv2.0":
+    _3dshapes = "${KISYS3DMOD}/Connectors_JST.3dshapes"+os.sep
+    ref_on_ffab = True
+    main_ref_on_silk = True
+    fab_line_width = 0.1
+    silk_line_width = 0.12
+    value_fontsize = [1,1]
+    value_fontwidth = 0.15
+    value_inside = False
+    silk_reference_fontsize=[1,1]
+    silk_reference_fontwidth=0.15
+    fab_reference_fontsize=[1,1]
+    fab_reference_fontwidth=0.15
+    fab_pin1_marker_type = 3
+    silk_pin1_marker_type = 2
+else:
+    print("Programming error: Unknown config!")
+    exit(-1)
 
 out_dir="Connectors_JST.pretty"+os.sep
 if len(sys.argv) > 2:
@@ -234,7 +250,7 @@ for pincount in range (2,17):
     #add the pads
     kicad_mod.append(Pad(number=1, type=Pad.TYPE_THT, shape=Pad.SHAPE_RECT,
                         at=[0, 0], size=pad_size,
-                        drill=0.7, layers=LAYERS_THT))
+                        drill=drill_size, layers=LAYERS_THT))
     for p in range(1, pincount):
         Y = 0
         X = p * pitch
@@ -242,7 +258,7 @@ for pincount in range (2,17):
         num = p+1
         kicad_mod.append(Pad(number=num, type=Pad.TYPE_THT, shape=Pad.SHAPE_OVAL,
                             at=[X, Y], size=pad_size,
-                            drill=0.7, layers=LAYERS_THT))
+                            drill=drill_size, layers=LAYERS_THT))
 
 
     # pin 1 marker

--- a/scripts/JST/connectors_jst_ph_tht_top.py
+++ b/scripts/JST/connectors_jst_ph_tht_top.py
@@ -13,7 +13,7 @@ LAYERS_THT = ['*.Cu','*.Mask']
 LAYERS_NPTH = ['*.Cu', '*.Mask']
 
 output_dir = os.getcwd()
-_3dshapes = "Connectors_JST.3dshapes"+os.sep
+_3dshapes = "${KISYS3DMOD}/Connectors_JST.3dshapes"+os.sep
 ref_on_ffab = False
 main_ref_on_silk = True
 fab_line_width = 0.1
@@ -33,6 +33,9 @@ pin1_marker_offset = 0.3
 pin1_marker_linelen = 1.25
 fab_pin1_marker_type = 1
 
+pad_size=[1.2, 1.7]
+drill_size = 0.75 #Datasheet: 0.7 +0.1/-0.0 => It might be better to assume 0.75 +/-0.05mm
+
 def round_to(n, precision):
     correction = 0.5 if n >= 0 else -0.5
     return int( n/precision+correction ) * precision
@@ -40,39 +43,54 @@ def round_to(n, precision):
 def round_crty_point(point):
     return [round_to(point[0],CrtYd_grid),round_to(point[1],CrtYd_grid)]
 
+config_to_use = "KLCv2.0"
+
 if len(sys.argv) > 1:
-    if sys.argv[1] == "TERA":
-        ref_on_ffab = True
-        main_ref_on_silk = False
-        fab_line_width = 0.05
-        silk_line_width = 0.15
-        _3dshapes = "tera_Connectors_JST.3dshapes"+os.sep
-        value_fontsize = [0.6,0.6]
-        value_fontwidth = 0.1
-        fab_pin1_marker_type = 2
-        value_inside = True
-    elif sys.argv[1] == "KLCv1.1":
-        _3dshapes = "Connectors_JST.3dshapes"+os.sep
-        ref_on_ffab = False
-        main_ref_on_silk = True
-        fab_line_width = 0.1
-        silk_line_width = 0.15
-        value_fontsize = [1,1]
-        value_fontwidth=0.15
-        value_inside = False
-    elif sys.argv[1] == "KLCv1.2":
-        _3dshapes = "Connectors_JST.3dshapes"+os.sep
-        ref_on_ffab = True
-        main_ref_on_silk = True
-        fab_line_width = 0.1
-        silk_line_width = 0.12
-        value_fontsize = [1,1]
-        value_fontwidth = 0.15
-        value_inside = False
-        silk_reference_fontsize=[1,1]
-        silk_reference_fontwidth=0.15
-        fab_reference_fontsize=[1,1]
-        fab_reference_fontwidth=0.15
+    if sys.argv[1].lower() == "tera":
+        config_to_use = "TERA"
+    elif sys.argv[1].lower() == "klcv1.1":
+        config_to_use = "KLCv1.1"
+    elif sys.argv[1].lower() == "klcv2.0":
+        config_to_use = "KLCv2.0"
+
+print("Used configuration: " + config_to_use)
+
+if config_to_use == "TERA":
+    ref_on_ffab = True
+    main_ref_on_silk = False
+    fab_line_width = 0.05
+    silk_line_width = 0.15
+    _3dshapes = "${KISYS3DMOD}/tera_Connectors_JST.3dshapes"+os.sep
+    value_fontsize = [0.6,0.6]
+    value_fontwidth = 0.1
+    fab_pin1_marker_type = 2
+    value_inside = True
+    drill_size = 0.8
+elif config_to_use == "KLCv1.1":
+    _3dshapes = "${KISYS3DMOD}/Connectors_JST.3dshapes"+os.sep
+    ref_on_ffab = False
+    main_ref_on_silk = True
+    fab_line_width = 0.1
+    silk_line_width = 0.15
+    value_fontsize = [1,1]
+    value_fontwidth=0.15
+    value_inside = False
+elif config_to_use == "KLCv2.0":
+    _3dshapes = "${KISYS3DMOD}/Connectors_JST.3dshapes"+os.sep
+    ref_on_ffab = True
+    main_ref_on_silk = True
+    fab_line_width = 0.1
+    silk_line_width = 0.12
+    value_fontsize = [1,1]
+    value_fontwidth = 0.15
+    value_inside = False
+    silk_reference_fontsize=[1,1]
+    silk_reference_fontwidth=0.15
+    fab_reference_fontsize=[1,1]
+    fab_reference_fontwidth=0.15
+else:
+    print("Programming error: Unknown config!")
+    exit(-1)
 
 out_dir="Connectors_JST.pretty"+os.sep
 if len(sys.argv) > 2:
@@ -238,16 +256,16 @@ for pincount in range (2,17):
     #createNumberedPadsTHT(kicad_mod, pincount, 2, 0.7, {'x':1.2, 'y':1.7})
     #add the pads
     kicad_mod.append(Pad(number=1, type=Pad.TYPE_THT, shape=Pad.SHAPE_RECT,
-                        at=[0, 0], size=[1.2, 1.7],
-                        drill=0.7, layers=LAYERS_THT))
+                        at=[0, 0], size=pad_size,
+                        drill=drill_size, layers=LAYERS_THT))
     for p in range(1, pincount):
         Y = 0
         X = p * pitch
 
         num = p+1
         kicad_mod.append(Pad(number=num, type=Pad.TYPE_THT, shape=Pad.SHAPE_OVAL,
-                            at=[X, Y], size=[1.2, 1.7],
-                            drill=0.7, layers=LAYERS_THT))
+                            at=[X, Y], size=pad_size,
+                            drill=drill_size, layers=LAYERS_THT))
     #Add a model
     kicad_mod.append(Model(filename=_3dshapes + footprint_name + ".wrl", at=[0,0,0], scale=[1,1,1], rotate=[0,0,0]))
 


### PR DESCRIPTION
The jst ph scripts for the fixes in pull footprint library pull requests:
https://github.com/KiCad/Connectors_JST.pretty/pull/39
https://github.com/KiCad/Connectors_JST.pretty/pull/38

Without argument these scripts now build KLCv2.0 compatible footprints.