### PR TITLE
Fix GH top-entry pin order

### DIFF
--- a/scripts/JST/gh_smd_top.py
+++ b/scripts/JST/gh_smd_top.py
@@ -27,7 +27,7 @@ for pincount in range(2,16):
 
     A = (pincount - 1) * 1.25
     B = 3.25 + pincount * 1.25
-    
+
     #A and B should be 0.1mm resolution
     A = int(A/0.1) * 0.1
     B = int(B/0.1) * 0.1
@@ -36,114 +36,114 @@ for pincount in range(2,16):
 
     # SMT type shrouded header,
     footprint_name = "JST_GH_" + jst_name + "_{pincount:02}x1.25mm_Straight".format(pincount=pincount)
-    
+
     print(footprint_name)
 
     kicad_mod = KicadMod(footprint_name)
-    kicad_mod.setDescription("JST GH series connector, " + jst_name + ", top entry type") 
+    kicad_mod.setDescription("JST GH series connector, " + jst_name + ", top entry type")
     kicad_mod.setAttribute('smd')
     kicad_mod.setTags('connector jst GH SMT top vertical entry 1.25mm pitch')
 
-    kicad_mod.setCenterPos({'x':0, 'y':-3.075})
+    kicad_mod.setCenterPos({'x':0, 'y':3.075})
 
     #draw outline on the F.Fab layer
-    y1 = -4.25 / 2 - 2.25
-    y2 = y1 + 4.25
+    y1 = 4.25 / 2 + 2.25
+    y2 = y1 - 4.25
     kicad_mod.addRectLine(
         {'x': -B/2,'y': y1},
         {'x':  B/2,'y': y2},
         'F.Fab', 0.10
     )
-    
+
     # set general values
-    kicad_mod.addText('reference', 'REF**', {'x':0, 'y':-6.75}, 'F.SilkS')
-    kicad_mod.addText('user', '%R', {'x':0, 'y':-1.25}, 'F.Fab')
-    kicad_mod.addText('value', footprint_name, {'x':0, 'y':1.5}, 'F.Fab')
+    kicad_mod.addText('reference', 'REF**', {'x':0, 'y':-1.5}, 'F.SilkS')
+    kicad_mod.addText('user', '%R', {'x':0, 'y':1.25}, 'F.Fab')
+    kicad_mod.addText('value', footprint_name, {'x':0, 'y':6.75}, 'F.Fab')
 
     #create outline
     # create Courtyard
     # output kicad model
 
     #create pads
-    createNumberedPadsSMD(kicad_mod, pincount, pad_spacing, {'x':pad_w,'y':pad_h},-4.75)
+    createNumberedPadsSMD(kicad_mod, pincount, pad_spacing, {'x':pad_w,'y':pad_h}, 4.75, pad_number_offset=1)
 
     #add mounting pads (no number)
     mpad_w = 1.0
     mpad_h = 2.8
     mpad_x = (B/2) - (mpad_w/2)
-    mpad_y = -1.4
+    mpad_y = 1.4
 
     kicad_mod.addPad('""', 'smd', 'rect', {'x':mpad_x, 'y':mpad_y}, {'x':mpad_w, 'y':mpad_h}, 0, ['F.Cu', 'F.Paste', 'F.Mask'])
     kicad_mod.addPad('""', 'smd', 'rect', {'x':-mpad_x, 'y':mpad_y}, {'x':mpad_w, 'y':mpad_h}, 0, ['F.Cu', 'F.Paste', 'F.Mask'])
 
     #side-wall thickness
     T = 0.5
-    
+
     #add bottom line
-    kicad_mod.addPolygoneLine([{'x':-B/2+mpad_w+0.6,'y':0.05},
-                            {'x':B/2-mpad_w-0.6,'y':0.05},
-                            {'x':B/2-mpad_w-0.6,'y':0.05 - T},
-                            {'x':-B/2+mpad_w+0.6,'y':0.05 - T},
-                            {'x':-B/2+mpad_w+0.6,'y':0.05}], width=0.12)
-                             
+    kicad_mod.addPolygoneLine([{'x':-B/2+mpad_w+0.6,'y':-0.05},
+                            {'x':B/2-mpad_w-0.6,'y':-0.05},
+                            {'x':B/2-mpad_w-0.6,'y':-0.05+T},
+                            {'x':-B/2+mpad_w+0.6,'y':-0.05+T},
+                            {'x':-B/2+mpad_w+0.6,'y':-0.05}], width=0.12)
+
     #add left line
-    kicad_mod.addPolygoneLine([{'x':-B/2-0.1,'y':-3.3},
-                                {'x':-B/2-0.1,'y':-4.5},
-                                {'x':-A/2-pad_w/2-0.4,'y':-4.5},
-                                {'x':-A/2-pad_w/2-0.4,'y':-4.5+T},
-                                {'x':-B/2-0.1+T,'y':-4.5+T},
-                                {'x':-B/2-0.1+T,'y':-3.3},
-                                {'x':-B/2-0.1,'y':-3.3}], width=0.12)
+    kicad_mod.addPolygoneLine([{'x':-B/2-0.1,'y':3.3},
+                                {'x':-B/2-0.1,'y':4.5},
+                                {'x':-A/2-pad_w/2-0.4,'y':4.5},
+                                {'x':-A/2-pad_w/2-0.4,'y':4.5-T},
+                                {'x':-B/2-0.1+T,'y':4.5-T},
+                                {'x':-B/2-0.1+T,'y':3.3},
+                                {'x':-B/2-0.1,'y':3.3}], width=0.12)
 
     #add right line
-    kicad_mod.addPolygoneLine([{'x':B/2+0.1,'y':-3.3},
-                                {'x':B/2+0.1,'y':-4.5},
-                                {'x':A/2+pad_w/2+0.4,'y':-4.5},
-                                {'x':A/2+pad_w/2+0.4,'y':-4.5+T},
-                                {'x':B/2+0.1-T, 'y':-4.5+T},
-                                {'x':B/2+0.1-T, 'y':-3.3},
-                                {'x':B/2+0.1,'y':-3.3}], width=0.12)                                  
-                                
-                                
+    kicad_mod.addPolygoneLine([{'x':B/2+0.1,'y':3.3},
+                                {'x':B/2+0.1,'y':4.5},
+                                {'x':A/2+pad_w/2+0.4,'y':4.5},
+                                {'x':A/2+pad_w/2+0.4,'y':4.5-T},
+                                {'x':B/2+0.1-T, 'y':4.5-T},
+                                {'x':B/2+0.1-T, 'y':3.3},
+                                {'x':B/2+0.1,'y':3.3}], width=0.12)
+
+
     #add designator for pin #1
 
-    y1 = -5.25
+    y1 = 5.25
 
     if pincount % 2 == 1: #odd pins
         x1 = -(pincount//2) * pad_spacing
     else: #even pins
         x1 = (-pincount/2 + 0.5) * pad_spacing
-        
+
     xp = x1 - 1
 
     m = 0.6
-       
+
     marker = [{'x':xp,'y':y1},
-               {'x':xp-m,'y':y1-m/2},
                {'x':xp-m,'y':y1+m/2},
+               {'x':xp-m,'y':y1-m/2},
                {'x':xp,'y':y1}]
 
     kicad_mod.addPolygoneLine(marker, width=0.12)
     kicad_mod.addPolygoneLine(marker,layer='F.Fab', width=0.1)
-                               
-                               
+
+
     #add picture of each pin
     p = 0.25
-    
-    y = -2.5 
+
+    y = 2.5
 
     for i in range(pincount):
-    
+
         x = x1 + (i * pad_spacing)
-        kicad_mod.addPolygoneLine([{'x': x-p,'y': y-p},
-                                   {'x': x-p,'y': y+p},
-                                   {'x': x+p,'y': y+p},
+        kicad_mod.addPolygoneLine([{'x': x-p,'y': y+p},
+                                   {'x': x-p,'y': y-p},
                                    {'x': x+p,'y': y-p},
-                                   {'x': x-p,'y': y-p}], layer='F.Fab', width=0.10)
-                              
+                                   {'x': x+p,'y': y+p},
+                                   {'x': x-p,'y': y+p}], layer='F.Fab', width=0.10)
+
     #add courtyard
-    kicad_mod.addRectLine({'x':-B/2-0.5,'y':-6.125},{'x':B/2+0.5,'y':0.525},'F.CrtYd',0.05)
-    
+    kicad_mod.addRectLine({'x':-B/2-0.5,'y':6.125},{'x':B/2+0.5,'y':-0.525},'F.CrtYd',0.05)
+
     kicad_mod.model = "Connectors_JST.3dshapes/" + footprint_name + ".wrl"
 
     f = open(footprint_name + ".kicad_mod","w")


### PR DESCRIPTION
According to the datasheet, pin no. 1 is located on the right for top-entry headers and on the left for side-entry headers. As this library currently stands, it is very easy to accidentally flip the polarity of a cable. I've tested these changes and am about to submit a PR with the re-generated footprints to the Connectors_JST.pretty repo.