### PR TITLE
Molex 6410 fix outline and silkscreen alignment

### DIFF
--- a/scripts/Molex/connectors_molex_kk_6410_top.py
+++ b/scripts/Molex/connectors_molex_kk_6410_top.py
@@ -68,6 +68,8 @@ if __name__ == '__main__':
     # create silkscreen
     kicad_mod.append(RectLine(start=[start_pos_x-pad_spacing/2.0-nudge, -3.02],\
         end=[end_pos_x+pad_spacing/2.0+nudge, 2.98], layer='F.SilkS', width=silk_w))
+    kicad_mod.append(Line(start=[start_pos_x-pad_spacing/2.0-0.4, -2.0],\
+        end=[start_pos_x-pad_spacing/2.0-0.4, 2.0], layer='F.SilkS', width=silk_w))
 
     if pincount <= 6:
         # one ramp

--- a/scripts/Molex/connectors_molex_kk_6410_top.py
+++ b/scripts/Molex/connectors_molex_kk_6410_top.py
@@ -62,8 +62,8 @@ if __name__ == '__main__':
         drill=1.2, layers=Pad.LAYERS_THT))
 
     # create fab outline
-    kicad_mod.append(RectLine(start=[start_pos_x-pad_spacing/2.0-2*nudge, -3.02-nudge],\
-        end=[end_pos_x+pad_spacing/2.0+2*nudge, 2.98+nudge], layer='F.Fab', width=silk_w))
+    kicad_mod.append(RectLine(start=[start_pos_x-pad_spacing/2.0, -5.8/2.0],\
+        end=[end_pos_x+pad_spacing/2.0, 5.8/2.0], layer='F.Fab', width=silk_w))
 
     # create silkscreen
     kicad_mod.append(RectLine(start=[start_pos_x-pad_spacing/2.0-nudge, -3.02],\

--- a/scripts/Molex/connectors_molex_kk_6410_top.py
+++ b/scripts/Molex/connectors_molex_kk_6410_top.py
@@ -68,8 +68,12 @@ if __name__ == '__main__':
     # create silkscreen
     kicad_mod.append(RectLine(start=[start_pos_x-pad_spacing/2.0-nudge, -3.02],\
         end=[end_pos_x+pad_spacing/2.0+nudge, 2.98], layer='F.SilkS', width=silk_w))
+
+    # pin 1 markers
     kicad_mod.append(Line(start=[start_pos_x-pad_spacing/2.0-0.4, -2.0],\
         end=[start_pos_x-pad_spacing/2.0-0.4, 2.0], layer='F.SilkS', width=silk_w))
+    kicad_mod.append(Line(start=[start_pos_x-pad_spacing/2.0-0.4, -2.0],\
+        end=[start_pos_x-pad_spacing/2.0-0.4, 2.0], layer='F.Fab', width=silk_w))
 
     if pincount <= 6:
         # one ramp


### PR DESCRIPTION
As discussed here: https://github.com/pointhi/kicad-footprint-generator/pull/31#issuecomment-295665628

Changes:
- fixed position of component outline
- added pin 1 markers to silkscreen and fab layers

![image](https://cloud.githubusercontent.com/assets/7076027/25233403/989c1c38-25d6-11e7-9554-ce2e24a62a47.png)
