### PR TITLE
New script for socket strips

### DIFF
--- a/scripts/Conn_PinSocket/canvas.py
+++ b/scripts/Conn_PinSocket/canvas.py
@@ -28,14 +28,29 @@
 #
 # (C) 2017 by Terje Io, <http://github.com/terjeio>
 
+#
+# NOTE:
+# The code for the the Keepout class is based on code from drawing_tools.py
+# Currently circular and (rounded) rectangular keepout zones are respected
+# for horizontal and vertical lines, only basic support (bounding box only) for diagonal lines.
+# Arcs and circles are not yet handled. On TODO: list.
+# More testing needs to be done for edge cases, such as for lines inside
+# the bounding box but extending outside the keepout area.
+# Preferably the private _Keepout class should encapsulate all the line processing?
+#
+
 import sys
 import os
 import math
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "\\..\\..")
 
-from KicadModTree.nodes.base import Line, Circle, Text, Pad
+from collections import namedtuple
+
+from KicadModTree import Point
+from KicadModTree.nodes.base import Line, Arc, Circle, Text, Pad
 from KicadModTree.nodes.specialized import RectFill
+from KicadModTree.util.kicad_util import formatFloat
 
 class Layer:
 
@@ -57,7 +72,9 @@ class Layer:
     def __init__(self, footprint, layer='F.Fab', origin=(0,0), line_width=None, offset=None):
         self.footprint = footprint
         self.layer = layer
+        self.polyline_start = None
         self.gridspacing = None
+        self.keepout = None
         self.setOrigin(origin[0], origin[1])
         self.txt_size = [1.0] * 2
         self.setTextDefaults()
@@ -72,6 +89,8 @@ class Layer:
         self.setLineWidth(self._DEFAULT_LINE_WIDTHS.get(layer, self._DEFAULT_LINE_WIDTH) if line_width == None else line_width)
         if layer.split('.')[1] == 'CrtYd':
             self.setGridSpacing(self._DEFAULT_GRID_CRT)
+#        else:
+#            self.setGridSpacing(0.001)
 
     @staticmethod        
     def getBevel(width, height):
@@ -90,6 +109,9 @@ class Layer:
         if self.auto_offset:
             self.offset = self.line_width / 2.0
         return self
+
+    def getMinPadDistance(self):
+        return self._DEFAULT_MIN_PAD_DISTANCE
 
     def setTextDefaults(self, max_size=None, min_size=None):
         if max_size == None and min_size == None:
@@ -131,6 +153,14 @@ class Layer:
         self.y = self._align(y)
         return self
 
+    def gotoX(self, x):
+        self.x = self._align(x)
+        return self
+
+    def gotoY(self, y):
+        self.y = self._align(y)
+        return self
+
     def jump(self, x, y):
         self.x += self._align(x)
         self.y += self._align(y)
@@ -146,11 +176,23 @@ class Layer:
         self.setOrigin(self._align(self.origin[0]), self._align(self.origin[1]))
         return self
 
+    def _line(self, x, y):
+        if self.keepout != None:
+            segments = self.keepout.processLine(self.x, self.y, self.x + x, self.y + y)
+            for line in segments: # TODO: move grid alignment to keepout code?
+                line[0] = self._align(line[0])
+                line[1] = self._align(line[1])
+                line[2] = self._align(line[2])
+                line[3] = self._align(line[3])
+                self.footprint.append(Line(start=[line[0], line[1]], end=[line[2], line[3]], layer=self.layer, width=self.line_width))
+        else:            
+            self.footprint.append(Line(start=[self.x, self.y], end=[self.x + x, self.y + y], layer=self.layer, width=self.line_width))
+
     def to(self, x, y, draw=True):
         x = self._align(x)
         y = self._align(y)
         if draw:
-            self.footprint.append(Line(start=[self.x, self.y], end=[self.x + x, self.y + y], layer=self.layer, width=self.line_width))
+            self._line(x, y)
         self.x += x
         self.y += y
         return self
@@ -158,29 +200,57 @@ class Layer:
     def left(self, distance, draw=True):
         distance = self._align(distance)
         if draw:
-            self.footprint.append(Line(start=[self.x, self.y], end=[self.x - distance, self.y], layer=self.layer, width=self.line_width))
+            self._line(-distance, 0.0)
         self.x -= distance
         return self
 
     def right(self, distance, draw=True):
         distance = self._align(distance)
         if draw:
-            self.footprint.append(Line(start=[self.x, self.y], end=[self.x + distance, self.y], layer=self.layer, width=self.line_width))
+            self._line(distance, 0.0)
         self.x += distance
         return self
 
     def up(self, distance, draw=True):
         distance = self._align(distance)
         if draw:
-            self.footprint.append(Line(start=[self.x, self.y], end=[self.x , self.y - distance], layer=self.layer, width=self.line_width))
+            self._line(0.0, -distance)
         self.y -= distance
         return self
 
     def down(self, distance, draw=True):
         distance = self._align(distance)
         if draw:
-            self.footprint.append(Line(start=[self.x, self.y], end=[self.x , self.y + distance], layer=self.layer, width=self.line_width))
+            self._line(0.0, distance)
         self.y += distance
+        return self
+
+    def polyline(self, vertices, close=False):
+        if self.polyline_start == None:
+            self.polyline_start = (self.x, self.y)
+        for vertex in vertices:
+            x = self._align(vertex[0])
+            y = self._align(vertex[1])
+            self._line(self.x + x, self.y + y)
+            self.x += x
+            self.y += y
+        if close:
+            self.close()
+        return self
+
+    def close(self):
+        if self.polyline_start != None:
+            if self.x != self.polyline_start[0] or self.x != self.polyline_start[1]:
+                self._line(self.polyline_start[0], self.polyline_start[1])
+            self.polyline_start = None
+        return self
+
+    def arc(self, center_x, center_y, angle):
+        arc = Arc(start=[self.x, self.y], center=[self.x + center_x, self.y + center_y], angle=angle, layer=self.layer, width=self.line_width)
+        self.footprint.append(arc)
+        end = arc._calulateEndPos()    
+        self.x += center_x + end.y
+        self.y += center_y + end.x
         return self
 
     def circle(self, radius, filled=False):
@@ -191,7 +261,8 @@ class Layer:
                 self.footprint.append(Circle(center=[self.x, self.y], radius=r, layer=self.layer, width=line_width))        
                 r += line_width - self.line_width / 2.0
         else:
-            self.footprint.append(Circle(center=[self.x, self.y], radius=radius, layer=self.layer, width=self.line_width))
+            line_width = round(min(self.line_width, radius / 2.0), 3)
+            self.footprint.append(Circle(center=[self.x, self.y], radius=radius, layer=self.layer, width=line_width))
         return self
    
     def fillrect(self, w, h):
@@ -211,6 +282,11 @@ class Layer:
         y = self.y
         w = self._align(w)
         h = self._align(h)
+        
+        if type(bevel) in [int, float]:
+            bevel = [bevel] * 4
+        elif bevel == None:
+            bevel = [0.0] * 4
 
         if origin == 'center':
             self.jump(self._align(-w / 2.0), self._align(-h / 2.0))
@@ -243,12 +319,58 @@ class Layer:
 
         return self
 
+    def rrect(self, w, h, radius, origin='center'):
+
+        x = self.x
+        y = self.y
+        w = self._align(w)
+        h = self._align(h)
+
+        if origin == 'center':
+            self.jump(self._align(-w / 2.0), self._align(-h / 2.0))
+
+        w -= radius * 2.0          
+        h -= radius * 2.0          
+
+        self.jump(radius, 0.0)
+        self.right(w)
+        self.arc(0.0, radius, 90.0)
+        self.down(h)
+        self.arc(-radius, 0.0, 90.0)
+        self.left(w)
+        self.arc(0.0, -radius, 90.0)
+        self.up(h)
+        self.arc(radius, 0.0, 90.0)
+
+        self.x = x
+        self.y = y
+
+        return self
+
     def text(self, type, text, rotation=0):
         self.footprint.append(Text(type=type, text=text, at=[self.x, self.y], rotation=rotation, layer=self.layer, size=self.txt_size, thickness=self.txt_thickness))
         return self
 
+# TODO: add methods for offsetting etc
+class PolyLine ():
 
+    def __init__(self, vertices=None):
+        self.vertices = []
+        if vertices != None:   
+            for vertex in vertices:
+                self.vertices.append(Point(vertex))
 
+    def __getattr__(self, name):
+        if name == "isClosed":
+            return False if len(self.vertices) < 3 else self.vertices[0].x == self.vertices[-1].x and self.vertices[0].y == self.vertices[-1].y
+        else:
+            raise AttributeError
+        
+    def append(self, x, y):
+        self.vertices.append([x, y])
+        return self
+
+    
 class PadLayer:
 
     def __init__(self, footprint, size, type, shape, shape_first=None, drill=None, layers=None, x_offset=0.0, y_offset=0.0):
@@ -275,7 +397,7 @@ class PadLayer:
 
         self.layers=layers
 
-    def add(self, x, y, number=None, x_offset=None, y_offset=None):
+    def add(self, x, y, number=None, type=None, shape=None, size=None, x_offset=None, y_offset=None):
 
         if number == None:
             number = self.p
@@ -286,15 +408,345 @@ class PadLayer:
 
         if y_offset == None:
             y_offset = self.y_offset
+            
+        if shape == None:
+            shape=self.shape_first if number == 1 else self.shape
 
-        self.last_pad = Pad(number=number, type=self.type,
-                            shape=self.shape_first if number == 1 else self.shape,
+        self.last_pad = Pad(number=number,
+                            type=self.type if type == None else type,
+                            shape=shape,
                             at=[x + x_offset, y + y_offset],
-                            size=self.size, drill=self.drill, layers=self.layers)
+                            size=self.size if size == None else size,
+                            drill=self.drill, layers=self.layers)
         self.footprint.append(self.last_pad)
         return self
 
     def getLast(self):
         return self.last_pad
+
+_RectWH = namedtuple("_RectWH", [
+    'x',
+    'y',
+    'height',
+    'width'
+])
+
+class _Point: 
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+    def __repr__(self):
+        return "(x={x}, y={y})".format(x=formatFloat(self.x), y=formatFloat(self.y))
+        
+class _Line: 
+    def __init__(self, a, b, x1=None, y1=None, normalize=False):
+        if x1 == None and y1 == None:
+            self._add_points(a, b, normalize)
+        else:    
+            self._add_points(_Point(a, b), _Point(x1, y1), normalize)
+
+    def _add_points(self, a, b, normalize):
+        if normalize:  
+            self.x0 = min(a.x, b.x)
+            self.x1 = max(a.x, b.x)
+            self.y0 = min(a.y, b.y)
+            self.y1 = max(a.y, b.y)
+        elif a.y < b.y:
+            self.x0 = a.x
+            self.x1 = b.x
+            self.y0 = a.y
+            self.y1 = b.y           
+        else:
+            self.x0 = b.x
+            self.x1 = a.x
+            self.y0 = b.y
+            self.y1 = a.y           
+
+    def __repr__(self):
+        return "(x0={x0}, y0={y0}, x1={x1}, y1={y1})".format(x0=formatFloat(self.x0), y0=formatFloat(self.y0),
+                                                             x1=formatFloat(self.x1), y1=formatFloat(self.y1))
+
+class _Keepout:
+    def __init__(self, a, b, x1=None, y1=None, radius=0.0):
+        self.lines = []
+        self.radius = radius
+        if x1 == None and y1 == None:
+            self._add_points(a, b)
+        else:    
+            self._add_points(_Point(a, b), _Point(x1, y1))
+
+    def _add_points(self, a, b):        
+        self.x0 = round(min(a.x, b.x), 5)
+        self.x1 = round(max(a.x, b.x), 5)
+        self.y0 = round(min(a.y, b.y), 5)
+        self.y1 = round(max(a.y, b.y), 5)
+
+    def pointIsInside(self, x, y):
+        x = round(x, 5); y = round(y, 5)
+        return x >= self.x0 and x <= self.x1 and y >= self.y0 and y <= self.y1
+
+    def _feq(self, a, b):
+        return abs(a-b) < 0.0001
+    
+    def _bbox_overlap(self, bbox):
+        x0 = min(bbox.x0, bbox.x1)
+        x1 = max(bbox.x0, bbox.x1)
+        y0 = min(bbox.y0, bbox.y1)
+        y1 = max(bbox.y0, bbox.y1)
+        return not (self.x0 < x1 and self.x1 > x0 and self.y0 > y1 and self.y1 < y0)
+
+    def lineIntersects(self, l):
+        
+        # skip proccesing if line bounding box is completely outside keepout bounding box
+        if not self._bbox_overlap(l):
+            return False
+    
+        points = []
+  
+        # get lines representing keepout bounding box
+        if len(self.lines) == 0:
+            self.lines.append(_Line(self.x0, self.y0, self.x1, self.y0))
+            self.lines.append(_Line(self.x1, self.y0, self.x1, self.y1))
+            self.lines.append(_Line(self.x0, self.y1, self.x1, self.y1))
+            self.lines.append(_Line(self.x0, self.y0, self.x0, self.y1))
+        
+        # find and return intersecting points
+        a1 = l.y1 - l.y0
+        b1 = l.x0 - l.x1
+        lr = l.x1 > l.x0
+
+        i = 0
+
+        for k in self.lines:
+            a2 = k.y1 - k.y0
+            b2 = k.x0 - k.x1
+            d = a1 * b2 - a2 * b1
+                    
+            if d != 0.0:
+                c2 = a2 * k.x0 + b2 * k.y0;
+                c1 = a1 * l.x0 + b1 * l.y0
+                xp = (b2 * c1 - b1 * c2) / d
+                yp = (a1 * c2 - a2 * c1) / d
+  
+                ka = (xp >= l.x0 and xp <= l.x1) if lr else (xp <= l.x0 and xp >= l.x1)
+                kb = self._feq(xp, k.x0) if k.x0 == k.x1 else self._feq(yp, k.y0)
+
+                if ka and kb and self.pointIsInside(xp, yp):
+                    if lr and (i == 0 or i == 3):
+                        points.insert(0, [xp, yp, i])
+                    else:
+                        points.append([xp, yp, i])
+            i += 1       
+
+        return False if len(points) == 0 else points
+
+    def HlineIntersects(self, y):
+        return y > self.y0 and y < self.y1
+
+    def VlineIntersects(self, x):
+        return x > self.x0 and x < self.x1
+
+    def HLineTrim(self, x0, y, x1):
+        r = self.radius
+        yi = 0 if y >= self.y0 + r else 1
+        yi += 0 if y <= self.y1 - r else 2
+        if yi == 0:
+            return x0
+        else:
+            h = (self.y0 + r - y if yi == 1 else y - self.y1 + r)
+            l = math.sqrt(r * r - h * h)
+            return min(x0 + r - l, x1) if x1 > x0 else max(x0 + -(r - l), x1)
+            
+    def VLineTrim(self, x, y0, y1):
+        r = self.radius
+        xi = 0 if x >= self.x0 + r else 1
+        xi += 0 if x <= self.x1 - r else 2
+        if xi == 0:
+            return y0
+        else:
+            h = (self.x0 + r - x if xi == 1 else x - self.x1 + r)
+            l = math.sqrt(r * r - h * h)
+            return min(y0 + r - l, y1) if y1 > y0 else max(y0 + -(r - l), y1)
+
+    def __repr__(self):
+        return "(x0={x0}, y0={y0}, x1={x1}, y1={y1}, r={r})".format(x0=formatFloat(self.x0), y0=formatFloat(self.y0),
+                                                             x1=formatFloat(self.x1), y1=formatFloat(self.y1),
+                                                             r=formatFloat(self.radius))
+
+
+class Keepout():
+
+    DEBUG = 0
+    _NUM_RECTS = 5
+
+    def __init__(self, layer):
+        self.layer = layer
+        self.keepouts = []
+        self.min_length = 0.01
+        layer.keepout = self
+
+    # float-variant of range()
+    @staticmethod
+    def frange(x, y, jump):
+        while x < y:
+            yield x
+            x += jump
+
+    def __getattr__(self, name):
+        if name == "offset":
+            return self.layer.line_width / 2.0 + self.layer.getMinPadDistance()
+        else:
+            raise AttributeError
+
+    def _align(self, value):
+        return self.layer._align(value)
+
+    def _add(self, x0, y0, x1, y1, radius=None):
+        self.keepouts.append(_Keepout(self._align(x0), self._align(y0), self._align(x1), self._align(y1), radius))
+
+    # add keepout area for rectangle
+    def addRect(self, x, y, w, h, offset=None):
+        if offset == None:
+            offset = self.offset
+        w = w / 2.0 + offset
+        h = h / 2.0 + offset
+        self._add(x - w, y - h, x + w, y + h, offset)
+        return self
+
+    # add keepout area for circular or oval object
+    def addRound(self, x, y, w, h, offset=None):
+        if offset == None:
+            offset = self.offset
+        d = w - h         
+        self.addRect(x, y, d if d > 0.0 else 0.0, -d if d < 0.0 else 0.0, min(h, w) / 2.0 + offset)
+        return self
+    
+    def addPads(self):
+        nodes = self.layer.footprint.getNormalChilds()
+        offset = self.offset
+        for node in nodes:
+            if isinstance(node, Pad):
+                if node.shape == Pad.SHAPE_RECT:
+                    self.addRect(node.at.x, node.at.y, node.size.x, node.size.y, offset)
+                else:
+                    self.addRound(node.at.x, node.at.y, node.size.x, node.size.y, offset)
+
+    def getPadBB(self, number):
+        # TODO: use node.calculateBoundingBox when implemented, this is a simple version that does not honor any rotation
+        nodes = self.layer.footprint.getNormalChilds()
+        offset = self.offset * 2.0
+        bb = None
+        for node in nodes:
+            if isinstance(node, Pad) and node.number == number:
+                bb = _RectWH(x = node.at.x, y = node.at.y, width = node.size.x + offset, height = node.size.y + offset)
+        return bb
+
+    # internal method for keepout-processing
+    def _processHVLine(self, x0, y0, x1, y1):
+        
+        def add_segment(x0, y0, x1, y1):
+            length = x1 - x0 + y1 - y0 
+            if length >= self.min_length:
+                segments.append([x0, y0, x1, y1])
+
+        vertical = x0 == x1
+        segments = [[x0, min(y0, y1), x1, max(y0, y1)]] if vertical else [[min(x0, x1), y0, max(x0, x1), y1]]
+        changes = True
+
+        if self.DEBUG & 2:
+            print "S", segments[0][0], segments[0][1], segments[0][2], segments[0][3] 
+
+        while changes:
+            changes = False
+            for keepout in self.keepouts:
+                if keepout.VlineIntersects(x0) if vertical else keepout.HlineIntersects(y0):
+                    for li in reversed(range(0, len(segments))):
+                        l = segments[li]
+                        p = (1 if keepout.pointIsInside(l[0], l[1]) else 0)
+                        p |= (2 if keepout.pointIsInside(l[2], l[3]) else 0)
+                        if p == 3 : # Line completely inside -> remove
+                            segments.pop(li)
+                            p = 0
+                            changes = True
+                        elif p == 0: # is line intersecting keepout rectangle?
+                            if vertical: 
+                                if l[1] < keepout.y0 and l[3] > keepout.y1:
+                                    p = 3
+                            else:
+                                if l[0] < keepout.x0 and l[2] > keepout.x1:
+                                    p = 3
+
+                        if self.DEBUG & 2:
+                            print "CHOP", p, "line:", l[0], l[1], l[2], l[3], "keepout:", keepout
+                               
+                        if p > 0:  # Line needs to be broken up
+                            changes = True
+                            segments.pop(li)
+                            if vertical:
+                                if p & 1:
+                                    add_segment(l[0], keepout.VLineTrim(l[0], keepout.y1, l[1]), l[2], l[3])
+                                if p & 2:
+                                    add_segment(l[0], l[1], l[2], keepout.VLineTrim(l[0], keepout.y0, l[3]))
+                            else:
+                                if p & 1:
+                                    add_segment(keepout.HLineTrim(keepout.x1, l[1], l[0]), l[1], l[2], l[3])
+                                if p & 2:
+                                    add_segment(l[0], l[1], keepout.HLineTrim(keepout.x0, l[1], l[2]), l[3])
+            if changes:
+                break
+
+        if self.DEBUG & 2:
+            print "LI", segments    
+
+        return segments
+    
+    # split an arbitrary line so it does not interfere with keepout areas defined as [[x0,x1,y0,y1], ...]
+    def processLine(self, x0, y0, x1, y1):
+
+        if x0 == x1 or y0 == y1: # use simpler and faster algorithm for horizontal and vertical lines
+            return self._processHVLine(x0, y0, x1, y1)
+    
+        # TODO: update to handle keepout area proper, now only respects the bounding box.
+        
+        line = _Line(x0, y0, x1, y1)
+        segments=[[line.x0, line.y0, line.x1, line.y1]]
+        for keepout in self.keepouts:
+            for li in reversed(range(0, len(segments))):
+                l = segments[li]
+                chop = keepout.lineIntersects(_Line(l[0], l[1], l[2], l[3]))
+                if chop != False:
+                    segments.pop(li)
+                    segments.append([l[0], l[1], chop[0][0], chop[0][1]])
+                    if len(chop) == 2:
+                        segments.append([chop[1][0], chop[1][1], l[2], l[3]])
+        return segments       
+
+    # draws the keepouts
+    def debug_draw(self):
+        if self.DEBUG & 1:
+            lw = self.layer.line_width
+            self.layer.line_width = 0.01
+            self.layer.keepout = None
+            for keepout in self.keepouts:
+                self.layer.goto(keepout.x0, keepout.y0)
+                self.layer.rrect(keepout.x1 - keepout.x0, keepout.y1 - keepout.y0, keepout.radius, origin="topLeft")
+                self.layer.rect(keepout.x1 - keepout.x0, keepout.y1 - keepout.y0, origin="topLeft")
+            self.layer.line_width = lw
+            self.layer.keepout = self
+
+
+class OutDir:
+
+    def __init__(self, root_dir=None):    
+        self.root_dir = "" if root_dir == None else root_dir
+        if root_dir != "" and self.root_dir[-1] != os.sep:
+            self.root_dir += os.sep
+
+    def saveTo(self, lib_name):
+        out_dir = "" if self.root_dir == "" else self.root_dir + lib_name + ".pretty" + os.sep   
+        if not os.path.exists(out_dir):
+            os.makedirs(out_dir)
+        return out_dir
 
 ### EOF ###

--- a/scripts/Conn_PinSocket/canvas.py
+++ b/scripts/Conn_PinSocket/canvas.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python
+
+# KicadModTree is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# KicadModTree is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kicad-footprint-generator. If not, see < http://www.gnu.org/licenses/ >.
+#
+# (C) 2016 by Thomas Pointhuber, <thomas.pointhuber@gmx.at>
+
+#
+# This module (canvas.py) contains wrapper classes and methods for parts
+# of the KicadModTree primitives.
+# They provide "turtle style" drawing using relative moves in order
+# to simplify the math involved in calculating and keeping track of vertex coordinates.
+# They also introduce the concept of canvases for drawing the different layers, this
+# to simplify drawing and provide functionality such as transparent grid align
+# and method chaining.
+# A canvas is somewhat similar to a workplane in CadQuery which is
+# often used for creating KiCad 3D models.
+#
+# (C) 2017 by Terje Io, <http://github.com/terjeio>
+
+import sys
+import os
+import math
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "\\..\\..")
+
+from KicadModTree.nodes.base import Line, Circle, Text, Pad
+from KicadModTree.nodes.specialized import RectFill
+
+class Layer:
+
+    _DEFAULT_LINE_WIDTHS = {'F.SilkS': 0.12,
+                            'B.SilkS': 0.12,
+                            'F.Fab':   0.1,
+                            'B.Fab':   0.1,
+                            'F.CrtYd': 0.05,
+                            'B.CrtYd': 0.05}
+
+    _DEFAULT_LINE_WIDTH       = 0.15
+    _DEFAULT_TEXT_OFFSET      = 1.0
+    _DEFAULT_TEXT_SIZE_MIN    = 0.25
+    _DEFAULT_TEXT_SIZE_MAX    = 2.00
+    _DEFAULT_GRID_CRT         = 0.05
+    _DEFAULT_OFFSET_CRT       = 0.25
+    _DEFAULT_MIN_PAD_DISTANCE = 0.2 # clearance?
+
+    def __init__(self, footprint, layer='F.Fab', origin=(0,0), line_width=None, offset=None):
+        self.footprint = footprint
+        self.layer = layer
+        self.gridspacing = None
+        self.setOrigin(origin[0], origin[1])
+        self.txt_size = [1.0] * 2
+        self.setTextDefaults()
+        self.setTextSize(1.0)
+        self.txt_offset = self._DEFAULT_TEXT_OFFSET
+        if offset == None and layer.split('.')[1] == 'CrtYd':
+            offset = self._DEFAULT_OFFSET_CRT
+        if offset != None:
+            self.offset = offset
+        self.auto_offset = offset == None
+        self.goHome()
+        self.setLineWidth(self._DEFAULT_LINE_WIDTHS.get(layer, self._DEFAULT_LINE_WIDTH) if line_width == None else line_width)
+        if layer.split('.')[1] == 'CrtYd':
+            self.setGridSpacing(self._DEFAULT_GRID_CRT)
+
+    @staticmethod        
+    def getBevel(width, height):
+        return min(1.0, min(width, height) * 0.25)
+
+    def setOrigin(self, x, y):
+        self.origin = (self._align(x), self._align(y))
+        self.goHome()
+        return self
+
+    def getOrigin(self):
+        return self.origin
+
+    def setLineWidth(self, width):
+        self.line_width = width
+        if self.auto_offset:
+            self.offset = self.line_width / 2.0
+        return self
+
+    def setTextDefaults(self, max_size=None, min_size=None):
+        if max_size == None and min_size == None:
+            self.text_size_min = self._DEFAULT_TEXT_SIZE_MIN
+            self.text_size_max = self._DEFAULT_TEXT_SIZE_MAX
+        else:
+            if max_size != None:
+                self.text_size_max = round(max_size, 2)
+            if min_size != None:
+                self.text_size_min = round(min_size, 2)
+        return self    
+
+    def setTextSize(self, height, width=None, thickness=None):
+        height = round(height, 2)
+        self.txt_size[0] = min(max(height, self.text_size_min), self.text_size_max)
+        self.txt_size[1] = min(max(height if width == None else round(width, 2), self.text_size_min), self.text_size_max)
+        self.txt_thickness = round(self.txt_size[0] * 0.15 if thickness == None else thickness, 2)
+        return self
+
+    def setGridSpacing(self, grid):
+        self.gridspacing = grid
+        if self.gridspacing != None:
+            self.alignToGrid()
+        return self
+
+    def getPadOffsetH(self, pad, offset=None):
+        return (pad[0] + self.line_width) / 2.0 + (self._DEFAULT_MIN_PAD_DISTANCE if offset == None else offset)
+
+    def getPadOffsetV(self, pad, offset=None):
+        return (pad[1] + self.line_width) / 2.0 + (self._DEFAULT_MIN_PAD_DISTANCE if offset == None else offset)
+
+    def goHome(self):
+        self.x = self.origin[0]
+        self.y = self.origin[1]
+        return self
+
+    def goto(self, x, y):
+        self.x = self._align(x)
+        self.y = self._align(y)
+        return self
+
+    def jump(self, x, y):
+        self.x += self._align(x)
+        self.y += self._align(y)
+        return self
+
+    def _align(self, value):
+        return value if self.gridspacing == None\
+                      else (math.ceil(value / self.gridspacing) * self.gridspacing if value > 0.0 else math.floor(value / self.gridspacing) * self.gridspacing)
+
+    def alignToGrid(self):
+        self.x = self._align(self.x)
+        self.y = self._align(self.y)
+        self.setOrigin(self._align(self.origin[0]), self._align(self.origin[1]))
+        return self
+
+    def to(self, x, y, draw=True):
+        x = self._align(x)
+        y = self._align(y)
+        if draw:
+            self.footprint.append(Line(start=[self.x, self.y], end=[self.x + x, self.y + y], layer=self.layer, width=self.line_width))
+        self.x += x
+        self.y += y
+        return self
+
+    def left(self, distance, draw=True):
+        distance = self._align(distance)
+        if draw:
+            self.footprint.append(Line(start=[self.x, self.y], end=[self.x - distance, self.y], layer=self.layer, width=self.line_width))
+        self.x -= distance
+        return self
+
+    def right(self, distance, draw=True):
+        distance = self._align(distance)
+        if draw:
+            self.footprint.append(Line(start=[self.x, self.y], end=[self.x + distance, self.y], layer=self.layer, width=self.line_width))
+        self.x += distance
+        return self
+
+    def up(self, distance, draw=True):
+        distance = self._align(distance)
+        if draw:
+            self.footprint.append(Line(start=[self.x, self.y], end=[self.x , self.y - distance], layer=self.layer, width=self.line_width))
+        self.y -= distance
+        return self
+
+    def down(self, distance, draw=True):
+        distance = self._align(distance)
+        if draw:
+            self.footprint.append(Line(start=[self.x, self.y], end=[self.x , self.y + distance], layer=self.layer, width=self.line_width))
+        self.y += distance
+        return self
+
+    def circle(self, radius, filled=False):
+        if filled:
+            line_width = radius / 3.0 + self.line_width / 2.0
+            r = line_width / 2.0
+            while r < radius:
+                self.footprint.append(Circle(center=[self.x, self.y], radius=r, layer=self.layer, width=line_width))        
+                r += line_width - self.line_width / 2.0
+        else:
+            self.footprint.append(Circle(center=[self.x, self.y], radius=radius, layer=self.layer, width=self.line_width))
+        return self
+   
+    def fillrect(self, w, h):
+        x = self.x
+        y = self.y
+        w = self._align(w)
+        h = self._align(h)
+        self.jump(self._align(-w / 2.0), self._align(-h / 2.0))
+        self.footprint.append(RectFill(start=[x, y], end=[w + x, h + y], layer=self.layer))
+        self.x = x
+        self.y = y
+        return self
+
+    def rect(self, w, h, bevel=(0.0, 0.0, 0.0, 0.0), draw=(True, True, True, True), origin='center'):
+
+        x = self.x
+        y = self.y
+        w = self._align(w)
+        h = self._align(h)
+
+        if origin == 'center':
+            self.jump(self._align(-w / 2.0), self._align(-h / 2.0))
+
+        if bevel[0] != 0.0:
+            self.jump(bevel[0], 0.0)
+
+        self.right(w - bevel[0] - bevel[1], draw[0])
+
+        if bevel[1] != 0.0:
+            self.to(bevel[1], bevel[1])
+
+        self.down(h - bevel[1] - bevel[2], draw[1])
+
+        if bevel[2] != 0.0:
+            self.to(-bevel[2], bevel[2])
+
+        self.left(w - bevel[3] - bevel[2], draw[2])
+
+        if bevel[3] != 0.0:
+            self.to(-bevel[3], -bevel[3])
+
+        self.up(h - bevel[3] - bevel[0], draw[3])
+
+        if bevel[0] != 0.0:
+            self.to(bevel[0], -bevel[0])
+
+        self.x = x
+        self.y = y
+
+        return self
+
+    def text(self, type, text, rotation=0):
+        self.footprint.append(Text(type=type, text=text, at=[self.x, self.y], rotation=rotation, layer=self.layer, size=self.txt_size, thickness=self.txt_thickness))
+        return self
+
+
+
+class PadLayer:
+
+    def __init__(self, footprint, size, type, shape, shape_first=None, drill=None, layers=None, x_offset=0.0, y_offset=0.0):
+        self.footprint = footprint
+        self.type = type
+        self.layers = layers
+        self.shape = shape
+        self.shape_first = shape if shape_first == None else shape_first
+        self.size = size
+        self.drill = 0.5 if drill == None and type == Pad.TYPE_SMT else drill
+        self.x_offset = x_offset
+        self.y_offset = y_offset
+        self._init_layers(layers)
+        self.p = 1
+        self.last_pad = None
+
+    def _init_layers(self, layers):
+
+        if layers == None:
+            if self.type == Pad.TYPE_SMT:
+                layers = Pad.LAYERS_SMT
+            elif self.type == Pad.TYPE_THT:
+                layers = Pad.LAYERS_THT
+
+        self.layers=layers
+
+    def add(self, x, y, number=None, x_offset=None, y_offset=None):
+
+        if number == None:
+            number = self.p
+            self.p += 1
+
+        if x_offset == None:
+            x_offset = self.x_offset
+
+        if y_offset == None:
+            y_offset = self.y_offset
+
+        self.last_pad = Pad(number=number, type=self.type,
+                            shape=self.shape_first if number == 1 else self.shape,
+                            at=[x + x_offset, y + y_offset],
+                            size=self.size, drill=self.drill, layers=self.layers)
+        self.footprint.append(self.last_pad)
+        return self
+
+    def getLast(self):
+        return self.last_pad
+
+### EOF ###

--- a/scripts/Conn_PinSocket/cq_base_parameters.py
+++ b/scripts/Conn_PinSocket/cq_base_parameters.py
@@ -1,0 +1,189 @@
+# -*- coding: utf8 -*-
+#!/usr/bin/python
+#
+
+#
+# Parts script module for socket strip footprints for KicCad
+#
+# This module is built on top of the kicad-footprint-generator framework
+# by Thomas Pointhuber, https://github.com/pointhi/kicad-footprint-generator
+#
+# This module is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This module is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kicad-footprint-generator. If not, see < http://www.gnu.org/licenses/ >.
+
+#
+# (C) 2017 Terje Io, <http://github.com/terjeio>
+#
+
+# 2017-11-25
+
+#
+# parts of this code is based on work by other contributors
+#
+
+from collections import namedtuple
+
+### use enums (Phyton 3+)
+
+class CaseType:
+    r"""A class for holding constants for part types
+
+    .. note:: will be changed to enum when Python version allows it
+    """
+    THT = 'THT'
+    r"""THT - trough hole part
+    """
+    SMD = 'SMD'
+    r"""SMD - surface mounted part
+    """
+
+class PinStyle:
+    r"""A class for holding constants for pin styles
+
+    .. note:: will be changed to enum when Python version allows it
+    """
+    STRAIGHT = 'Straight'
+    ANGLED   = 'Angled' 
+
+###
+
+#
+# The following classes must be subclassed
+#
+class PartParametersBase:
+    """
+
+    .. document private functions
+    .. automethod:: _make_params
+    """
+
+    Model = namedtuple("Model", [
+        'variant',      # generic model name
+        'params',       # parameters
+        'model'         # model creator class
+    ])
+    """ Internally used for passing information from the base parameters to the class instance used for creating models
+
+    .. py:attribute:: variant
+
+        The generic name from the list of parameters
+
+    .. py:attribute:: params
+
+        The final parameters passed to the class instance
+
+    .. py:attribute:: model
+
+        The class instance itself
+
+    """
+
+    Params = namedtuple("Params", [
+        'num_pins',
+        'pin_pitch',
+        'pin_style',
+        'type'
+    ])
+    """ Basic parameters for parts, if further parameters are required this should be subclassed/overriden 
+
+    .. note:: The existing parameters should be kept with the same name when overriden as the framework requires them
+
+    .. py:attribute:: num_pins
+
+        Number of pins, for parts with this is usually set to None for 
+
+    .. py:attribute:: pin_pitch
+
+        The final parameters passed to the class instance
+
+    .. py:attribute:: pin_style
+
+        The class instance itself
+
+    .. py:attribute:: type
+
+        The class instance itself
+
+    """
+
+    def __init__(self):
+        self.base_params = {}
+
+    def _make_params(self, pin_pitch, num_pin_rows, pin_style, type):
+        r"""add a list of new points
+        """
+        return self.Params(
+            num_pins = None,                # to be added programmatically
+            pin_pitch = pin_pitch,          # pin pitch
+            pin_style = pin_style,          # pin style: 'Straight' or 'Angled'
+            type = type                     # part type: 'THT' or 'SMD'
+        )
+
+    def getAllModels(self, model_classes):
+        r"""Generate model parameters for all series and variants
+
+        Loops through all base parameters and model classes instantiating the classes and checks whether a variant should be made.
+        If a variant is to be made a namedtuple is made with the index from a call to the model instance makeModelName method
+        and the base parameters are copied to this. When copying the base parameters others may be added such as number of pins (num_pins). 
+
+        .. note:: Typically this method is overriden in order to add calculated parameters like number of pins.
+                  The model specific parameters are contained in the model class itself.
+
+        :param model_classes:
+            list of part creator classes inherited from :class:`cq_base_model.PartBase`
+        :type  model_classes: ``list of classes``
+
+        :rtype: ```tuple````
+
+        """
+        models = {}
+
+        # instantiate generator classes in order to make a dictionary of all model names
+        for i in range(0, len(model_classes)):
+            for variant in self.base_params.keys():
+                params = self.base_params[variant]
+                model = model_classes[i](params)
+                if model.make_me:
+                    models[model.makeModelName(variant)] = self.Model(variant, params, model_classes[i])
+
+        return models
+
+    def getSampleModels(self, model_classes):
+        r"""Generate model parameters for all series and variants
+
+        Loops through all base parameters and model classes instantiating the classes and checks whether a variant should be made.
+        If a variant is to be made a namedtuple is made with the index from a call to the model instance makeModelName method
+        and the base parameters are copied to this. When copying the base parameters others may be added such as number of pins (num_pins). 
+
+        .. note:: Typically this method is overriden in order to add calculated parameters like number of pins.
+                  The model specific parameters are contained in the model class itself.
+
+        :param model_classes:
+            list of part creator classes inherited from :class:`cq_base_model.PartBase`
+        :type  model_classes: ``list of classes``
+
+        :rtype: ```tuple````
+
+        """
+
+        models = {}
+
+        # instantiate generator classes in order to make a dictionary of all model names
+        for i in range(0, len(model_classes)):
+            for variant in self.base_params.keys():
+                params = self.base_params[variant]
+                model = model_classes[i](params)
+                if model.make_me:
+                    models[model.makeModelName(variant)] = self.Model(variant, params, model_classes[i])
+
+        return models

--- a/scripts/Conn_PinSocket/main_generator.py
+++ b/scripts/Conn_PinSocket/main_generator.py
@@ -1,0 +1,286 @@
+# -*- coding: utf8 -*-
+#!/usr/bin/env python
+
+# KicadModTree is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# KicadModTree is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kicad-footprint-generator. If not, see < http://www.gnu.org/licenses/ >.
+#
+
+#
+# based on scripts\pin_headers_socket_strips
+# refactored by Terje Io, <http://github.com/terjeio>
+# updated for KLC3 and new naming convention
+#
+
+# Some datasheet sources:
+#
+# http://www.amphenol-icc.com/board-to-board.html?gender_filter=559
+# http://www.taydaelectronics.com/connectors-sockets/pin-headers.html
+# https://gct.co/board-to-board-connector/list?pitch=2.54mm%2C1.00mm&gender=Socket
+# https://www.harwin.com/products/M50-3100545/
+# https://lbconnector.en.alibaba.com/productgrouplist-804748813-8/Pin_Female_Box_Header.html?spm=a2700.8304367.costd19dbc.23.2ccc31d5Xg47e5&isGallery=Y
+#
+
+#
+# NOTE: most footprints are based on legacy dimensions which does not have any documented datasheet sources
+#
+
+#import sys
+#import os
+
+#sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "\\..\\tools")
+
+from socket_strips import *  # NOQA
+
+if __name__ == '__main__':
+
+    def getPadOffsets(overall_width, pads):
+        result = []
+        for i in range(0, len(pads)):
+            result.append(round((overall_width[i] - pads[i][0]) / 2.0, 3))
+        return result
+
+    def getPinLength(overall_width, packwidth):
+        result = []
+        for i in range(0, len(overall_width)):
+            result.append(round((overall_width[i] - packwidth[i]) / 2.0, 3))
+        return result
+
+    # bw  - body width
+    # bo  - body offset
+    # blo - body overlength
+    # pl  - pin length, THT for 3D model
+    # pad - pad size
+    # drl - drill size
+    # ow  - SMD, overall width (including pins)
+    # lpo - SMD land pattern overall width
+    # psz - SMD pin size (width, [, thickness for 3D model]) 
+    # bh  - body height (3D parameter, PCB to top)
+    
+    # t  - typical
+    # >  - min (greater or equal)
+    # <  - max (smaller or equal)
+    # NA - not available
+    
+    ######################
+    # 2.54mm pin sockets #
+    ######################
+
+    # THT 1 row vertical:
+    # KiCad legacy : bw: 2.54;             pad: 1.7; drl: 1.0
+    # Amphenol FCi : bw: 2.54; blo: -0.08;           drl: >0.75; psz: 0.6, 0.2;  pl: 2.5; bh: 7.0
+
+    # THT 2 rows vertical:
+    # KiCad legacy : bw: 5.08;             pad: 1.7; drl: 1.0
+    # Amphenol FCi : bw: 5.08; blo: -0.08;           drl: >0.8;  psz: 0.6, 0.2; pl: 2.5; bh: 7.0
+
+    # THT 1 row horizontal:
+    # KiCad legacy : bw: 8.51; bo: 1.52; pad: 1.7; drl: 1.0
+
+    # THT 2 rows horizontal:
+    # KiCad legacy : bw: 8.51; bo: 1.52; pad: 1.7; drl: 1.0
+
+    # SMD 1 row:
+    # Amphenol FCi 1: bw: 5.08;           blo: -0.08; pad: 2 - 1.0, <1.5; lpo: 6.1±0.2; psz: 0.6; bh: 7.0
+    # V FHC50    1RL: bw: 2.50; ow: 4.80; blo: 0.60;  pad: 2.10, 1.02;    lpo: 5.5;     psz: 0.5, 0.2; bh: 5.0
+    # V HOYATO    1*: bw: 2.50; ow: 4.05,             pad: 1.91, 1.00;    lpo; 5.2;     psz: 0.5, 0.2; bh: 7.5
+
+    # SMD 2 rows vertical:
+    # KiCad legacy   : bw: 5.08; ow: 8.04;             pad: 3.0, 1.0;                  psz: 1.38, 0.64
+    # Amphenol FCi   : bw: 5.08; ow: 6.10; blo: -0.08; pad: t1.27, >4.2; lpo: 3.2±0.2; psz: 0.6;           bh: 7.0; Top entry
+    # Amphenol FCi   : bw: 5.08; ow: 6.10; blo: -0.08; pad: t1.27, >1.4; lpo: 3.2±0.2; drl: 1.4; psz: 0.6; bh: 7.0; Dual entry
+    # HOYATO PSDSM254: bw: 5.1;  ow: 7.2;              pad: 1.9, 1.2; psz: NA, 0.25 - with guide pins
+
+    # common settings
+    rm      = 2.54
+    ddrill  = 1.0
+
+    tht_pad              = [1.7, 1.7]
+    tht_packwidth_vert   = [2.54, 5.08]
+    tht_packoffset_vert  = [0, 0]
+    tht_packwidth_horiz  = [8.51, 8.51]
+    tht_packoffset_horiz = [1.52, 1.52]
+    tht_pin_width_horiz  = 0.64
+
+    smd_pin_width        = 0.64
+    smd_packwidth_vert   = [2.54, 5.08]
+    smd_overall_width    = [4.54, 7.84] # including pins
+    smd_packoffset_vert  = [0, 0]
+    smd_pads             = [[2.1, 1.0], [3.0, 1.0]]
+    smd_overall_lp_width = [5.2, 8.04]
+    smd_pin_length       = getPinLength(smd_overall_width, smd_packwidth_vert)
+    smd_pad_offset       = getPadOffsets(smd_overall_lp_width, smd_pads)
+
+    for cols in [1, 2]:
+
+        tht_overlen_top    = rm / 2.0
+        tht_overlen_bottom = tht_overlen_top
+        smd_overlen_top    = tht_overlen_top
+        smd_overlen_bottom = tht_overlen_top
+
+        for rows in range(1, 41):
+            makePinHeadStraight(rows, cols, rm, rm, tht_packwidth_vert[cols-1] + tht_packoffset_vert[cols-1],
+                                tht_overlen_top, tht_overlen_bottom, ddrill, tht_pad, [],
+                                "Conn_PinSocket_2.54mm", "PinSocket", "socket strip", isSocket=True)
+            makeSocketStripAngled(rows, cols, rm, rm, tht_packwidth_horiz[cols-1], tht_packoffset_horiz[cols-1], tht_pin_width_horiz, ddrill, tht_pad, [],
+                                 "Conn_PinSocket_2.54mm",  "PinSocket", "socket strip")
+            if cols == 2:
+                makePinHeadStraightSMD(rows, cols, rm, rm, smd_pad_offset[cols-1], smd_pin_length[cols-1], smd_pin_width,
+                                       smd_packwidth_vert[cols-1] + smd_packoffset_vert[cols-1],
+                                       smd_overlen_top, tht_overlen_bottom, smd_pads[cols-1], False, [],
+                                       "Conn_PinSocket_2.54mm", "PinSocket", "socket strip", isSocket=True)
+            elif rows > 2:
+                makePinHeadStraightSMD(rows, cols, rm, rm, smd_pad_offset[cols-1], smd_pin_length[cols-1], smd_pin_width,
+                                       smd_packwidth_vert[cols-1] + smd_packoffset_vert[cols-1],
+                                       smd_overlen_top, smd_overlen_bottom, smd_pads[cols-1], True, [],
+                                       "Conn_PinSocket_2.54mm", "PinSocket", "socket strip", isSocket=True)
+                makePinHeadStraightSMD(rows, cols, rm, rm, smd_pad_offset[cols-1], smd_pin_length[cols-1], smd_pin_width,
+                                       smd_packwidth_vert[cols-1] + smd_packoffset_vert[cols-1],
+                                       smd_overlen_top, smd_overlen_bottom, smd_pads[cols-1], False, [],
+                                       "Conn_PinSocket_2.54mm", "PinSocket", "socket strip", isSocket=True)
+
+    ######################
+    # 2.00mm pin sockets #
+    ######################
+
+    # THT 1 row vertical:
+    # KiCad legacy : bw: 2.00;            pad: 1.35; drl: 0.8
+
+    # THT 2 rows vertical:
+    # KiCad legacy : bw: 4.00;            pad: 1.35; drl: 0.8
+    # Amphenol FCi : bw: 4.20; blo: 0.8;                       psz: 0.5, 0.2;  pl: 2.5; bh: 7.0
+
+    # THT 1 row horizontal:
+    # KiCad legacy : bw: 6.35; bo: 1.27; pad: 1.7; drl: 1.0
+
+    # THT 2 rows horizontal:
+    # KiCad legacy : bw: 6.35; bo: 1.27; pad: 1.7; drl: 1.0
+
+    # SMD 1 row LR:
+    # 4601WVS-XX-6TV01 : bw: 2.5; ow: 4.2±0.15; blo: 0.6; pad: 2.0, 0.89; lpo: 5.2; psz: 0.5, 0.2; bh: 4.3
+    #                  : bw: 2.4; ow: 4.2;      blo: 0.6; pad: 2.3, 0.90; lpo: 5.2; psz: 0.5, 0.2; bh: 4.3
+
+    # SMD 2 rows vertical:
+    # KiCad legacy   : bw: 4.0; ow: 6.00;             pad:  2.75,  1.0; lpo:  9.0; psz: 0.50
+    # Amphenol FCi   : bw: 4.0; ow: 6.00; blo: -0.08; pad: >1.50, t1.0; lpo: >6.5; psz: 0.44, NA;    bh: 4.5
+    # HOYATO PSDSM20 : bw: 4.0; ow: 6.15; blo: -0.08; pad:  2.00,  1.0; lpo:  7.0; psz: 0.50, NA;    bh: 4.5
+    #                : bw: 4.0; ow: 6.00; blo:  0.60; pad:  2.30,  0.9; lpo:  7.0; psz: 0.50, 0.20;  bh: 4.3
+
+    rm = 2.00
+    ddrill = 0.8
+
+    tht_pad              = [1.35, 1.35]
+    tht_packwidth_vert   = [2.0, 4.0]
+    tht_packoffset_vert  = [0, 0]
+    tht_packwidth_horiz  = [6.35, 6.35]
+    tht_packoffset_horiz = [1.27, 1.27]
+    tht_pin_width_horiz  = 0.5
+
+    smd_pin_width        = 0.5
+    smd_packwidth_vert   = [2.0, 4.0]
+    smd_overall_width    = [4.4, 6.0]
+    smd_packoffset_vert  = [0, 0]
+    smd_pads             = [[2.0, 0.9], [2.75, 1.0]]
+    smd_overall_lp_width = [5.2, 9.0] # land pattern width (8.04)
+    smd_pin_length       = getPinLength(smd_overall_width, smd_packwidth_vert)
+    smd_pad_offset       = getPadOffsets(smd_overall_lp_width, smd_pads)
+
+    for cols in [1, 2]:
+
+        tht_overlen_top    = rm / 2.0
+        tht_overlen_bottom = tht_overlen_top
+        smd_overlen_top    = tht_overlen_top
+        smd_overlen_bottom = tht_overlen_top
+
+        for rows in range(1, 41):
+            makePinHeadStraight(rows, cols, rm, rm, tht_packwidth_vert[cols-1] + tht_packoffset_vert[cols-1],
+                                tht_overlen_top, tht_overlen_top, ddrill, tht_pad, [],
+                                "Conn_PinSocket_2.00mm", "PinSocket", "socket strip", isSocket=True)
+            makeSocketStripAngled(rows, cols, rm, rm, tht_packwidth_horiz[cols-1], tht_packoffset_horiz[cols-1],
+                              tht_pin_width_horiz, ddrill, tht_pad, [],
+                              "Conn_PinSocket_2.00mm", "PinSocket", "socket strip")
+            if cols == 2:
+                makePinHeadStraightSMD(rows, cols, rm, rm, smd_pad_offset[cols-1], smd_pin_length[cols-1], smd_pin_width,
+                                       smd_packwidth_vert[cols-1] + smd_packoffset_vert[cols-1],
+                                       smd_overlen_top, tht_overlen_top, smd_pads[cols-1], False, [],
+                                       "Conn_PinSocket_2.00mm", "PinSocket", "socket strip", isSocket=True)
+            elif rows > 2:
+                makePinHeadStraightSMD(rows, cols, rm, rm, smd_pad_offset[cols-1], smd_pin_length[cols-1], smd_pin_width,
+                                       smd_packwidth_vert[cols-1] + smd_packoffset_vert[cols-1],
+                                       rm / 2.0 + tht_packoffset_vert[cols-1], rm / 2.0 + tht_packoffset_vert[cols-1], smd_pads[cols-1], True, [],
+                                       "Conn_PinSocket_2.00mm", "PinSocket", "socket strip", isSocket=True)
+                makePinHeadStraightSMD(rows, cols, rm, rm, smd_pad_offset[cols-1], smd_pin_length[cols-1], smd_pin_width,
+                                       smd_packwidth_vert[cols-1] + tht_packoffset_vert[cols-1], smd_overlen_top, smd_overlen_bottom, smd_pads[cols-1], False, [], "Conn_PinSocket_2.00mm", "PinSocket", "socket strip", isSocket=True)
+
+    ######################
+    # 1.27mm pin sockets #
+    ######################
+
+    # THT 1 row vertical:
+    # KiCad legacy : bw: 2.00;            pad: 1.00; drl: 0.7
+    # InterContact : bw: 2.20; blo: NA;              drl: 0.6; pl: 2.45; bh: 4.1
+
+    # THT 2 rows vertical:
+    # KiCad legacy : bw: 3.05;            pad: 1.00; drl: 0.7
+    # Amphenol FCi : bw: 3.00; blo: 0.46;            drl: 0.65; psz: 0.2, 0.4; pl: 2.4±0.3; bh: 4.4
+    # InterContact : bw: 3.05;                       drl: 0.60;                pl: 2.45;    bh: 4.1,
+
+    # THT 1 row horizontal:
+    # InterContact : bw: 4.1, po: 1.2; drl: 0.60; pl: 3.00; bh: 2.2
+
+    # THT 2 rows horizontal:
+    # InterContact : bw: 4.1, po: 1.2;  drl: 0.60;                  pl: 3.00; bh: 3.05
+    # GCT BD091    : bw: 4.4, po: 0.07; drl: 0.65; psz: 0.42, 0.15; pl: 2.00; bh: 3.10
+
+    # SMD 1 row LR:
+    # GCT BD074         : bw: 1.8; ow: 3.6; blo: 0.35; pad: 2.30, 0.70; lpo: 4.6; psz: 0.42, 0.15; bh: 2.2
+    # GCT BD075         : bw: 1.8; ow: 3.6; blo: 0.35; pad: 1.80, 0.65; lpo: 3.5; psz: 0.42, 0.15; bh: 4.6
+
+    # SMD 2 rows vertical:
+    # KiCad legacy : bw: 2.54; ow: 5.11;                pad: 2.10, 0.75;      lpo: 5.7; psz: 0.40
+    # Amphenol FCi : bw: 3.00; ow: 4.50±0.5; blo: 1.73; pad: 2.05, 0.76±0.05; lpo: 5.6; psz: 0.40, NA;   bh: 4.4
+    # GCT BD064    : bw: 3.10; ow: 4.80±0.3; blo: 1.73; pad: 2.15, 0.65;      lpo: 5.8; psz: 0.42, 0.15; bh: 4.6
+
+    rm = 1.27
+    ddrill = 0.7
+
+    tht_pad             = [1.0, 1.0]
+    tht_packwidth_vert  = [2.54, 3.05]
+    tht_packoffset_vert = [0.0, 0.0]
+
+    smd_pin_width        = 0.4
+    smd_packwidth_vert   = [2.54, 2.54]
+    smd_overall_width    = [3.27, 5.11]
+    smd_packoffset_vert  = [0.0, 0.0]
+    smd_pads             = [[2.1, 1.0], [2.1, 0.75]]
+    smd_overall_lp_width = [5.2, 5.7] # land pattern width
+    smd_pin_length       = getPinLength(smd_overall_width, smd_packwidth_vert)
+    smd_pad_offset       = getPadOffsets(smd_overall_lp_width, smd_pads)
+
+    for cols in [1, 2]:
+
+        tht_overlen_top    = rm / 2.0 # tht_packwidth_vert[cols-1] / 2.0 # + tht_packoffset_vert[cols-1]
+        tht_overlen_bottom = tht_overlen_top
+        smd_overlen_top    = tht_overlen_top
+        smd_overlen_bottom = tht_overlen_top
+
+        for rows in range(1, 41):
+            makePinHeadStraight(rows, cols, rm, rm, tht_packwidth_vert[cols-1],
+                                tht_overlen_top, tht_overlen_bottom, ddrill, tht_pad, [],
+                                "Conn_PinSocket_1.27mm", "PinSocket", "socket strip", isSocket=True)
+            if cols == 2:
+                makePinHeadStraightSMD(rows, cols, rm, rm, smd_pad_offset[cols-1], smd_pin_length[cols-1], smd_pin_width,
+                                       smd_packwidth_vert[cols-1],
+                                       smd_overlen_top, smd_overlen_bottom, smd_pads[cols-1], False, [],
+                                       "Conn_PinSocket_1.27mm", "PinSocket", "socket strip", isSocket=True)
+
+### EOF ###

--- a/scripts/Conn_PinSocket/main_generator.py
+++ b/scripts/Conn_PinSocket/main_generator.py
@@ -79,14 +79,14 @@ if __name__ == '__main__':
     # KiCad legacy : bw: 2.54;             pad: 1.7; drl: 1.0
     # Amphenol FCi : bw: 2.54; blo: -0.08;           drl: >0.75; psz: 0.6, 0.2;  pl: 2.5; bh: 7.0
 
-    # THT 2 rows vertical:
+    # THT 2 cols vertical:
     # KiCad legacy : bw: 5.08;             pad: 1.7; drl: 1.0
     # Amphenol FCi : bw: 5.08; blo: -0.08;           drl: >0.8;  psz: 0.6, 0.2; pl: 2.5; bh: 7.0
 
     # THT 1 row horizontal:
     # KiCad legacy : bw: 8.51; bo: 1.52; pad: 1.7; drl: 1.0
 
-    # THT 2 rows horizontal:
+    # THT 2 cols horizontal:
     # KiCad legacy : bw: 8.51; bo: 1.52; pad: 1.7; drl: 1.0
 
     # SMD 1 row:
@@ -94,7 +94,7 @@ if __name__ == '__main__':
     # V FHC50    1RL: bw: 2.50; ow: 4.80; blo: 0.60;  pad: 2.10, 1.02;    lpo: 5.5;     psz: 0.5, 0.2; bh: 5.0
     # V HOYATO    1*: bw: 2.50; ow: 4.05,             pad: 1.91, 1.00;    lpo; 5.2;     psz: 0.5, 0.2; bh: 7.5
 
-    # SMD 2 rows vertical:
+    # SMD 2 cols vertical:
     # KiCad legacy   : bw: 5.08; ow: 8.04;             pad: 3.0, 1.0;                  psz: 1.38, 0.64
     # Amphenol FCi   : bw: 5.08; ow: 6.10; blo: -0.08; pad: t1.27, >4.2; lpo: 3.2±0.2; psz: 0.6;           bh: 7.0; Top entry
     # Amphenol FCi   : bw: 5.08; ow: 6.10; blo: -0.08; pad: t1.27, >1.4; lpo: 3.2±0.2; drl: 1.4; psz: 0.6; bh: 7.0; Dual entry
@@ -120,32 +120,32 @@ if __name__ == '__main__':
     smd_pin_length       = getPinLength(smd_overall_width, smd_packwidth_vert)
     smd_pad_offset       = getPadOffsets(smd_overall_lp_width, smd_pads)
 
-    for cols in [1, 2]:
+    for rows in [1, 2]:
 
         tht_overlen_top    = rm / 2.0
         tht_overlen_bottom = tht_overlen_top
         smd_overlen_top    = tht_overlen_top
         smd_overlen_bottom = tht_overlen_top
 
-        for rows in range(1, 41):
-            makePinHeadStraight(rows, cols, rm, rm, tht_packwidth_vert[cols-1] + tht_packoffset_vert[cols-1],
+        for cols in range(1, 41):
+            makePinHeadStraight(cols, rows, rm, rm, tht_packwidth_vert[rows-1] + tht_packoffset_vert[rows-1],
                                 tht_overlen_top, tht_overlen_bottom, ddrill, tht_pad, [],
                                 "Conn_PinSocket_2.54mm", "PinSocket", "socket strip", isSocket=True)
-            makeSocketStripAngled(rows, cols, rm, rm, tht_packwidth_horiz[cols-1], tht_packoffset_horiz[cols-1], tht_pin_width_horiz, ddrill, tht_pad, [],
+            makeSocketStripAngled(cols, rows, rm, rm, tht_packwidth_horiz[rows-1], tht_packoffset_horiz[rows-1], tht_pin_width_horiz, ddrill, tht_pad, [],
                                  "Conn_PinSocket_2.54mm",  "PinSocket", "socket strip")
-            if cols == 2:
-                makePinHeadStraightSMD(rows, cols, rm, rm, smd_pad_offset[cols-1], smd_pin_length[cols-1], smd_pin_width,
-                                       smd_packwidth_vert[cols-1] + smd_packoffset_vert[cols-1],
-                                       smd_overlen_top, tht_overlen_bottom, smd_pads[cols-1], False, [],
+            if rows == 2:
+                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
+                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
+                                       smd_overlen_top, tht_overlen_bottom, smd_pads[rows-1], False, [],
                                        "Conn_PinSocket_2.54mm", "PinSocket", "socket strip", isSocket=True)
-            elif rows > 2:
-                makePinHeadStraightSMD(rows, cols, rm, rm, smd_pad_offset[cols-1], smd_pin_length[cols-1], smd_pin_width,
-                                       smd_packwidth_vert[cols-1] + smd_packoffset_vert[cols-1],
-                                       smd_overlen_top, smd_overlen_bottom, smd_pads[cols-1], True, [],
+            elif cols > 1:
+                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
+                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
+                                       smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], True, [],
                                        "Conn_PinSocket_2.54mm", "PinSocket", "socket strip", isSocket=True)
-                makePinHeadStraightSMD(rows, cols, rm, rm, smd_pad_offset[cols-1], smd_pin_length[cols-1], smd_pin_width,
-                                       smd_packwidth_vert[cols-1] + smd_packoffset_vert[cols-1],
-                                       smd_overlen_top, smd_overlen_bottom, smd_pads[cols-1], False, [],
+                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
+                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
+                                       smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], False, [],
                                        "Conn_PinSocket_2.54mm", "PinSocket", "socket strip", isSocket=True)
 
     ######################
@@ -155,21 +155,21 @@ if __name__ == '__main__':
     # THT 1 row vertical:
     # KiCad legacy : bw: 2.00;            pad: 1.35; drl: 0.8
 
-    # THT 2 rows vertical:
+    # THT 2 cols vertical:
     # KiCad legacy : bw: 4.00;            pad: 1.35; drl: 0.8
     # Amphenol FCi : bw: 4.20; blo: 0.8;                       psz: 0.5, 0.2;  pl: 2.5; bh: 7.0
 
     # THT 1 row horizontal:
     # KiCad legacy : bw: 6.35; bo: 1.27; pad: 1.7; drl: 1.0
 
-    # THT 2 rows horizontal:
+    # THT 2 cols horizontal:
     # KiCad legacy : bw: 6.35; bo: 1.27; pad: 1.7; drl: 1.0
 
     # SMD 1 row LR:
     # 4601WVS-XX-6TV01 : bw: 2.5; ow: 4.2±0.15; blo: 0.6; pad: 2.0, 0.89; lpo: 5.2; psz: 0.5, 0.2; bh: 4.3
     #                  : bw: 2.4; ow: 4.2;      blo: 0.6; pad: 2.3, 0.90; lpo: 5.2; psz: 0.5, 0.2; bh: 4.3
 
-    # SMD 2 rows vertical:
+    # SMD 2 cols vertical:
     # KiCad legacy   : bw: 4.0; ow: 6.00;             pad:  2.75,  1.0; lpo:  9.0; psz: 0.50
     # Amphenol FCi   : bw: 4.0; ow: 6.00; blo: -0.08; pad: >1.50, t1.0; lpo: >6.5; psz: 0.44, NA;    bh: 4.5
     # HOYATO PSDSM20 : bw: 4.0; ow: 6.15; blo: -0.08; pad:  2.00,  1.0; lpo:  7.0; psz: 0.50, NA;    bh: 4.5
@@ -194,32 +194,33 @@ if __name__ == '__main__':
     smd_pin_length       = getPinLength(smd_overall_width, smd_packwidth_vert)
     smd_pad_offset       = getPadOffsets(smd_overall_lp_width, smd_pads)
 
-    for cols in [1, 2]:
+    for rows in [1, 2]:
 
         tht_overlen_top    = rm / 2.0
         tht_overlen_bottom = tht_overlen_top
         smd_overlen_top    = tht_overlen_top
         smd_overlen_bottom = tht_overlen_top
 
-        for rows in range(1, 41):
-            makePinHeadStraight(rows, cols, rm, rm, tht_packwidth_vert[cols-1] + tht_packoffset_vert[cols-1],
+        for cols in range(1, 41):
+            makePinHeadStraight(cols, rows, rm, rm, tht_packwidth_vert[rows-1] + tht_packoffset_vert[rows-1],
                                 tht_overlen_top, tht_overlen_top, ddrill, tht_pad, [],
                                 "Conn_PinSocket_2.00mm", "PinSocket", "socket strip", isSocket=True)
-            makeSocketStripAngled(rows, cols, rm, rm, tht_packwidth_horiz[cols-1], tht_packoffset_horiz[cols-1],
+            makeSocketStripAngled(cols, rows, rm, rm, tht_packwidth_horiz[rows-1], tht_packoffset_horiz[rows-1],
                               tht_pin_width_horiz, ddrill, tht_pad, [],
                               "Conn_PinSocket_2.00mm", "PinSocket", "socket strip")
-            if cols == 2:
-                makePinHeadStraightSMD(rows, cols, rm, rm, smd_pad_offset[cols-1], smd_pin_length[cols-1], smd_pin_width,
-                                       smd_packwidth_vert[cols-1] + smd_packoffset_vert[cols-1],
-                                       smd_overlen_top, tht_overlen_top, smd_pads[cols-1], False, [],
+            if rows == 2:
+                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
+                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
+                                       smd_overlen_top, tht_overlen_top, smd_pads[rows-1], False, [],
                                        "Conn_PinSocket_2.00mm", "PinSocket", "socket strip", isSocket=True)
-            elif rows > 2:
-                makePinHeadStraightSMD(rows, cols, rm, rm, smd_pad_offset[cols-1], smd_pin_length[cols-1], smd_pin_width,
-                                       smd_packwidth_vert[cols-1] + smd_packoffset_vert[cols-1],
-                                       rm / 2.0 + tht_packoffset_vert[cols-1], rm / 2.0 + tht_packoffset_vert[cols-1], smd_pads[cols-1], True, [],
+            elif cols > 1:
+                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
+                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
+                                       rm / 2.0 + tht_packoffset_vert[rows-1], rm / 2.0 + tht_packoffset_vert[rows-1], smd_pads[rows-1], True, [],
                                        "Conn_PinSocket_2.00mm", "PinSocket", "socket strip", isSocket=True)
-                makePinHeadStraightSMD(rows, cols, rm, rm, smd_pad_offset[cols-1], smd_pin_length[cols-1], smd_pin_width,
-                                       smd_packwidth_vert[cols-1] + tht_packoffset_vert[cols-1], smd_overlen_top, smd_overlen_bottom, smd_pads[cols-1], False, [], "Conn_PinSocket_2.00mm", "PinSocket", "socket strip", isSocket=True)
+                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
+                                       smd_packwidth_vert[rows-1] + tht_packoffset_vert[rows-1], smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], False, [],
+                                      "Conn_PinSocket_2.00mm", "PinSocket", "socket strip", isSocket=True)
 
     ######################
     # 1.27mm pin sockets #
@@ -229,7 +230,7 @@ if __name__ == '__main__':
     # KiCad legacy : bw: 2.00;            pad: 1.00; drl: 0.7
     # InterContact : bw: 2.20; blo: NA;              drl: 0.6; pl: 2.45; bh: 4.1
 
-    # THT 2 rows vertical:
+    # THT 2 cols vertical:
     # KiCad legacy : bw: 3.05;            pad: 1.00; drl: 0.7
     # Amphenol FCi : bw: 3.00; blo: 0.46;            drl: 0.65; psz: 0.2, 0.4; pl: 2.4±0.3; bh: 4.4
     # InterContact : bw: 3.05;                       drl: 0.60;                pl: 2.45;    bh: 4.1,
@@ -237,7 +238,7 @@ if __name__ == '__main__':
     # THT 1 row horizontal:
     # InterContact : bw: 4.1, po: 1.2; drl: 0.60; pl: 3.00; bh: 2.2
 
-    # THT 2 rows horizontal:
+    # THT 2 cols horizontal:
     # InterContact : bw: 4.1, po: 1.2;  drl: 0.60;                  pl: 3.00; bh: 3.05
     # GCT BD091    : bw: 4.4, po: 0.07; drl: 0.65; psz: 0.42, 0.15; pl: 2.00; bh: 3.10
 
@@ -245,10 +246,13 @@ if __name__ == '__main__':
     # GCT BD074         : bw: 1.8; ow: 3.6; blo: 0.35; pad: 2.30, 0.70; lpo: 4.6; psz: 0.42, 0.15; bh: 2.2
     # GCT BD075         : bw: 1.8; ow: 3.6; blo: 0.35; pad: 1.80, 0.65; lpo: 3.5; psz: 0.42, 0.15; bh: 4.6
 
-    # SMD 2 rows vertical:
+    # SMD 2 cols vertical:
     # KiCad legacy : bw: 2.54; ow: 5.11;                pad: 2.10, 0.75;      lpo: 5.7; psz: 0.40
     # Amphenol FCi : bw: 3.00; ow: 4.50±0.5; blo: 1.73; pad: 2.05, 0.76±0.05; lpo: 5.6; psz: 0.40, NA;   bh: 4.4
     # GCT BD064    : bw: 3.10; ow: 4.80±0.3; blo: 1.73; pad: 2.15, 0.65;      lpo: 5.8; psz: 0.42, 0.15; bh: 4.6
+    
+    # SMD 1 cols vertical:
+    # GCT BD075    : bw: 1.80; ow: 3.50;     blo: 0.81; pad: 1.80, 0.65;      lpo: 4.5; psz: 0.42, 0.15; bh: 4.6
 
     rm = 1.27
     ddrill = 0.7
@@ -258,29 +262,97 @@ if __name__ == '__main__':
     tht_packoffset_vert = [0.0, 0.0]
 
     smd_pin_width        = 0.4
-    smd_packwidth_vert   = [2.54, 2.54]
-    smd_overall_width    = [3.27, 5.11]
+    smd_packwidth_vert   = [1.80, 2.54]
+    smd_overall_width    = [3.5, 5.11]
     smd_packoffset_vert  = [0.0, 0.0]
-    smd_pads             = [[2.1, 1.0], [2.1, 0.75]]
-    smd_overall_lp_width = [5.2, 5.7] # land pattern width
+    smd_pads             = [[1.8, 0.65], [2.1, 0.75]]
+    smd_overall_lp_width = [4.5, 5.7] # land pattern width
     smd_pin_length       = getPinLength(smd_overall_width, smd_packwidth_vert)
     smd_pad_offset       = getPadOffsets(smd_overall_lp_width, smd_pads)
 
-    for cols in [1, 2]:
+    for rows in [1, 2]:
 
-        tht_overlen_top    = rm / 2.0 # tht_packwidth_vert[cols-1] / 2.0 # + tht_packoffset_vert[cols-1]
+        tht_overlen_top    = rm / 2.0 # tht_packwidth_vert[rows-1] / 2.0 # + tht_packoffset_vert[rows-1]
         tht_overlen_bottom = tht_overlen_top
         smd_overlen_top    = tht_overlen_top
         smd_overlen_bottom = tht_overlen_top
 
-        for rows in range(1, 41):
-            makePinHeadStraight(rows, cols, rm, rm, tht_packwidth_vert[cols-1],
+        for cols in range(1, 41):
+            makePinHeadStraight(cols, rows, rm, rm, tht_packwidth_vert[rows-1],
                                 tht_overlen_top, tht_overlen_bottom, ddrill, tht_pad, [],
                                 "Conn_PinSocket_1.27mm", "PinSocket", "socket strip", isSocket=True)
-            if cols == 2:
-                makePinHeadStraightSMD(rows, cols, rm, rm, smd_pad_offset[cols-1], smd_pin_length[cols-1], smd_pin_width,
-                                       smd_packwidth_vert[cols-1],
-                                       smd_overlen_top, smd_overlen_bottom, smd_pads[cols-1], False, [],
+            if rows == 2:
+                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
+                                       smd_packwidth_vert[rows-1],
+                                       smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], False, [],
                                        "Conn_PinSocket_1.27mm", "PinSocket", "socket strip", isSocket=True)
+            elif cols > 1:
+                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
+                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
+                                       rm / 2.0 + tht_packoffset_vert[rows-1], rm / 2.0 + tht_packoffset_vert[rows-1], smd_pads[rows-1], True, [],
+                                       "Conn_PinSocket_1.27mm", "PinSocket", "socket strip", isSocket=True)
+                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
+                                       smd_packwidth_vert[rows-1] + tht_packoffset_vert[rows-1], smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], False, [],
+                                       "Conn_PinSocket_1.27mm", "PinSocket", "socket strip", isSocket=True)
+
+    ######################
+    # 1.00mm pin sockets #
+    ######################
+
+    # THT 1 row vertical:
+    # GHC BC065    : bw: 1.50; blo: 0.75;              drl: 0.5; pl: 1.8; bh: 2.1
+
+    # THT 2 cols vertical:
+
+    # SMD 1 row LR:
+    # GCT BC070    : bw: 1.5; ow: 2.9; blo: 0.75; pad: 1.95, 0.50; lpo: 3.9; psz: 0.30, 0.10; bh: 2.25
+
+    # SMD 2 cols vertical:
+    # GCT BC085    : bw: 2.5; ow: 3.90±0.25; blo: 0.25; pad: 1.85, 0.50;      lpo: 4.9; psz: 0.30, 0.10; bh: 2.25
+
+    rm = 1.00
+    ddrill = 0.5
+
+    tht_pad             = [0.85, 0.85]
+    tht_packwidth_vert  = [1.50, 3.05]
+    tht_packoffset_vert = [0.75, 0.0]
+    tht_overlen         = 0.75
+    tht_pad_offset      = 0.29
+    
+    smd_pin_width        = 0.3
+    smd_packwidth_vert   = [1.50, 2.5]
+    smd_overall_width    = [2.9, 3.9]
+    smd_packoffset_vert  = [0.0, 0.0]
+    smd_overlen          = 0.75
+    smd_pads             = [[1.95, 0.50], [1.85, 0.50]]
+    smd_overall_lp_width = [3.9, 4.9] # land pattern width
+    smd_pin_length       = getPinLength(smd_overall_width, smd_packwidth_vert)
+    smd_pad_offset       = getPadOffsets(smd_overall_lp_width, smd_pads)
+
+    for rows in [1, 2]:
+
+        tht_overlen_top    = tht_overlen
+        tht_overlen_bottom = tht_overlen
+        smd_overlen_top    = smd_overlen
+        smd_overlen_bottom = smd_overlen
+
+        for cols in range(1, 41):
+            if rows == 2:
+                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
+                                       smd_packwidth_vert[rows-1],
+                                       smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], False, [],
+                                       "Conn_PinSocket_1.00mm", "PinSocket", "socket strip", isSocket=True)
+            elif cols > 1:
+                makePinHeadStraight(cols, rows, rm, rm, tht_packwidth_vert[rows-1],
+                                    tht_overlen_top, tht_overlen_bottom, ddrill, tht_pad, [],
+                                    "Conn_PinSocket_1.00mm", "PinSocket", "socket strip", isSocket=True, pad_offset=tht_pad_offset)
+                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
+                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
+                                       smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], True, [],
+                                       "Conn_PinSocket_1.00mm", "PinSocket", "socket strip", isSocket=True)
+                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
+                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
+                                       smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], False, [],
+                                       "Conn_PinSocket_1.00mm", "PinSocket", "socket strip", isSocket=True)
 
 ### EOF ###

--- a/scripts/Conn_PinSocket/main_generator.py
+++ b/scripts/Conn_PinSocket/main_generator.py
@@ -1,358 +1,59 @@
 # -*- coding: utf8 -*-
 #!/usr/bin/env python
 
-# KicadModTree is free software: you can redistribute it and/or
+#
+# Parts script module for socket strip footprints for KicCad
+#
+# This module is built on top of the kicad-footprint-generator framework
+# by Thomas Pointhuber, https://github.com/pointhi/kicad-footprint-generator
+#
+# This module is free software: you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# KicadModTree is distributed in the hope that it will be useful,
+# This module is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
 # along with kicad-footprint-generator. If not, see < http://www.gnu.org/licenses/ >.
-#
 
 #
-# based on scripts\pin_headers_socket_strips
-# refactored by Terje Io, <http://github.com/terjeio>
-# updated for KLC3 and new naming convention
+# (C) 2017 Terje Io, <http://github.com/terjeio>
 #
 
-# Some datasheet sources:
-#
-# http://www.amphenol-icc.com/board-to-board.html?gender_filter=559
-# http://www.taydaelectronics.com/connectors-sockets/pin-headers.html
-# https://gct.co/board-to-board-connector/list?pitch=2.54mm%2C1.00mm&gender=Socket
-# https://www.harwin.com/products/M50-3100545/
-# https://lbconnector.en.alibaba.com/productgrouplist-804748813-8/Pin_Female_Box_Header.html?spm=a2700.8304367.costd19dbc.23.2ccc31d5Xg47e5&isGallery=Y
-#
+# 2017-11-25
 
 #
-# NOTE: most footprints are based on legacy dimensions which does not have any documented datasheet sources
+# NOTE: many footprints are based on legacy dimensions which does not have any documented datasheet sources
+#       see parameter.yaml for which
 #
 
-#import sys
-#import os
+from parameters import params
 
-#sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "\\..\\tools")
-
-from socket_strips import *  # NOQA
+import socket_strips
 
 if __name__ == '__main__':
 
-    def getPadOffsets(overall_width, pads):
-        result = []
-        for i in range(0, len(pads)):
-            result.append(round((overall_width[i] - pads[i][0]) / 2.0, 3))
-        return result
+    series = [
+        socket_strips.pinSocketVerticalTHT,
+        socket_strips.pinSocketHorizontalTHT,
+        socket_strips.pinSocketVerticalSMD
+    ]
 
-    def getPinLength(overall_width, packwidth):
-        result = []
-        for i in range(0, len(overall_width)):
-            result.append(round((overall_width[i] - packwidth[i]) / 2.0, 3))
-        return result
+    params = params()
+#    models = params.getSampleModels(series, 4)
+    models = params.getAllModels(series)
+    i = 0
+    for variant in models.keys():
+        params = models[variant].params
+        model = models[variant].model(params)
+        if model.make_me:
+            model.make()
+        i += 1
 
-    # bw  - body width
-    # bo  - body offset
-    # blo - body overlength
-    # pl  - pin length, THT for 3D model
-    # pad - pad size
-    # drl - drill size
-    # ow  - SMD, overall width (including pins)
-    # lpo - SMD land pattern overall width
-    # psz - SMD pin size (width, [, thickness for 3D model]) 
-    # bh  - body height (3D parameter, PCB to top)
-    
-    # t  - typical
-    # >  - min (greater or equal)
-    # <  - max (smaller or equal)
-    # NA - not available
-    
-    ######################
-    # 2.54mm pin sockets #
-    ######################
-
-    # THT 1 row vertical:
-    # KiCad legacy : bw: 2.54;             pad: 1.7; drl: 1.0
-    # Amphenol FCi : bw: 2.54; blo: -0.08;           drl: >0.75; psz: 0.6, 0.2;  pl: 2.5; bh: 7.0
-
-    # THT 2 cols vertical:
-    # KiCad legacy : bw: 5.08;             pad: 1.7; drl: 1.0
-    # Amphenol FCi : bw: 5.08; blo: -0.08;           drl: >0.8;  psz: 0.6, 0.2; pl: 2.5; bh: 7.0
-
-    # THT 1 row horizontal:
-    # KiCad legacy : bw: 8.51; bo: 1.52; pad: 1.7; drl: 1.0
-
-    # THT 2 cols horizontal:
-    # KiCad legacy : bw: 8.51; bo: 1.52; pad: 1.7; drl: 1.0
-
-    # SMD 1 row:
-    # Amphenol FCi 1: bw: 5.08;           blo: -0.08; pad: 2 - 1.0, <1.5; lpo: 6.1±0.2; psz: 0.6; bh: 7.0
-    # V FHC50    1RL: bw: 2.50; ow: 4.80; blo: 0.60;  pad: 2.10, 1.02;    lpo: 5.5;     psz: 0.5, 0.2; bh: 5.0
-    # V HOYATO    1*: bw: 2.50; ow: 4.05,             pad: 1.91, 1.00;    lpo; 5.2;     psz: 0.5, 0.2; bh: 7.5
-
-    # SMD 2 cols vertical:
-    # KiCad legacy   : bw: 5.08; ow: 8.04;             pad: 3.0, 1.0;                  psz: 1.38, 0.64
-    # Amphenol FCi   : bw: 5.08; ow: 6.10; blo: -0.08; pad: t1.27, >4.2; lpo: 3.2±0.2; psz: 0.6;           bh: 7.0; Top entry
-    # Amphenol FCi   : bw: 5.08; ow: 6.10; blo: -0.08; pad: t1.27, >1.4; lpo: 3.2±0.2; drl: 1.4; psz: 0.6; bh: 7.0; Dual entry
-    # HOYATO PSDSM254: bw: 5.1;  ow: 7.2;              pad: 1.9, 1.2; psz: NA, 0.25 - with guide pins
-
-    # common settings
-    rm      = 2.54
-    ddrill  = 1.0
-
-    tht_pad              = [1.7, 1.7]
-    tht_packwidth_vert   = [2.54, 5.08]
-    tht_packoffset_vert  = [0, 0]
-    tht_packwidth_horiz  = [8.51, 8.51]
-    tht_packoffset_horiz = [1.52, 1.52]
-    tht_pin_width_horiz  = 0.64
-
-    smd_pin_width        = 0.64
-    smd_packwidth_vert   = [2.54, 5.08]
-    smd_overall_width    = [4.54, 7.84] # including pins
-    smd_packoffset_vert  = [0, 0]
-    smd_pads             = [[2.1, 1.0], [3.0, 1.0]]
-    smd_overall_lp_width = [5.2, 8.04]
-    smd_pin_length       = getPinLength(smd_overall_width, smd_packwidth_vert)
-    smd_pad_offset       = getPadOffsets(smd_overall_lp_width, smd_pads)
-
-    for rows in [1, 2]:
-
-        tht_overlen_top    = rm / 2.0
-        tht_overlen_bottom = tht_overlen_top
-        smd_overlen_top    = tht_overlen_top
-        smd_overlen_bottom = tht_overlen_top
-
-        for cols in range(1, 41):
-            makePinHeadStraight(cols, rows, rm, rm, tht_packwidth_vert[rows-1] + tht_packoffset_vert[rows-1],
-                                tht_overlen_top, tht_overlen_bottom, ddrill, tht_pad, [],
-                                "Conn_PinSocket_2.54mm", "PinSocket", "socket strip", isSocket=True)
-            makeSocketStripAngled(cols, rows, rm, rm, tht_packwidth_horiz[rows-1], tht_packoffset_horiz[rows-1], tht_pin_width_horiz, ddrill, tht_pad, [],
-                                 "Conn_PinSocket_2.54mm",  "PinSocket", "socket strip")
-            if rows == 2:
-                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
-                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
-                                       smd_overlen_top, tht_overlen_bottom, smd_pads[rows-1], False, [],
-                                       "Conn_PinSocket_2.54mm", "PinSocket", "socket strip", isSocket=True)
-            elif cols > 1:
-                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
-                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
-                                       smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], True, [],
-                                       "Conn_PinSocket_2.54mm", "PinSocket", "socket strip", isSocket=True)
-                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
-                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
-                                       smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], False, [],
-                                       "Conn_PinSocket_2.54mm", "PinSocket", "socket strip", isSocket=True)
-
-    ######################
-    # 2.00mm pin sockets #
-    ######################
-
-    # THT 1 row vertical:
-    # KiCad legacy : bw: 2.00;            pad: 1.35; drl: 0.8
-
-    # THT 2 cols vertical:
-    # KiCad legacy : bw: 4.00;            pad: 1.35; drl: 0.8
-    # Amphenol FCi : bw: 4.20; blo: 0.8;                       psz: 0.5, 0.2;  pl: 2.5; bh: 7.0
-
-    # THT 1 row horizontal:
-    # KiCad legacy : bw: 6.35; bo: 1.27; pad: 1.7; drl: 1.0
-
-    # THT 2 cols horizontal:
-    # KiCad legacy : bw: 6.35; bo: 1.27; pad: 1.7; drl: 1.0
-
-    # SMD 1 row LR:
-    # 4601WVS-XX-6TV01 : bw: 2.5; ow: 4.2±0.15; blo: 0.6; pad: 2.0, 0.89; lpo: 5.2; psz: 0.5, 0.2; bh: 4.3
-    #                  : bw: 2.4; ow: 4.2;      blo: 0.6; pad: 2.3, 0.90; lpo: 5.2; psz: 0.5, 0.2; bh: 4.3
-
-    # SMD 2 cols vertical:
-    # KiCad legacy   : bw: 4.0; ow: 6.00;             pad:  2.75,  1.0; lpo:  9.0; psz: 0.50
-    # Amphenol FCi   : bw: 4.0; ow: 6.00; blo: -0.08; pad: >1.50, t1.0; lpo: >6.5; psz: 0.44, NA;    bh: 4.5
-    # HOYATO PSDSM20 : bw: 4.0; ow: 6.15; blo: -0.08; pad:  2.00,  1.0; lpo:  7.0; psz: 0.50, NA;    bh: 4.5
-    #                : bw: 4.0; ow: 6.00; blo:  0.60; pad:  2.30,  0.9; lpo:  7.0; psz: 0.50, 0.20;  bh: 4.3
-
-    rm = 2.00
-    ddrill = 0.8
-
-    tht_pad              = [1.35, 1.35]
-    tht_packwidth_vert   = [2.0, 4.0]
-    tht_packoffset_vert  = [0, 0]
-    tht_packwidth_horiz  = [6.35, 6.35]
-    tht_packoffset_horiz = [1.27, 1.27]
-    tht_pin_width_horiz  = 0.5
-
-    smd_pin_width        = 0.5
-    smd_packwidth_vert   = [2.0, 4.0]
-    smd_overall_width    = [4.4, 6.0]
-    smd_packoffset_vert  = [0, 0]
-    smd_pads             = [[2.0, 0.9], [2.75, 1.0]]
-    smd_overall_lp_width = [5.2, 9.0] # land pattern width (8.04)
-    smd_pin_length       = getPinLength(smd_overall_width, smd_packwidth_vert)
-    smd_pad_offset       = getPadOffsets(smd_overall_lp_width, smd_pads)
-
-    for rows in [1, 2]:
-
-        tht_overlen_top    = rm / 2.0
-        tht_overlen_bottom = tht_overlen_top
-        smd_overlen_top    = tht_overlen_top
-        smd_overlen_bottom = tht_overlen_top
-
-        for cols in range(1, 41):
-            makePinHeadStraight(cols, rows, rm, rm, tht_packwidth_vert[rows-1] + tht_packoffset_vert[rows-1],
-                                tht_overlen_top, tht_overlen_top, ddrill, tht_pad, [],
-                                "Conn_PinSocket_2.00mm", "PinSocket", "socket strip", isSocket=True)
-            makeSocketStripAngled(cols, rows, rm, rm, tht_packwidth_horiz[rows-1], tht_packoffset_horiz[rows-1],
-                              tht_pin_width_horiz, ddrill, tht_pad, [],
-                              "Conn_PinSocket_2.00mm", "PinSocket", "socket strip")
-            if rows == 2:
-                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
-                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
-                                       smd_overlen_top, tht_overlen_top, smd_pads[rows-1], False, [],
-                                       "Conn_PinSocket_2.00mm", "PinSocket", "socket strip", isSocket=True)
-            elif cols > 1:
-                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
-                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
-                                       rm / 2.0 + tht_packoffset_vert[rows-1], rm / 2.0 + tht_packoffset_vert[rows-1], smd_pads[rows-1], True, [],
-                                       "Conn_PinSocket_2.00mm", "PinSocket", "socket strip", isSocket=True)
-                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
-                                       smd_packwidth_vert[rows-1] + tht_packoffset_vert[rows-1], smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], False, [],
-                                      "Conn_PinSocket_2.00mm", "PinSocket", "socket strip", isSocket=True)
-
-    ######################
-    # 1.27mm pin sockets #
-    ######################
-
-    # THT 1 row vertical:
-    # KiCad legacy : bw: 2.00;            pad: 1.00; drl: 0.7
-    # InterContact : bw: 2.20; blo: NA;              drl: 0.6; pl: 2.45; bh: 4.1
-
-    # THT 2 cols vertical:
-    # KiCad legacy : bw: 3.05;            pad: 1.00; drl: 0.7
-    # Amphenol FCi : bw: 3.00; blo: 0.46;            drl: 0.65; psz: 0.2, 0.4; pl: 2.4±0.3; bh: 4.4
-    # InterContact : bw: 3.05;                       drl: 0.60;                pl: 2.45;    bh: 4.1,
-
-    # THT 1 row horizontal:
-    # InterContact : bw: 4.1, po: 1.2; drl: 0.60; pl: 3.00; bh: 2.2
-
-    # THT 2 cols horizontal:
-    # InterContact : bw: 4.1, po: 1.2;  drl: 0.60;                  pl: 3.00; bh: 3.05
-    # GCT BD091    : bw: 4.4, po: 0.07; drl: 0.65; psz: 0.42, 0.15; pl: 2.00; bh: 3.10
-
-    # SMD 1 row LR:
-    # GCT BD074         : bw: 1.8; ow: 3.6; blo: 0.35; pad: 2.30, 0.70; lpo: 4.6; psz: 0.42, 0.15; bh: 2.2
-    # GCT BD075         : bw: 1.8; ow: 3.6; blo: 0.35; pad: 1.80, 0.65; lpo: 3.5; psz: 0.42, 0.15; bh: 4.6
-
-    # SMD 2 cols vertical:
-    # KiCad legacy : bw: 2.54; ow: 5.11;                pad: 2.10, 0.75;      lpo: 5.7; psz: 0.40
-    # Amphenol FCi : bw: 3.00; ow: 4.50±0.5; blo: 1.73; pad: 2.05, 0.76±0.05; lpo: 5.6; psz: 0.40, NA;   bh: 4.4
-    # GCT BD064    : bw: 3.10; ow: 4.80±0.3; blo: 1.73; pad: 2.15, 0.65;      lpo: 5.8; psz: 0.42, 0.15; bh: 4.6
-    
-    # SMD 1 cols vertical:
-    # GCT BD075    : bw: 1.80; ow: 3.50;     blo: 0.81; pad: 1.80, 0.65;      lpo: 4.5; psz: 0.42, 0.15; bh: 4.6
-
-    rm = 1.27
-    ddrill = 0.7
-
-    tht_pad             = [1.0, 1.0]
-    tht_packwidth_vert  = [2.54, 3.05]
-    tht_packoffset_vert = [0.0, 0.0]
-
-    smd_pin_width        = 0.4
-    smd_packwidth_vert   = [1.80, 2.54]
-    smd_overall_width    = [3.5, 5.11]
-    smd_packoffset_vert  = [0.0, 0.0]
-    smd_pads             = [[1.8, 0.65], [2.1, 0.75]]
-    smd_overall_lp_width = [4.5, 5.7] # land pattern width
-    smd_pin_length       = getPinLength(smd_overall_width, smd_packwidth_vert)
-    smd_pad_offset       = getPadOffsets(smd_overall_lp_width, smd_pads)
-
-    for rows in [1, 2]:
-
-        tht_overlen_top    = rm / 2.0 # tht_packwidth_vert[rows-1] / 2.0 # + tht_packoffset_vert[rows-1]
-        tht_overlen_bottom = tht_overlen_top
-        smd_overlen_top    = tht_overlen_top
-        smd_overlen_bottom = tht_overlen_top
-
-        for cols in range(1, 41):
-            makePinHeadStraight(cols, rows, rm, rm, tht_packwidth_vert[rows-1],
-                                tht_overlen_top, tht_overlen_bottom, ddrill, tht_pad, [],
-                                "Conn_PinSocket_1.27mm", "PinSocket", "socket strip", isSocket=True)
-            if rows == 2:
-                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
-                                       smd_packwidth_vert[rows-1],
-                                       smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], False, [],
-                                       "Conn_PinSocket_1.27mm", "PinSocket", "socket strip", isSocket=True)
-            elif cols > 1:
-                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
-                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
-                                       rm / 2.0 + tht_packoffset_vert[rows-1], rm / 2.0 + tht_packoffset_vert[rows-1], smd_pads[rows-1], True, [],
-                                       "Conn_PinSocket_1.27mm", "PinSocket", "socket strip", isSocket=True)
-                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
-                                       smd_packwidth_vert[rows-1] + tht_packoffset_vert[rows-1], smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], False, [],
-                                       "Conn_PinSocket_1.27mm", "PinSocket", "socket strip", isSocket=True)
-
-    ######################
-    # 1.00mm pin sockets #
-    ######################
-
-    # THT 1 row vertical:
-    # GHC BC065    : bw: 1.50; blo: 0.75;              drl: 0.5; pl: 1.8; bh: 2.1
-
-    # THT 2 cols vertical:
-
-    # SMD 1 row LR:
-    # GCT BC070    : bw: 1.5; ow: 2.9; blo: 0.75; pad: 1.95, 0.50; lpo: 3.9; psz: 0.30, 0.10; bh: 2.25
-
-    # SMD 2 cols vertical:
-    # GCT BC085    : bw: 2.5; ow: 3.90±0.25; blo: 0.25; pad: 1.85, 0.50;      lpo: 4.9; psz: 0.30, 0.10; bh: 2.25
-
-    rm = 1.00
-    ddrill = 0.5
-
-    tht_pad             = [0.85, 0.85]
-    tht_packwidth_vert  = [1.50, 3.05]
-    tht_packoffset_vert = [0.75, 0.0]
-    tht_overlen         = 0.75
-    tht_pad_offset      = 0.29
-    
-    smd_pin_width        = 0.3
-    smd_packwidth_vert   = [1.50, 2.5]
-    smd_overall_width    = [2.9, 3.9]
-    smd_packoffset_vert  = [0.0, 0.0]
-    smd_overlen          = 0.75
-    smd_pads             = [[1.95, 0.50], [1.85, 0.50]]
-    smd_overall_lp_width = [3.9, 4.9] # land pattern width
-    smd_pin_length       = getPinLength(smd_overall_width, smd_packwidth_vert)
-    smd_pad_offset       = getPadOffsets(smd_overall_lp_width, smd_pads)
-
-    for rows in [1, 2]:
-
-        tht_overlen_top    = tht_overlen
-        tht_overlen_bottom = tht_overlen
-        smd_overlen_top    = smd_overlen
-        smd_overlen_bottom = smd_overlen
-
-        for cols in range(1, 41):
-            if rows == 2:
-                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
-                                       smd_packwidth_vert[rows-1],
-                                       smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], False, [],
-                                       "Conn_PinSocket_1.00mm", "PinSocket", "socket strip", isSocket=True)
-            elif cols > 1:
-                makePinHeadStraight(cols, rows, rm, rm, tht_packwidth_vert[rows-1],
-                                    tht_overlen_top, tht_overlen_bottom, ddrill, tht_pad, [],
-                                    "Conn_PinSocket_1.00mm", "PinSocket", "socket strip", isSocket=True, pad_offset=tht_pad_offset)
-                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
-                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
-                                       smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], True, [],
-                                       "Conn_PinSocket_1.00mm", "PinSocket", "socket strip", isSocket=True)
-                makePinHeadStraightSMD(cols, rows, rm, rm, smd_pad_offset[rows-1], smd_pin_length[rows-1], smd_pin_width,
-                                       smd_packwidth_vert[rows-1] + smd_packoffset_vert[rows-1],
-                                       smd_overlen_top, smd_overlen_bottom, smd_pads[rows-1], False, [],
-                                       "Conn_PinSocket_1.00mm", "PinSocket", "socket strip", isSocket=True)
+    print "\nFootprints made:", i
 
 ### EOF ###

--- a/scripts/Conn_PinSocket/parameters.yaml
+++ b/scripts/Conn_PinSocket/parameters.yaml
@@ -1,0 +1,571 @@
+#
+# Pin Sockets - footprint and 3D dimensions
+# NOTE for SMD parts: pins.length is overall length (tip to tip)
+#                     pads.lp_width is overall land pattern width
+# 2017-11-25
+#
+series: THT-1x1.00mm_Vertical
+body:
+    width: 1.5
+    height: 2.1
+    overlength: 0.5
+    offset: 0.0
+pins:
+    min: 2
+    max: 40
+    width: 0.3
+    thickness: 0.1
+    drill: 0.5
+    length: 1.8
+    offset: 0.29
+pads:
+    length: 0.85
+    width: 0.85
+    lp_width: 0
+datasheet: https://gct.co/files/drawings/bc065.pdf
+---
+series: THT-1x1.27mm_Vertical
+body:
+    width: 2.54
+    height: 4.4
+    overlength: 0.0
+    offset: 0.0
+pins:
+    min: 1
+    max: 40
+    width: 0.5
+    thickness: 0.2
+    drill: 0.7
+    length: 2.4
+    offset: 0.0
+pads:
+    length: 1.0
+    width: 1.0
+    lp_width: 0
+datasheet: from Kicad 4.0.7
+---
+series: THT-1x2.00mm_Vertical
+body:
+    width: 2.0
+    height: 5.6
+    overlength: 0.0
+    offset: 0.0
+pins:
+    min: 1
+    max: 40
+    width: 0.6
+    thickness: 0.2
+    drill: 0.8
+    length: 2.5
+    offset: 0.0
+pads:
+    length: 1.35
+    width: 1.35
+    lp_width: 0
+datasheet: from Kicad 4.0.7
+---
+series: THT-1x2.54mm_Vertical
+body:
+    width: 2.54
+    height: 7.0
+    overlength: 0.0
+    offset: 0.0
+pins:
+    min: 1
+    max: 40
+    width: 0.6
+    thickness: 0.2
+    drill: 1.0
+    length: 2.9
+    offset: 0.0
+pads:
+    length: 1.7
+    width: 1.7
+    lp_width: 0
+datasheet: from Kicad 4.0.7
+---
+series: THT-2x1.00mm_Vertical N/A
+body:
+    width: 1.5
+    height: 2.1
+    overlength: 0.75
+    offset: 0.0
+pins:
+    min: 1
+    max: 40
+    width: 0.3
+    thickness: 0.1
+    drill: 0.5
+    length: 1.8
+    offset: 0.29
+pads:
+    length: 0
+    width: 0
+    lp_width: 0
+datasheet:
+---
+series: THT-2x1.27mm_Vertical
+body:
+    width: 3.05
+    height: 4.4
+    overlength: 0.0
+    offset: 0.0
+pins:
+    min: 1
+    max: 40
+    width: 0.5
+    thickness: 0.2
+    drill: 0.7
+    length: 2.4
+    offset: 0.0
+pads:
+    length: 1.0
+    width: 1.0
+    lp_width: 0
+datasheet: from Kicad 4.0.7
+---
+series: THT-2x2.00mm_Vertical
+body:
+    width: 4.0
+    height: 5.6
+    overlength: 0.0
+    offset: 0.0
+pins:
+    min: 1
+    max: 40
+    width: 0.6
+    thickness: 0.2
+    drill: 0.8
+    length: 2.5
+    offset: 0.0
+pads:
+    length: 1.35
+    width: 1.35
+    lp_width: 0
+datasheet: from Kicad 4.0.7
+---
+series: THT-2x2.54mm_Vertical
+body:
+    width: 5.08
+    height: 7.0
+    overlength: 0.0
+    offset: 0.0
+pins:
+    min: 1
+    max: 40
+    width: 0.6
+    thickness: 0.2
+    drill: 1.0
+    length: 2.9
+    offset: 0.0
+pads:
+    length: 1.7
+    width: 1.7
+    lp_width: 0
+datasheet: from Kicad 4.0.7
+---
+#
+# Horizontal THT parts
+#
+series: THT-1x1.00mm_Horizontal N/A
+body:
+    width: 1.5
+    height: 2.1
+    overlength: 0.75
+    offset: 0.0
+pins:
+    min: 1
+    max: 40
+    width: 0.3
+    thickness: 0.1
+    drill: 0.5
+    length: 1.8
+    offset: 0.29
+pads:
+    length: 0
+    width: 0
+    lp_width: 0
+datasheet:
+---
+series: THT-1x1.27mm_Horizontal
+body:
+    width: 4.3
+    height: 1.8
+    overlength: 0.35
+    offset: 0.15
+pins:
+    min: 3
+    max: 40
+    width: 0.42
+    thickness: 0.15
+    drill: 0.65
+    length: 2.0
+    offset: 0.0
+pads:
+    length: 1.0
+    width: 1.0
+    lp_width: 0
+datasheet: https://gct.co/pdfjs/web/viewer.html?file=/Files/Drawings/BD090.pdf&t=1511593690632
+---
+series: THT-1x2.00mm_Horizontal
+body:
+    width: 6.35
+    height: 2.0
+    overlength: 0.0
+    offset: 1.27
+pins:
+    min: 1
+    max: 40
+    width: 0.6
+    thickness: 0.2
+    drill: 0.8
+    length: 2.5
+    offset: 0.2
+pads:
+    length: 1.35
+    width: 1.35
+    lp_width: 0
+datasheet: from Kicad 4.0.7
+---
+series: THT-1x2.54mm_Horizontal
+body:
+    width: 8.51
+    height: 2.54
+    overlength: 0.0
+    offset: 1.52
+pins:
+    min: 1
+    max: 40
+    width: 0.6
+    thickness: 0.2
+    drill: 1.0
+    length: 2.9
+    offset: 0.2
+pads:
+    length: 1.7
+    width: 1.7
+    lp_width: 0
+datasheet: from Kicad 4.0.7
+---
+series: THT-2x1.00mm_Horizontal N/A
+body:
+    width: 1.5
+    height: 2.1
+    overlength: 0.75
+    offset: 0.0
+pins:
+    min: 1
+    max: 40
+    width: 0.3
+    thickness: 0.1
+    drill: 0.5
+    length: 1.8
+    offset: 0.29
+pads:
+    length: 0
+    width: 0
+    lp_width: 0
+datasheet:
+---
+series: THT-2x1.27mm_Horizontal
+body:
+    width: 4.4
+    height: 3.10
+    overlength: 0.35
+    offset: 0.15
+pins:
+    min: 3
+    max: 50
+    width: 0.5
+    thickness: 0.15
+    drill: 0.65
+    length: 2.0
+    offset: 0.15
+pads:
+    length: 1.0
+    width: 1.0
+    lp_width: 0
+datasheet: https://gct.co/pdfjs/web/viewer.html?file=/Files/Drawings/BD091.pdf&t=1511594177220
+---
+series: THT-2x2.00mm_Horizontal
+body:
+    width: 6.35
+    height: 4.0
+    overlength: 0.0
+    offset: 1.27
+pins:
+    min: 1
+    max: 40
+    width: 0.6
+    thickness: 0.2
+    drill: 0.8
+    length: 2.5
+    offset: 0.2
+pads:
+    length: 1.35
+    width: 1.35
+    lp_width: 0
+datasheet: from Kicad 4.0.7
+---
+series: THT-2x2.54mm_Horizontal
+body:
+    width: 8.51
+    height: 5.08
+    overlength: 0.0
+    offset: 1.52
+pins:
+    min: 1
+    max: 40
+    width: 0.6
+    thickness: 0.2
+    drill: 1.0
+    length: 2.5
+    offset: 0.2
+pads:
+    length: 1.7
+    width: 1.7
+    lp_width: 0
+datasheet: from Kicad 4.0.7
+---
+#
+# SMD parts
+#
+series: SMD-1x1.00mm_Vertical_Right
+body:
+    width: 1.5
+    height: 2.25
+    overlength: 0.5
+    offset: 0.0
+pins:
+    min: 2
+    max: 40
+    width: 0.3
+    thickness: 0.1
+    drill: None
+    length: 2.9
+    offset: 0.0
+pads:
+    length: 1.95
+    width: 0.50
+    lp_width: 3.9
+datasheet: https://gct.co/files/drawings/bc070.pdf
+---
+series: SMD-1x1.00mm_Vertical_Left
+body:
+    width: 1.5
+    height: 2.25
+    overlength: 0.5
+    offset: 0.0
+pins:
+    min: 2
+    max: 40
+    width: 0.3
+    thickness: 0.1
+    drill: None
+    length: 2.9
+    offset: 0.0
+pads:
+    length: 1.95
+    width: 0.50
+    lp_width: 3.9
+datasheet: https://gct.co/files/drawings/bc070.pdf
+---
+series: SMD-1x1.27mm_Vertical_Right
+body:
+    width: 1.8
+    height: 4.6
+    overlength: 0.35
+    offset: 0.0
+pins:
+    min: 2
+    max: 40
+    width: 0.42
+    thickness: 0.15
+    drill: None
+    length: 3.5
+    offset: 0.0
+pads:
+    length: 1.8
+    width: 0.65
+    lp_width: 4.5
+datasheet: https://gct.co/pdfjs/web/viewer.html?file=/Files/Drawings/BD075.pdf&t=1511594726925
+---
+series: SMD-1x1.27mm_Vertical_Left
+body:
+    width: 1.8
+    height: 4.6
+    overlength: 0.35
+    offset: 0.0
+pins:
+    min: 2
+    max: 40
+    width: 0.42
+    thickness: 0.15
+    drill: None
+    length: 3.5
+    offset: 0.0
+pads:
+    length: 1.8
+    width: 0.65
+    lp_width: 4.5
+datasheet: https://gct.co/pdfjs/web/viewer.html?file=/Files/Drawings/BD075.pdf&t=1511594726925
+---
+series: SMD-1x2.00mm_Vertical_Right
+body:
+    width: 2.5
+    height: 4.3
+    overlength: 0.6
+    offset: 0.0
+pins:
+    min: 2
+    max: 40
+    width: 0.5
+    thickness: 0.2
+    drill: None
+    length: 4.2
+    offset: 0.0
+pads:
+    length: 2.0
+    width: 0.9
+    lp_width: 5.2
+datasheet: https://www.jayconsystems.com/fileuploader/download/download/?d=1&file=custom%2Fupload%2FFile-1375728122.pdf
+---
+series: SMD-1x2.00mm_Vertical_Left
+body:
+    width: 2.5
+    height: 4.3
+    overlength: 0.6
+    offset: 0.0
+pins:
+    min: 2
+    max: 40
+    width: 0.5
+    thickness: 0.2
+    drill: None
+    length: 4.2
+    offset: 0.0
+pads:
+    length: 2.0
+    width: 0.9
+    lp_width: 5.2
+datasheet: https://www.jayconsystems.com/fileuploader/download/download/?d=1&file=custom%2Fupload%2FFile-1375728122.pdf
+---
+series: SMD-1x2.54mm_Vertical_Right
+body:
+    width: 2.54
+    height: 7.1
+    overlength: 0.2
+    offset: 0.0
+pins:
+    min: 2
+    max: 40
+    width: 0.6
+    thickness: 0.2
+    drill: None
+    length: 4.54
+    offset: 0.0
+pads:
+    length: 1.9
+    width: 1.0
+    lp_width: 5.2
+datasheet: https://cdn.harwin.com/pdfs/M20-786.pdf
+---
+series: SMD-1x2.54mm_Vertical_Left
+body:
+    width: 2.54
+    height: 7.1
+    overlength: 0.2
+    offset: 0.0
+pins:
+    min: 2
+    max: 40
+    width: 0.6
+    thickness: 0.2
+    drill: None
+    length: 4.54
+    offset: 0.0
+pads:
+    length: 1.9
+    width: 1.0
+    lp_width: 5.2
+datasheet: https://cdn.harwin.com/pdfs/M20-786.pdf
+---
+series: SMD-2x1.00mm_Vertical
+body:
+    width: 2.5
+    height: 2.25
+    overlength: 0.5
+    offset: 0.0
+pins:
+    min: 2
+    max: 40
+    width: 0.3
+    thickness: 0.1
+    drill: None
+    length: 3.9
+    offset: 0.0
+pads:
+    length: 1.85
+    width: 0.50
+    lp_width: 4.9
+datasheet: https://gct.co/files/drawings/bc085.pdf
+---
+series: SMD-2x1.27mm_Vertical
+body:
+    width: 2.54
+    height: 4.6
+    overlength: 0.0
+    offset: 0.0
+pins:
+    min: 1
+    max: 40
+    width: 0.4
+    thickness: 0.15
+    drill: None
+    length: 5.11
+    offset: 0.0
+pads:
+    length: 2.1
+    width: 0.75
+    lp_width: 5.7
+datasheet: from Kicad 4.0.7!
+---
+series: SMD-2x2.00mm_Vertical
+body:
+    width: 4.0
+    height: 4.5
+    overlength: 0.0
+    offset: 0.0
+pins:
+    min: 1
+    max: 40
+    width: 0.5
+    thickness: 0.2
+    drill: None
+    length: 6.0
+    offset: 0.0
+pads:
+    length: 2.75
+    width: 1.0
+    lp_width: 9.0
+datasheet: from Kicad 4.0.7
+---
+series: SMD-2x2.54mm_Vertical
+body:
+    width: 5.08
+    height: 7.0
+    overlength: 0.0
+    offset: 0.0
+pins:
+    min: 1
+    max: 40
+    width: 0.64
+    thickness: 0.2
+    drill: None
+    length: 7.84
+    offset: 0.0
+pads:
+    length: 3.0
+    width: 1.0
+    lp_width: 8.04
+datasheet: from Kicad 4.0.7

--- a/scripts/Conn_PinSocket/socket_strips.py
+++ b/scripts/Conn_PinSocket/socket_strips.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python
+
+# KicadModTree is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# KicadModTree is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kicad-footprint-generator. If not, see < http://www.gnu.org/licenses/ >.
+#
+
+#
+# based on scripts/tools/footprint_scripts_pin_headers.py
+# refactored by Terje Io, <http://github.com/terjeio>
+#
+
+import sys
+import os
+
+sys.path.append(os.path.join(sys.path[0],"..","..")) # load kicad_mod path
+
+from KicadModTree import Footprint, Translation, Pad, Model, KicadFileHandler
+from canvas import Layer, PadLayer
+
+save_dir = "./"
+txt_descr = ["", ", single row", ", double rows", ", double rows", ", triple rows", ", quadruple rows"]
+txt_tag = ["", " single row", " double row", ", triple rows", " quadruple row"]
+
+def save_to(lib_name):
+    out_dir = "" if save_dir == "" or save_dir == None else save_dir + lib_name + ".pretty/"
+
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    return out_dir
+
+def make_me(series, rows, cols, rm):
+#    return series == 0 and rm == 1.27 and rows == 9
+#    return series == 2 and rm == 1.27 and (rows == 5 or rows == 8) # and cols == 1
+#    return series < 10 and (rows <= 3 or rows == 5 or rows == 8) #and cols == 1
+    return True
+
+def makePinHeadStraight(rows, cols, rm, coldist, package_width, overlen_top, overlen_bottom, ddrill, pad,
+                        tags_additional=[], lib_name=None, classname=None, classname_description=None, isSocket=False):
+
+    if not make_me(0, rows, cols, rm):
+        return
+
+    if lib_name == None or classname == None or classname_description == None:
+        return # raise error?
+
+    footprint_name = "{3}_{0}x{1:02}_P{2:03.2f}mm_Vertical".format(cols, rows, rm, classname)
+    description = "Through hole straight {3}, {0}x{1:02}, {2:03.2f}mm pitch".format(cols, rows, rm,classname_description)
+    tags = "Through hole {3} THT {0}x{1:02} {2:03.2f}mm".format(cols, rows, rm, classname_description)
+
+    tags += txt_tag[cols]
+    description += txt_descr[cols]
+
+    if len(tags_additional) > 0:
+        for t in tags_additional:
+            footprint_name = footprint_name + "_" + t
+            description = description + ", " + t
+            tags = tags + " " + t
+
+    print "###################"
+    print footprint_name, "in", lib_name
+
+    # init kicad footprint
+    kicad_mod = Footprint(footprint_name)
+    kicad_mod.setDescription(description)
+    kicad_mod.setTags(tags)
+
+    # anchor for THT-symbols at pin1
+    kicad_modg = Translation(-coldist if isSocket and cols > 1 else 0.0, 0.0)
+    kicad_mod.append(kicad_modg)
+
+    # create layer canvases
+    silk = Layer(kicad_modg, 'F.SilkS')
+    fab  = Layer(kicad_modg, 'F.Fab')
+    crt  = Layer(kicad_modg, 'F.CrtYd', offset=0.5) # offset 0.5 for connectors
+    pads = PadLayer(kicad_modg, pad, Pad.TYPE_THT, Pad.SHAPE_OVAL, shape_first=Pad.SHAPE_RECT, drill=ddrill)
+
+    rmh = rm / 2.0
+    c_dist = coldist * (cols - 1)
+
+    h_fab = (rows - 1) * rm + overlen_top + overlen_bottom
+    w_fab = package_width
+#    l_fab = (c_dist - w_fab) / 2.0
+    t_fab = -overlen_top
+
+    h_slk = h_fab + silk.offset * 2.0
+    w_slk = max(w_fab + silk.offset * 2.0, c_dist - pad[0] - silk.offset * 4.0)
+#    l_slk = (c_dist - w_slk) / 2.0
+    t_slk = -overlen_top - silk.offset
+
+    w_crt = max(package_width, c_dist + pad[0]) + crt.offset * 2.0
+    h_crt = max(h_fab, (rows - 1) * rm + pad[1]) + crt.offset * 2.0
+    t_crt = t_fab - crt.offset
+
+    c_ofs = 0.0 if cols == 1 else rmh
+
+    if cols == 1:
+        c_dist = coldist
+
+    # add text to silk layer
+    silk.goto(c_ofs, t_crt - silk.txt_offset)\
+        .text('reference', 'REF**')\
+        .setOrigin(-w_slk / 2.0 + c_ofs, t_slk)
+
+    bevel = Layer.getBevel(h_fab, w_fab)
+    fab.goto(c_ofs, h_crt + t_crt + fab.txt_offset)\
+       .text('value', footprint_name)\
+       .goto(c_ofs, h_fab / 2.0 + t_fab)\
+       .setTextDefaults(max_size=1.0)\
+       .setTextSize(0.6 * (h_fab if rows == 1 and cols <= 2 else w_fab))\
+       .text('user', '%R', rotation=0 if rows == 1 and cols <= 2 else 90)\
+       .setOrigin(-w_fab / 2.0 + c_ofs, t_fab)\
+       .rect(w_fab, h_fab, bevel=(0.0 if isSocket else bevel, bevel if isSocket else 0.0, 0.0, 0.0, 0.0), origin="topLeft")
+
+    # create SILKSCREEN-layer + pin1 marker
+
+    f = -1 if isSocket else 1
+    sofs = coldist + silk.offset
+
+    if cols == 1:
+        silk.jump(w_slk if isSocket else 0.0, -t_slk + rmh)
+        if rows == 1:
+            silk.right(f * w_slk)
+        else:
+            silk.rect(f * w_slk, h_slk - rmh + t_slk, origin="topLeft")
+    else:
+        if isSocket:
+            silk.right(w_slk, draw=False)
+        silk.right(f * w_slk / 2.0, draw=False)\
+            .right(f * w_slk / 2.0)\
+            .down(h_slk)\
+            .left(f * w_slk)\
+            .up(h_slk + t_slk - sofs / 2.0)\
+            .right(f * w_slk / 2.0)\
+            .up(-t_slk + sofs / 2.0)
+
+    # add pin1 marker
+    silk.goHome()\
+        .jump(w_slk if isSocket else 0.0, sofs / 2.0)\
+        .up(sofs / 2.0)\
+        .right(f * sofs / 2.0)
+
+    # add courtyard
+    crt.setOrigin(-w_crt / 2.0 + c_ofs, t_crt)\
+       .rect(w_crt, h_crt, origin="topLeft")
+
+    # create pads
+
+    y = 0.0
+    for r in range(1, rows + 1):
+        x = coldist if isSocket and cols > 1 else 0.0
+        for c in range(1, cols + 1):
+            pads.add(x, y)
+            x = x + (-coldist if isSocket and cols > 1 else coldist)
+        y += rm
+
+    # add model
+    kicad_modg.append(Model(filename="${KISYS3DMOD}/" + lib_name + ".3dshapes/" + footprint_name + ".wrl"))
+
+    # print render tree
+    # print(kicad_mod.getRenderTree())
+    # print(kicad_mod.getCompleteRenderTree())
+
+    # write file
+    file_handler = KicadFileHandler(kicad_mod)
+    file_handler.writeFile(save_to(lib_name) + footprint_name + '.kicad_mod')
+
+
+
+#
+#                                                          <-->pack_offset
+#                 <--------------pack_width--------------->
+#                                                             <-coldist>
+#                 +---------------------------------------+            ---+
+#                 |                                       |  OOO      OOO |          ^
+#                 |                                       |  OOO ==== OOO |  ^       pin_width
+#                 |                                       |  OOO      OOO    |       v
+#                 +---------------------------------------+                  rm
+#                 |                                       |  OOO      OOO    |
+#                 |                                       |  OOO ==== OOO    v
+#                 |                                       |  OOO      OOO
+#                 +---------------------------------------+
+#
+def makeSocketStripAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_width, ddrill, pad,
+                           tags_additional=[], lib_name=None, classname=None, classname_description=None):
+
+    if not make_me(1, rows, cols, rm):
+        return
+
+    if lib_name == None or classname == None or classname_description == None:
+        return # raise error?
+
+    footprint_name = "{3}_{0}x{1:02}_P{2:03.2f}mm_Horizontal".format(cols, rows, rm, classname)
+    description = "Through hole angled {4}, {0}x{1:02}, {2:03.2f}mm pitch, {3}mm socket length"\
+                   .format(cols, rows, rm, pack_width, classname_description)
+    tags = "Through hole angled {3} THT {0}x{1:02} {2:03.2f}mm".format(cols, rows, rm, classname_description)
+
+    tags += txt_tag[cols]
+    description += txt_descr[cols]
+
+    if len(tags_additional) > 0:
+        for t in tags_additional:
+            footprint_name = footprint_name + "_" + t
+            description = description + ", " + t
+            tags = tags + " " + t
+
+    print "###################"
+    print footprint_name, "in", lib_name
+
+    # init kicad footprint
+    kicad_mod = Footprint(footprint_name)
+    kicad_mod.setDescription(description)
+    kicad_mod.setTags(tags)
+
+    # anchor for SMD-symbols is in the center, for THT-sybols at pin1
+    kicad_modg = Translation(0, 0)
+    kicad_mod.append(kicad_modg)
+
+    # create layer canvases
+    silk = Layer(kicad_modg, 'F.SilkS')
+    fab  = Layer(kicad_modg, 'F.Fab')
+    crt  = Layer(kicad_modg, 'F.CrtYd', offset=0.5) # offset 0.5 for connectors
+    pads = PadLayer(kicad_modg, pad, Pad.TYPE_THT, Pad.SHAPE_OVAL, shape_first=Pad.SHAPE_RECT, drill=ddrill)
+
+    rmh = rm / 2.0
+    c_dist = coldist * (cols - 1)
+
+    h_fab = (rows - 1) * rm + rm
+    w_fab = -pack_width
+    l_fab = -(c_dist + pack_offset)
+    t_fab = -rmh
+
+    h_slk = h_fab + silk.offset * 2.0
+    w_slk = w_fab - silk.offset * 2.0
+    l_slk = l_fab + silk.offset
+    t_slk = t_fab - silk.offset
+
+    w_crt = -(rmh + c_dist + pack_offset + pack_width + crt.offset * 2.0)
+    h_crt = h_fab + crt.offset * 2.0
+    l_crt = rmh + crt.offset
+    t_crt = -rmh - crt.offset
+
+    # create silk layer and add text
+    silk.goto(l_crt + w_crt / 2.0, t_crt - silk.txt_offset)\
+        .text('reference', 'REF**')
+
+    # create FAB-layer
+    bevel = min(1.0, rm * 0.25 if rows == 1 else -t_fab - pin_width / 2.0)
+    fab.goto(l_fab + w_fab / 2.0, (h_fab - rm) / 2.0)\
+       .text('user', '%R', rotation=(90 if h_fab >= -w_fab else 0))\
+       .rect(-w_fab, h_fab, bevel=(0.0, bevel, 0.0, 0.0))\
+       .goto(l_crt + w_crt / 2.0, h_crt + t_crt + fab.txt_offset)\
+       .text('value', footprint_name)
+
+    # add pin markers
+    fab.goto(l_fab / 2.0, 0.0)
+    for r in range(1, rows + 1):
+        fab.rect(l_fab, pin_width, draw=(True, False, True, True))\
+           .down(rm, False)
+
+    # continue silk layer, set origin and fill pin1 rectangle
+    silk.setOrigin(l_fab + w_slk + silk.offset, t_slk)\
+        .jump(0.0, -t_slk - rmh)\
+        .fillrect(-w_slk, rm)\
+
+    #add pin markers and separation lines
+    pw = pin_width + silk.offset * 2.0
+    x1 = rm - pad[0] / 2.0 - silk.offset - silk.line_width - l_slk - rm * cols #silly code? offset & line width
+    xn = rm - pad[0] - (silk.offset + silk.line_width) * 2.0                   #silly code? offset & line width
+
+    for r in range(1, rows + 1):
+        silk.right(-w_slk, r != 1)\
+            .down((rm - pw) / 2.0, False)\
+            .right(x1)\
+            .down(pw, False)\
+            .left(x1)
+        for s in range(1, cols):
+            xo = rm * s + x1
+            silk.jump(xo, -pw)\
+                .left(xn)\
+                .down(pw, False)\
+                .right(xn)\
+                .left(xo, False)
+        silk.jump(w_slk, (rm - pw) / 2.0)
+
+    # add outline
+    silk.goHome()\
+        .rect(-w_slk, h_slk, origin='topLeft')
+
+    # pin1 marker
+    silk.goto(0.0, -rmh)\
+        .right(rmh)\
+        .down(rmh)
+
+    # create courtyard
+    crt.setOrigin(l_crt + w_crt / 2.0, t_crt + h_crt / 2.0)\
+       .rect(w_crt, h_crt)
+
+    # create pads
+
+    y = 0.0
+    for r in range(1, rows + 1):
+        x = 0.0
+        for c in range(1, cols + 1):
+            pads.add(x, y)
+            x -= coldist
+        y += rm
+
+    # add model
+    kicad_modg.append(Model(filename="${KISYS3DMOD}/" + lib_name + ".3dshapes/" + footprint_name + ".wrl"))
+
+    # print render tree
+    # print(kicad_mod.getRenderTree())
+    # print(kicad_mod.getCompleteRenderTree())
+
+    # write file
+    file_handler = KicadFileHandler(kicad_mod)
+    file_handler.writeFile(save_to(lib_name) + footprint_name + '.kicad_mod')
+
+
+
+def makePinHeadStraightSMD(rows, cols, rm, coldist, rmx_pad_offset, rmx_pin_length, pin_width, package_width, overlen_top, overlen_bottom, pad,
+                            start_left=True, tags_additional=[], lib_name=None, classname=None, classname_description=None, isSocket=False):
+
+    if not make_me(2, rows, cols, rm):
+        return
+
+    if lib_name == None or classname == None or classname_description == None:
+        return # raise error?
+
+    footprint_name = "{3}_{0}x{1:02}_P{2:03.2f}mm_Vertical_SMD".format(cols, rows, rm, classname)
+    description = "surface-mounted straight {3}, {0}x{1:02}, {2:03.2f}mm pitch".format(cols, rows, rm, classname_description)
+    tags = "Surface mounted {3} SMD {0}x{1:02} {2:03.2f}mm".format(cols, rows, rm, classname_description)
+
+    tags += txt_tag[cols]
+    description += txt_descr[cols]
+
+    if (cols == 1):
+        if start_left:
+            description += ", style 1 (pin 1 left)"
+            tags += " style1 pin1 left"
+            footprint_name += "_Pin1Left"
+        else:
+            description += ", style 2 (pin 1 right)"
+            tags += " style2 pin1 right"
+            footprint_name += "_Pin1Right"
+
+    if len(tags_additional) > 0:
+        for t in tags_additional:
+            footprint_name = footprint_name + "_" + t
+            description = description + ", " + t
+            tags = tags + " " + t
+
+    print "###################"
+    print footprint_name, "in", lib_name
+
+    # init kicad footprint
+    kicad_mod = Footprint(footprint_name)
+    kicad_mod.setDescription(description)
+    kicad_mod.setTags(tags)
+    kicad_mod.setAttribute('smd')
+
+    # anchor for SMD-symbols is in the center
+    kicad_modg = Translation(0.0, 0.0)
+    kicad_mod.append(kicad_modg)
+
+    rmh = rm / 2.0
+
+    # create layer canvases
+    silk = Layer(kicad_modg, 'F.SilkS')
+    fab  = Layer(kicad_modg, 'F.Fab')
+    crt  = Layer(kicad_modg, 'F.CrtYd', offset=0.5) # offset 0.5 for connectors
+    pads = PadLayer(kicad_modg, pad, Pad.TYPE_SMT, Pad.SHAPE_RECT, y_offset=(rows - 1) * -rmh)
+
+    c_dist = coldist * (cols - 1)
+
+    h_fab = (rows - 1) * rm + overlen_top + overlen_bottom
+    w_fab = package_width
+    t_fab = -overlen_top
+
+    h_slk = h_fab + silk.offset * 2.0
+    w_slk = max(w_fab + silk.offset * 2.0, c_dist - pad[0] - silk.offset * 4.0)
+    l_slk = (c_dist - w_slk) / 2.0
+    t_slk = -overlen_top - silk.offset
+
+    h_crt = max(h_fab, (rows - 1) * rm + pad[1]) + crt.offset * 2.0
+    w_crt = max(package_width, rmx_pad_offset * 2.0 + pad[0]) + crt.offset * 2.0
+
+    cleft = range(0, rows, 2) if start_left else range(1, rows, 2)
+    cright = range(1, rows, 2) if start_left else range(0, rows, 2)
+    even_pins = rows % 2.0 == 0.0
+
+    # add text to silk layer
+    silk.goto(0.0, -(h_crt / 2.0) - silk.txt_offset)\
+        .text('reference', 'REF**')\
+        .setOrigin(-w_slk / 2.0, -h_slk / 2.0)
+
+    # add text and outline to fab layer
+    bevel = min(1.0, rm * 0.25 if rows == 1 else (-t_fab - pin_width / 2.0))
+     
+    fab.down((h_crt) / 2.0 + fab.txt_offset, draw=False)\
+       .text('value', footprint_name)\
+       .goHome()\
+       .setTextDefaults(max_size=1.0)\
+       .setTextSize(0.6 * (h_fab if rows == 1 and cols <= 2 else w_fab))\
+       .text('user', '%R', rotation=(90 if h_fab >= w_fab else 0))\
+       .rect(w_fab, h_fab, bevel=(bevel if start_left else 0.0, 0.0 if start_left else bevel, 0.0, 0.0, 0.0))\
+       .setOrigin(-w_fab / 2.0, -h_fab / 2.0)
+
+    # add pin markers to fab layer
+    trl = w_fab + rmx_pin_length
+    if cols == 2:
+        fab.jump(-rmx_pin_length / 2.0, -t_fab)
+        for r in range(1, rows + 1):
+            fab.rect(rmx_pin_length, pin_width, draw=(True, False, True, True))\
+               .right(trl, draw=False)\
+               .rect(rmx_pin_length, pin_width, draw=(True, True, True, False))\
+               .left(trl, draw=False)\
+               .down(rm, draw=False)
+    elif start_left:
+        fab.jump(-rmx_pin_length / 2.0, -t_fab)
+        for c in cleft:
+            fab.rect(rmx_pin_length, pin_width, draw=(True, False, True, True))\
+               .jump(trl, rm)
+            if even_pins or c != cleft[-1]:
+                fab.rect(rmx_pin_length, pin_width, draw=(True, True, True, False))\
+                   .jump(-trl, rm)
+    else:
+        trl = -trl
+        fab.jump(w_fab + rmx_pin_length / 2.0, -t_fab)
+        for c in cright:
+            fab.rect(rmx_pin_length, pin_width, draw=(True, True, True, False))\
+               .jump(trl, rm)
+            if even_pins or c != cright[-1]:
+                fab.rect(rmx_pin_length, pin_width, draw=(True, False, True, True))\
+                   .jump(-trl, rm)
+
+    # continue with silkscreen
+    slk_offset_pad = silk.getPadOffsetV(pad)
+    p1len = silk.getPadOffsetH(pad, rmx_pad_offset) + (l_slk if cols == 1 else - rmh + l_slk )
+    tvl = -(t_slk + slk_offset_pad)
+    slk_offset_pad *= 2.0
+
+    # top, pin1 marker and bottom silk
+    silk.jump(-p1len, tvl)\
+        .right(p1len, draw=not start_left ^ isSocket)\
+        .up(tvl, draw=cols > 1 or start_left)\
+        .right(w_slk)\
+        .down(tvl, draw=cols > 1 or not start_left)\
+        .right(p1len, draw=start_left ^ isSocket)\
+        .jump(-p1len, h_slk - tvl * 2.0)\
+        .down(tvl, draw=cols > 1 or not start_left ^ even_pins)\
+        .left(w_slk)\
+        .up(tvl, draw=cols > 1 or start_left ^ even_pins)
+
+    silk.goHome()
+    pl = rm - slk_offset_pad
+    if cols == 2:
+        if slk_offset_pad < rm - silk.line_width * 2.0:
+            silk.down(-t_slk + (rm - pl) / 2.0, draw=False)
+            for c in range(0, rows - 1):
+                silk.down(pl)\
+                    .right(w_slk, draw=False)\
+                    .up(pl)\
+                    .jump(-w_slk, rm)
+    else:
+        pl += rm
+        sofs = (-t_slk * 2.0 - pl) / 2.0
+        silk.jump(0.0, tvl + slk_offset_pad if start_left else 0.0)
+        if rows < 3:
+            silk.down(pl + sofs)\
+                .goHome()\
+                .jump(w_slk, 0.0 if start_left else tvl + slk_offset_pad)\
+                .down(pl + sofs)
+        else:
+            sl = []
+            if not start_left:
+                sl.append(cright[0])
+            if not start_left ^ even_pins:
+                sl.append(cright[-1])
+            for c in cright:
+                silk.down(pl + sofs if c in sl else pl)\
+                    .down(slk_offset_pad, draw=False)
+
+            silk.goHome()\
+                .jump(w_slk, 0.0 if start_left else tvl + slk_offset_pad)
+            sl = []
+            if start_left:
+                sl.append(cleft[0])
+            if start_left ^ even_pins:
+                sl.append(cleft[-1])
+            for c in cleft:
+                silk.down(pl + sofs if c in sl else pl)\
+                    .jump(0.0, slk_offset_pad)
+
+    # add courtyard
+    crt.rect(w_crt, h_crt)
+
+    # create pads
+    if cols == 1:
+        for y in cleft:
+            pads.add(-rmx_pad_offset, y * rm, number=y + 1)
+        for y in cright:
+            pads.add(rmx_pad_offset, y * rm, number=y + 1)
+    elif cols == 2:
+        f = 1.0 if isSocket else -1.0
+        for y in range(0,rows):
+            pads.add(f * rmx_pad_offset, y * rm)\
+                .add(f * -rmx_pad_offset, y * rm)
+
+    # add model
+    kicad_modg.append(Model(filename="${KISYS3DMOD}/" + lib_name + ".3dshapes/" + footprint_name + ".wrl"))
+
+    # print render tree
+    # print(kicad_mod.getRenderTree())
+    # print(kicad_mod.getCompleteRenderTree())
+
+    # write file
+    file_handler = KicadFileHandler(kicad_mod)
+    file_handler.writeFile(save_to(lib_name) + footprint_name + '.kicad_mod')

--- a/scripts/Conn_PinSocket/socket_strips.py
+++ b/scripts/Conn_PinSocket/socket_strips.py
@@ -1,483 +1,542 @@
 #!/usr/bin/env python
 
-# KicadModTree is free software: you can redistribute it and/or
+#
+# Parts script module for socket strip footprints for KicCad
+#
+# This script is built on top of the kicad-footprint-generator framework
+# by Thomas Pointhuber, https://github.com/pointhi/kicad-footprint-generator
+#
+# This module is free software: you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# KicadModTree is distributed in the hope that it will be useful,
+# This module is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
 # along with kicad-footprint-generator. If not, see < http://www.gnu.org/licenses/ >.
-#
 
 #
 # based on scripts/tools/footprint_scripts_pin_headers.py
-# refactored by Terje Io, <http://github.com/terjeio>
+# refactored by and (C) 2017 Terje Io, <http://github.com/terjeio>
 #
+
+# 2017-11-25
 
 import sys
 import os
 
-sys.path.append(os.path.join(sys.path[0],"..","..")) # load kicad_mod path
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../kicad-footprint-generator")
+sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../")
 
 from KicadModTree import Footprint, Translation, Pad, Model, KicadFileHandler
 from canvas import Layer, PadLayer, Keepout, OutDir
+from cq_base_parameters import PinStyle, CaseType
 
-txt_descr = ["", ", single row", ", double rows", ", double rows", ", triple rows", ", quadruple rows"]
-txt_tag = ["", " single row", " double row", ", triple rows", " quadruple row"]
+txt_descr = ["", ", single row", ", double cols", ", double cols", ", triple cols", ", quadruple cols"]
+txt_tag = ["", " single row", " double row", ", triple cols", " quadruple row"]
 
-root_dir = OutDir("./")   
+root_dir = OutDir("./")
 
 #Keepout.DEBUG = 1
 
-def make_me(series, rows, cols, rm):
-#    return rows <= 4 and rm == 1.00 and series == 0
-    return True
-#    return series == 2 and rm == 1.27 and (rows == 5 or rows == 8) # and cols == 1
-#    return series < 10 and (rows <= 3 or rows == 5 or rows == 8) #and cols == 1
+def getPadOffsets(overall_width, pad):
+    return round((overall_width - pad[0]) / 2.0, 3)
 
-def makePinHeadStraight(rows, cols, rm, coldist, package_width, overlen_top, overlen_bottom, ddrill, pad,
-                        tags_additional=[], lib_name=None, classname=None, classname_description=None,
-                        isSocket=False, pad_offset=0.0):
+def getPinLength(overall_width, packwidth):
+    return round((overall_width - packwidth) / 2.0, 3)
 
-    if not make_me(0, rows, cols, rm):
-        return
+class pinSocketVerticalTHT (object):
+    def __init__(self, params):
+        self.make_me = params.type == CaseType.THT and params.pin_style == PinStyle.STRAIGHT and params.pad_width > 0
+        self.params = params
 
-    if lib_name == None or classname == None or classname_description == None:
-        return # raise error?
+    def makeModelName(self, genericName):
+        return "PinSocket_{0}x{1:02}_P{2:03.2f}mm_Vertical".format(self.params.num_pin_rows, self.params.num_pins, self.params.pin_pitch)
 
-    footprint_name = "{3}_{0}x{1:02}_P{2:03.2f}mm_Vertical".format(cols, rows, rm, classname)
-    description = "Through hole straight {3}, {0}x{1:02}, {2:03.2f}mm pitch".format(cols, rows, rm,classname_description)
-    tags = "Through hole {3} THT {0}x{1:02} {2:03.2f}mm".format(cols, rows, rm, classname_description)
+    def make(self, tags_additional=[], isSocket=True):
 
-    tags += txt_tag[cols]
-    description += txt_descr[cols]
+        param = self.params
 
-    if len(tags_additional) > 0:
-        for t in tags_additional:
-            footprint_name = footprint_name + "_" + t
-            description = description + ", " + t
-            tags = tags + " " + t
+        lib_name ="Conn_PinSocket_{0:03.2f}mm".format(param.pin_pitch)
+        footprint_name = self.makeModelName("")
+        description = "Through hole straight socket strip, {0}x{1:02}, {2:03.2f}mm pitch".format(param.num_pin_rows, param.num_pins, param.pin_pitch)
+        tags = "Through hole socket strip THT {0}x{1:02} {2:03.2f}mm".format(param.num_pin_rows, param.num_pins, param.pin_pitch)
 
-    print "###################"
-    print footprint_name, "in", lib_name
+        tags += txt_tag[param.num_pin_rows]
+        description += txt_descr[param.num_pin_rows]
 
-    # init kicad footprint
-    kicad_mod = Footprint(footprint_name)
-    kicad_mod.setDescription(description)
-    kicad_mod.setTags(tags)
+        pad = [param.pad_length, param.pad_width]
+        rowdist = param.pin_pitch
 
-    # anchor for THT-symbols at pin1
-    kicad_modg = Translation(-coldist if isSocket and cols > 1 else -pad_offset, 0.0)
-    kicad_mod.append(kicad_modg)
+        if len(tags_additional) > 0:
+            for t in tags_additional:
+                footprint_name = footprint_name + "_" + t
+                description = description + ", " + t
+                tags = tags + " " + t
 
-    # create layer canvases
-    silk    = Layer(kicad_modg, 'F.SilkS')
-    fab     = Layer(kicad_modg, 'F.Fab')
-    crt     = Layer(kicad_modg, 'F.CrtYd', offset=0.5) # offset 0.5 for connectors
-    pads    = PadLayer(kicad_modg, pad, Pad.TYPE_THT, Pad.SHAPE_OVAL, shape_first=Pad.SHAPE_RECT, drill=ddrill, x_offset=pad_offset)
-    keepout = Keepout(silk)
+        if len(param.datasheet) > 0:
+            description += " (" + param.datasheet + ")"
 
-    rmh = rm / 2.0
-    c_dist = coldist * (cols - 1)
+        description += ", script generated"
 
-    h_fab = (rows - 1) * rm + overlen_top + overlen_bottom
-    w_fab = package_width
-    t_fab = -overlen_top
+        print "###################"
+        print footprint_name, "in", lib_name
 
-    h_slk = h_fab + silk.offset * 2.0
-    w_slk = max(w_fab + silk.offset * 2.0, c_dist - pad[0] - silk.offset * 4.0)
-    t_slk = -overlen_top - silk.offset
+        # init kicad footprint
+        kicad_mod = Footprint(footprint_name)
+        kicad_mod.setDescription(description)
+        kicad_mod.setTags(tags)
 
-    w_crt = max(package_width, c_dist + pad[0]) + crt.offset * 2.0
-    h_crt = max(h_fab, (rows - 1) * rm + pad[1]) + crt.offset * 2.0
-    t_crt = t_fab - crt.offset
-
-    c_ofs = 0.0 if cols == 1 else rmh
-
-    if cols == 1:
-        c_dist = coldist
-
-    # create pads
-
-    y = 0.0
-    for r in range(1, rows + 1):
-        x = coldist if isSocket and cols > 1 else 0.0
-        for c in range(1, cols + 1):
-            pads.add(x, y)
-            x = x + (-coldist if isSocket and cols > 1 else coldist)
-        y += rm
-
-    # add pads to silk keepout
-    keepout.addPads()
-    keepout.debug_draw()
-    
-
-    # add text to silk layer
-    silk.goto(c_ofs, t_crt - silk.txt_offset)\
-        .text('reference', 'REF**')\
-        .setOrigin(-w_slk / 2.0 + c_ofs, t_slk)
-
-    # add fab layer
-    bevel = Layer.getBevel(h_fab, w_fab)
-    fab.goto(c_ofs, h_crt + t_crt + fab.txt_offset)\
-       .text('value', footprint_name)\
-       .goto(c_ofs, h_fab / 2.0 + t_fab)\
-       .setTextDefaults(max_size=1.0)\
-       .setTextSize(0.6 * (h_fab if rows == 1 and cols <= 2 else w_fab))\
-       .text('user', '%R', rotation=0 if rows == 1 and cols <= 2 else 90)\
-       .setOrigin(-w_fab / 2.0 + c_ofs, t_fab)\
-       .rect(w_fab, h_fab, bevel=(0.0 if isSocket else bevel, bevel if isSocket else 0.0, 0.0, 0.0), origin="topLeft")
-
-    # continue with silkscreen
-
-    pin1 = keepout.getPadBB(1)
-
-    if isSocket and pad_offset > 0.0: # for 1.00 mm sockets
-        w_slk = w_slk / 2.0 + (pin1.width / 2.0 + pin1.x)
-        
-    f = -1 if isSocket else 1
-
-    if cols == 1:
-        silk.jump(w_slk if isSocket else 0.0, -t_slk + rmh)
-        if rows == 1:
-            silk.right(f * w_slk)
+        if Keepout.DEBUG:
+            kicad_modg = Translation(0.0, 0.0)
         else:
-            silk.rect(f * w_slk, h_slk - rmh + t_slk, origin="topLeft")
-    else:
-        if isSocket:
-            silk.right(w_slk, draw=False)
-        silk.right(f * w_slk / 2.0, draw=False)\
-            .right(f * w_slk / 2.0)\
-            .down(h_slk)\
-            .left(f * w_slk)\
-            .up(h_slk + t_slk - coldist / 2.0)\
-            .right(f * w_slk / 2.0)\
-            .up(-t_slk + coldist / 2.0)
+            kicad_modg = Translation(-rowdist if isSocket and param.num_pin_rows > 1 else -param.pins_offset, 0.0)
+        kicad_mod.append(kicad_modg)
 
-    silk.goHome()
-    
-    # add pin1 marker
+        # create layer canvases
+        silk    = Layer(kicad_modg, 'F.SilkS')
+        fab     = Layer(kicad_modg, 'F.Fab')
+        crt     = Layer(kicad_modg, 'F.CrtYd', offset=0.5) # offset 0.5 for connectors
+        pads    = PadLayer(kicad_modg, pad, Pad.TYPE_THT, Pad.SHAPE_OVAL, shape_first=Pad.SHAPE_RECT, drill=param.pin_drill, x_offset=param.pins_offset)
+        keepout = Keepout(silk)
 
-    silk.goHome()\
-        .jump(w_slk if isSocket else 0.0, -t_slk)\
-        .up(max(-t_slk, pin1.y + pin1.height / 2.0))\
-        .right(f * (coldist / 2.0 + silk.offset))
+        if Keepout.DEBUG:
+            kicad_mod.setSolderMaskMargin(silk.getSoldermaskMargin())
 
-    # add courtyard
-    crt.setOrigin(-w_crt / 2.0 + c_ofs, t_crt)\
-       .rect(w_crt, h_crt, origin="topLeft")
- 
-    # add model
-    kicad_modg.append(Model(filename="${KISYS3DMOD}/" + lib_name + ".3dshapes/" + footprint_name + ".wrl"))
+        rmh = param.pin_pitch / 2.0
+        r_dist = rowdist * (param.num_pin_rows - 1)
 
-    # write file
-    file_handler = KicadFileHandler(kicad_mod)
-    file_handler.writeFile(root_dir.saveTo(lib_name) + footprint_name + '.kicad_mod')
+        h_fab = param.num_pins * param.pin_pitch + param.body_overlength
+        w_fab = param.body_width
+        t_fab = -rmh - param.body_overlength / 2.0
+
+        h_slk = h_fab + silk.offset * 2.0
+        w_slk = max(w_fab + silk.offset * 2.0, r_dist - pad[0] - silk.offset * 4.0)
+        t_slk = t_fab - silk.offset
+
+        w_crt = max(param.body_width, r_dist + pad[0]) + crt.offset * 2.0
+        h_crt = max(h_fab, (param.num_pins - 1) * param.pin_pitch + pad[1]) + crt.offset * 2.0
+        t_crt = t_fab - crt.offset
+
+        c_ofs = 0.0 if param.num_pin_rows == 1 else rmh
+
+        if param.num_pin_rows == 1:
+            r_dist = rowdist
+
+        # create pads
+
+        y = 0.0
+        for r in range(1, param.num_pins + 1):
+            x = rowdist if isSocket and param.num_pin_rows > 1 else 0.0
+            for c in range(1, param.num_pin_rows + 1):
+                pads.add(x, y)
+                x = x + (-rowdist if isSocket and param.num_pin_rows > 1 else rowdist)
+            y += param.pin_pitch
+
+        # add pads to silk keepout
+        keepout.addPads()
+        keepout.debug_draw()
+
+        # add text to silk layer
+        silk.goto(c_ofs, t_crt - silk.txt_offset)\
+            .text('reference', 'REF**')\
+            .setOrigin(-w_slk / 2.0 + c_ofs, t_slk)
+
+        # add fab layer
+        bevel = Layer.getBevel(h_fab, w_fab)
+        fab.goto(c_ofs, h_crt + t_crt + fab.txt_offset)\
+           .text('value', footprint_name)\
+           .goto(c_ofs, h_fab / 2.0 + t_fab)\
+           .setTextDefaults(max_size=1.0)\
+           .setTextSize(0.6 * (h_fab if param.num_pins == 1 and param.num_pin_rows <= 2 else w_fab))\
+           .text('user', '%R', rotation=0 if param.num_pins == 1 and param.num_pin_rows <= 2 else 90)\
+           .setOrigin(-w_fab / 2.0 + c_ofs, t_fab)\
+           .rect(w_fab, h_fab, bevel=(0.0 if isSocket else bevel, bevel if isSocket else 0.0, 0.0, 0.0), origin="topLeft")
+
+        # continue with silkscreen
+
+        pin1 = keepout.getPadBB(1)
+
+    #    if isSocket and param.pins_offset > 0.0: # for 1.00 mm sockets
+    #        w_slk = w_slk / 2.0 + (pin1.width / 2.0 + pin1.x)
+
+        f = -1 if isSocket else 1
+
+        if param.num_pin_rows == 1:
+            silk.jump(w_slk if isSocket else 0.0, -t_slk + rmh)
+            if param.num_pins == 1:
+                silk.down(silk.offset, draw=False)\
+                    .right(f * w_slk)\
+                    .up(silk.line_width)\
+                    .jump(-f * w_slk, silk.line_width)\
+                    .up(silk.line_width)
+            else:
+                silk.rect(f * w_slk, h_slk - rmh + t_slk, origin="topLeft")
+        else:
+            if isSocket:
+                silk.right(w_slk, draw=False)
+            silk.right(f * w_slk / 2.0, draw=False)\
+                .right(f * w_slk / 2.0)\
+                .down(h_slk)\
+                .left(f * w_slk)\
+                .up(h_slk + t_slk - rowdist / 2.0)\
+                .right(f * w_slk / 2.0)\
+                .up(-t_slk + rowdist / 2.0)
+
+        # add pin1 marker
+        silk.goto(max(pin1.x - f * pin1.width / 2.0, w_slk / 2.0 + c_ofs), pin1.y)\
+            .up(max(-t_slk, pin1.height / 2.0))\
+            .right(f * (silk.x - pin1.x))
+
+        # add courtyard
+        crt.setOrigin(-w_crt / 2.0 + c_ofs, t_crt)\
+           .rect(w_crt, h_crt, origin="topLeft")
+
+        # add model
+        kicad_modg.append(Model(filename="${KISYS3DMOD}/" + lib_name + ".3dshapes/" + footprint_name + ".wrl"))
+
+        # write file
+        file_handler = KicadFileHandler(kicad_mod)
+        file_handler.writeFile(root_dir.saveTo(lib_name) + footprint_name + '.kicad_mod')
 
 
 
 #
 #                                                          <-->pack_offset
 #                 <--------------pack_width--------------->
-#                                                             <-coldist>
+#                                                             <-rowdist>
 #                 +---------------------------------------+            ---+
 #                 |                                       |  OOO      OOO |          ^
 #                 |                                       |  OOO ==== OOO |  ^       pin_width
 #                 |                                       |  OOO      OOO    |       v
-#                 +---------------------------------------+                  rm
+#                 +---------------------------------------+                  pin_pitch
 #                 |                                       |  OOO      OOO    |
 #                 |                                       |  OOO ==== OOO    v
 #                 |                                       |  OOO      OOO
 #                 +---------------------------------------+
 #
-def makeSocketStripAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_width, ddrill, pad,
-                           tags_additional=[], lib_name=None, classname=None, classname_description=None):
+class pinSocketHorizontalTHT (object):
+    def __init__(self, params):
+        self.make_me =  params.type == CaseType.THT and params.pin_style == PinStyle.ANGLED and params.pad_width > 0
+        self.params = params
 
-    if not make_me(1, rows, cols, rm):
-        return
+    def makeModelName(self, genericName):
+        return "PinSocket_{0}x{1:02}_P{2:03.2f}mm_Horizontal".format(self.params.num_pin_rows, self.params.num_pins, self.params.pin_pitch)
 
-    if lib_name == None or classname == None or classname_description == None:
-        return # raise error?
+    def make(self, tags_additional=[], isSocket=True):
 
-    footprint_name = "{3}_{0}x{1:02}_P{2:03.2f}mm_Horizontal".format(cols, rows, rm, classname)
-    description = "Through hole angled {4}, {0}x{1:02}, {2:03.2f}mm pitch, {3}mm socket length"\
-                   .format(cols, rows, rm, pack_width, classname_description)
-    tags = "Through hole angled {3} THT {0}x{1:02} {2:03.2f}mm".format(cols, rows, rm, classname_description)
+        param = self.params
 
-    tags += txt_tag[cols]
-    description += txt_descr[cols]
+        lib_name ="Conn_PinSocket_{0:03.2f}mm".format(param.pin_pitch)
+        footprint_name = self.makeModelName("")
+        description = "Through hole angled socket strip, {0}x{1:02}, {2:03.2f}mm pitch, {3}mm socket length"\
+                       .format(param.num_pin_rows, param.num_pins, param.pin_pitch, param.body_width)
+        tags = "Through hole angled socket strip THT {0}x{1:02} {2:03.2f}mm".format(param.num_pin_rows, param.num_pins, param.pin_pitch)
 
-    if len(tags_additional) > 0:
-        for t in tags_additional:
-            footprint_name = footprint_name + "_" + t
-            description = description + ", " + t
-            tags = tags + " " + t
+        tags += txt_tag[param.num_pin_rows]
+        description += txt_descr[param.num_pin_rows]
 
-    print "###################"
-    print footprint_name, "in", lib_name
+        pad = [param.pad_length, param.pad_width]
+        rowdist = param.pin_pitch
 
-    # init kicad footprint
-    kicad_mod = Footprint(footprint_name)
-    kicad_mod.setDescription(description)
-    kicad_mod.setTags(tags)
+        if len(tags_additional) > 0:
+            for t in tags_additional:
+                footprint_name = footprint_name + "_" + t
+                description = description + ", " + t
+                tags = tags + " " + t
 
-    # anchor for SMD-symbols is in the center, for THT-sybols at pin1
-    kicad_modg = Translation(0, 0)
-    kicad_mod.append(kicad_modg)
+        if len(param.datasheet) > 0:
+            description += " (" + param.datasheet + ")"
 
-    # create layer canvases
-    silk    = Layer(kicad_modg, 'F.SilkS')
-    fab     = Layer(kicad_modg, 'F.Fab')
-    crt     = Layer(kicad_modg, 'F.CrtYd', offset=0.5) # offset 0.5 for connectors
-    pads    = PadLayer(kicad_modg, pad, Pad.TYPE_THT, Pad.SHAPE_OVAL, shape_first=Pad.SHAPE_RECT, drill=ddrill)
-    keepout = Keepout(silk)
+        description += ", script generated"
 
-    rmh = rm / 2.0
-    c_dist = coldist * (cols - 1)
+        print "###################"
+        print footprint_name, "in", lib_name
 
-    h_fab = (rows - 1) * rm + rm
-    w_fab = -pack_width
-    l_fab = -(c_dist + pack_offset)
-    t_fab = -rmh
+        # init kicad footprint
+        kicad_mod = Footprint(footprint_name)
+        kicad_mod.setDescription(description)
+        kicad_mod.setTags(tags)
 
-    h_slk = h_fab + silk.offset * 2.0
-    w_slk = w_fab - silk.offset * 2.0
-    l_slk = l_fab + silk.offset
-    t_slk = t_fab - silk.offset
+        # anchor for SMD-symbols is in the center, for THT-sybols at pin1
+        kicad_modg = Translation(0, 0)
+        kicad_mod.append(kicad_modg)
 
-    w_crt = -(rmh + c_dist + pack_offset + pack_width + crt.offset * 2.0)
-    h_crt = h_fab + crt.offset * 2.0
-    l_crt = rmh + crt.offset
-    t_crt = -rmh - crt.offset
+        # create layer canvases
+        silk    = Layer(kicad_modg, 'F.SilkS')
+        fab     = Layer(kicad_modg, 'F.Fab')
+        crt     = Layer(kicad_modg, 'F.CrtYd', offset=0.5) # offset 0.5 for connectors
+        pads    = PadLayer(kicad_modg, pad, Pad.TYPE_THT, Pad.SHAPE_OVAL, shape_first=Pad.SHAPE_RECT, drill=param.pin_drill)
+        keepout = Keepout(silk)
 
-    # create pads
-    y = 0.0
-    for r in range(1, rows + 1):
-        x = 0.0
-        for c in range(1, cols + 1):
-            pads.add(x, y)
-            x -= coldist
-        y += rm
+        if Keepout.DEBUG:
+            kicad_mod.setSolderMaskMargin(silk.getSoldermaskMargin())
 
-    # add pads to silk keepout
-    keepout.addPads()
-    keepout.debug_draw()
+        rmh = param.pin_pitch / 2.0
+        r_dist = rowdist * (param.num_pin_rows - 1)
 
-    # add text to silk
-    silk.goto(l_crt + w_crt / 2.0, t_crt - silk.txt_offset)\
-        .text('reference', 'REF**')
+        h_fab = (param.num_pins - 1) * param.pin_pitch + param.pin_pitch
+        w_fab = -param.body_width
+        l_fab = -(r_dist + param.body_offset)
+        t_fab = -rmh
 
-    # create FAB-layer
-#    bevel = min(1.0, rm * 0.25 if rows == 1 else -t_fab - pin_width / 2.0)
-    bevel = min(Layer.getBevel(h_fab, abs(w_fab)), -t_fab - pin_width / 2.0)
+        h_slk = h_fab + silk.offset * 2.0
+        w_slk = w_fab - silk.offset * 2.0
+        l_slk = l_fab + silk.offset
+        t_slk = t_fab - silk.offset
 
-    fab.goto(l_fab + w_fab / 2.0, (h_fab - rm) / 2.0)\
-       .text('user', '%R', rotation=(90 if h_fab >= -w_fab else 0))\
-       .rect(-w_fab, h_fab, bevel=(0.0, bevel, 0.0, 0.0))\
-       .goto(l_crt + w_crt / 2.0, h_crt + t_crt + fab.txt_offset)\
-       .text('value', footprint_name)
+        w_crt = -(rmh + r_dist + param.body_offset + param.body_width + crt.offset * 2.0)
+        h_crt = h_fab + crt.offset * 2.0
+        l_crt = rmh + crt.offset
+        t_crt = -rmh - crt.offset
 
-    # add pin markers
-    fab.goto(l_fab / 2.0, 0.0)
-    for r in range(1, rows + 1):
-        fab.rect(l_fab, pin_width, draw=(True, False, True, True))\
-           .down(rm, False)
+        # create pads
+        y = 0.0
+        for r in range(1, param.num_pins + 1):
+            x = 0.0
+            for c in range(1, param.num_pin_rows + 1):
+                pads.add(x, y)
+                x -= rowdist
+            y += param.pin_pitch
 
-    # continue silk layer, set origin and fill pin1 rectangle
-    silk.setOrigin(l_fab + w_slk + silk.offset, t_slk)\
-        .jump(0.0, -t_slk - rmh)\
-        .fillrect(-w_slk, rm)\
+        # add pads to silk keepout
+        keepout.addPads()
+        keepout.debug_draw()
 
-    pw = pin_width + silk.offset * 2.0
+        # add text to silk
+        silk.goto(l_crt + w_crt / 2.0, t_crt - silk.txt_offset)\
+            .text('reference', 'REF**')
 
-    # add pin markers
-    silk.goto(l_slk / 2.0, 0.0)
-    for r in range(1, rows + 1):
-        silk.rect(l_slk, pw, draw=(True, False, True, False))\
-           .down(rm, False)
+        # create FAB-layer
+        bevel = min(Layer.getBevel(h_fab, abs(w_fab)), -t_fab - param.pin_width / 2.0)
 
-    #add separation lines
-    silk.goHome()\
-        .jump(0.0, silk.line_width / 2.0)
-    for r in range(1, rows + 1):
-        silk.right(-w_slk, r != 1)\
-            .jump(w_slk, rm)
+        fab.goto(l_fab + w_fab / 2.0, (h_fab - param.pin_pitch) / 2.0)\
+           .text('user', '%R', rotation=(90 if h_fab >= -w_fab else 0))\
+           .rect(-w_fab, h_fab, bevel=(0.0, bevel, 0.0, 0.0))\
+           .goto(l_crt + w_crt / 2.0, h_crt + t_crt + fab.txt_offset)\
+           .text('value', footprint_name)
 
-    # add outline
-    silk.goHome()\
-        .rect(-w_slk, h_slk, origin='topLeft')
+        # add pin markers
+        fab.goto(l_fab / 2.0, 0.0)
+        for r in range(1, param.num_pins + 1):
+            fab.rect(l_fab, param.pin_width, draw=(True, False, True, True))\
+               .down(param.pin_pitch, False)
 
-    # add pin1 marker
-    silk.goto(0.0, -rmh)\
-        .right(rmh)\
-        .down(rmh)
+        # continue silk layer, set origin and fill pin1 rectangle
+        silk.setOrigin(l_fab + w_slk + silk.offset, t_slk)\
+            .jump(0.0, -t_slk - rmh)\
+            .fillrect(-w_slk, param.pin_pitch + silk.offset + (silk.offset if param.num_pins == 1 else 0.0))\
 
-    # create courtyard
-    crt.setOrigin(l_crt + w_crt / 2.0, t_crt + h_crt / 2.0)\
-       .rect(w_crt, h_crt)
+        pw = param.pin_width + silk.offset * 2.0
 
-    # add model
-    kicad_modg.append(Model(filename="${KISYS3DMOD}/" + lib_name + ".3dshapes/" + footprint_name + ".wrl"))
+        # add pin markers
+        silk.goto(l_slk / 2.0, 0.0)
+        for r in range(1, param.num_pins + 1):
+            silk.rect(l_slk, pw, draw=(True, False, True, False))\
+               .down(param.pin_pitch, False)
 
-    # write file
-    file_handler = KicadFileHandler(kicad_mod)
-    file_handler.writeFile(root_dir.saveTo(lib_name) + footprint_name + '.kicad_mod')
+        #add separation lines
+        silk.goHome()\
+            .jump(0.0, silk.line_width / 2.0)
+        for r in range(1, param.num_pins + 1):
+            silk.right(-w_slk, r != 1)\
+                .jump(w_slk, param.pin_pitch)
+
+        # add outline
+        silk.goHome()\
+            .rect(-w_slk, h_slk, origin='topLeft')
+
+        pin1 = keepout.getPadBB(1)
+
+        # add pin1 marker
+        silk.goto(pin1.x + pin1.width / 2.0, pin1.y)\
+            .up(max(-t_slk, pin1.height / 2.0))\
+            .left(silk.x - pin1.x)
+
+        # create courtyard
+        crt.setOrigin(l_crt + w_crt / 2.0, t_crt + h_crt / 2.0)\
+           .rect(w_crt, h_crt)
+
+        # add model
+        kicad_modg.append(Model(filename="${KISYS3DMOD}/" + lib_name + ".3dshapes/" + footprint_name + ".wrl"))
+
+        # write file
+        file_handler = KicadFileHandler(kicad_mod)
+        file_handler.writeFile(root_dir.saveTo(lib_name) + footprint_name + '.kicad_mod')
 
 
 
-def makePinHeadStraightSMD(rows, cols, rm, coldist, rmx_pad_offset, rmx_pin_length, pin_width, package_width, overlen_top, overlen_bottom, pad,
-                            start_left=True, tags_additional=[], lib_name=None, classname=None, classname_description=None, isSocket=False):
+class pinSocketVerticalSMD (object):
+    def __init__(self, params):
+        self.make_me = params.type == 'SMD' and params.pad_width > 0
+        self.params = params
 
-    if not make_me(2, rows, cols, rm):
-        return
+    def makeModelName(self, genericName):
+        genericName = "PinSocket_{0}x{1:02}_P{2:03.2f}mm_Vertical_SMD".format(self.params.num_pin_rows, self.params.num_pins, self.params.pin_pitch)
+        return genericName + (("_Pin1Right" if self.params.pin1start_right else "_Pin1Left") if self.params.num_pin_rows == 1 else "" )
 
-    if lib_name == None or classname == None or classname_description == None:
-        return # raise error?
+    def make(self, tags_additional=[], isSocket=True):
 
-    footprint_name = "{3}_{0}x{1:02}_P{2:03.2f}mm_Vertical_SMD".format(cols, rows, rm, classname)
-    description = "surface-mounted straight {3}, {0}x{1:02}, {2:03.2f}mm pitch".format(cols, rows, rm, classname_description)
-    tags = "Surface mounted {3} SMD {0}x{1:02} {2:03.2f}mm".format(cols, rows, rm, classname_description)
+        param = self.params
 
-    tags += txt_tag[cols]
-    description += txt_descr[cols]
+        lib_name ="Conn_PinSocket_{0:03.2f}mm".format(param.pin_pitch)
+        footprint_name = self.makeModelName("")
+        description = "surface-mounted straight socket strip, {0}x{1:02}, {2:03.2f}mm pitch".format(param.num_pin_rows, param.num_pins, param.pin_pitch)
+        tags = "Surface mounted socket strip SMD {0}x{1:02} {2:03.2f}mm".format(param.num_pin_rows, param.num_pins, param.pin_pitch)
 
-    if (cols == 1):
-        if start_left:
-            description += ", style 1 (pin 1 left)"
-            tags += " style1 pin1 left"
-            footprint_name += "_Pin1Left"
+        tags += txt_tag[param.num_pin_rows]
+        description += txt_descr[param.num_pin_rows]
+
+        pad = [param.pad_length, param.pad_width]
+        rowdist = param.pin_pitch
+
+        rmx_pad_offset = getPadOffsets(param.pads_lp_width, pad)
+        rmx_pin_length = getPinLength(param.pin_length, param.body_width)
+
+        if (param.num_pin_rows == 1):
+            if param.pin1start_right:
+                description += ", style 2 (pin 1 right)"
+                tags += " style2 pin1 right"
+            else:
+                description += ", style 1 (pin 1 left)"
+                tags += " style1 pin1 left"
+
+        if len(tags_additional) > 0:
+            for t in tags_additional:
+                footprint_name = footprint_name + "_" + t
+                description = description + ", " + t
+                tags = tags + " " + t
+
+        if len(param.datasheet) > 0:
+            description += " (" + param.datasheet + ")"
+
+        description += ", script generated"
+
+        print "###################"
+        print footprint_name, "in", lib_name
+
+        # init kicad footprint
+        kicad_mod = Footprint(footprint_name)
+        kicad_mod.setDescription(description)
+        kicad_mod.setTags(tags)
+        kicad_mod.setAttribute('smd')
+
+        # anchor for SMD-symbols is in the center
+        kicad_modg = Translation(0.0, 0.0)
+        kicad_mod.append(kicad_modg)
+
+        rmh = param.pin_pitch / 2.0
+
+        # create layer canvases
+        silk    = Layer(kicad_modg, 'F.SilkS')
+        fab     = Layer(kicad_modg, 'F.Fab')
+        crt     = Layer(kicad_modg, 'F.CrtYd', offset=0.5) # offset 0.5 for connectors
+        pads    = PadLayer(kicad_modg, pad, Pad.TYPE_SMT, Pad.SHAPE_RECT, y_offset=(param.num_pins - 1) * -rmh)
+        keepout = Keepout(silk)
+
+        if Keepout.DEBUG:
+            kicad_mod.setSolderMaskMargin(silk.getSoldermaskMargin())
+
+        r_dist = rowdist * (param.num_pin_rows - 1)
+
+        h_fab = param.num_pins * param.pin_pitch + param.body_overlength
+        w_fab = param.body_width
+        t_fab = -param.body_overlength / 2.0
+
+        h_slk = h_fab + silk.offset * 2.0
+        w_slk = max(w_fab + silk.offset * 2.0, r_dist - pad[0] - silk.offset * 4.0)
+    #    l_slk = (r_dist - w_slk) / 2.0
+    #    t_slk = -param.body_overlength - silk.offset
+
+        h_crt = max(h_fab, (param.num_pins - 1) * param.pin_pitch + pad[1]) + crt.offset * 2.0
+        w_crt = max(param.body_width, rmx_pad_offset * 2.0 + pad[0]) + crt.offset * 2.0
+
+        cleft = range(1, param.num_pins, 2) if param.pin1start_right else range(0, param.num_pins, 2)
+        cright = range(0, param.num_pins, 2) if param.pin1start_right else range(1, param.num_pins, 2)
+        even_pins = param.num_pins % 2.0 == 0.0
+
+        # create pads
+        if param.num_pin_rows == 1:
+            for y in cleft:
+                pads.add(-rmx_pad_offset, y * param.pin_pitch, number=y + 1)
+            for y in cright:
+                pads.add(rmx_pad_offset, y * param.pin_pitch, number=y + 1)
+        elif param.num_pin_rows == 2:
+            f = 1.0 if isSocket else -1.0
+            for y in range(0,param.num_pins):
+                pads.add(f * rmx_pad_offset, y * param.pin_pitch)\
+                    .add(f * -rmx_pad_offset, y * param.pin_pitch)
+
+        # add pads to silk keepout
+        keepout.addPads()
+        keepout.debug_draw()
+
+        # add text and outline to silk layer
+        silk.goto(0.0, -(h_crt / 2.0) - silk.txt_offset)\
+            .text('reference', 'REF**')\
+            .setOrigin(-w_slk / 2.0, -h_slk / 2.0)\
+            .rect(w_slk, h_slk, origin = "topLeft")
+
+        # pin1 marker
+        pad1 = keepout.getPadBB(1)
+        f = 1 if isSocket ^ (not param.pin1start_right) else -1
+
+        silk.gotoY(pad1.y)\
+            .jump(w_slk if f == 1 else 0.0, -pad1.height / 2.0)\
+            .right(f * (pad[0] - silk.line_width) / 2.0 - (silk.x - pad1.x))
+
+        # add text and outline to fab layer
+        bevel = min(Layer.getBevel(h_fab, w_fab), -t_fab + rmh + param.pin_width / 2.0)
+
+        fab.down((h_crt) / 2.0 + fab.txt_offset, draw=False)\
+           .text('value', footprint_name)\
+           .goHome()\
+           .setTextDefaults(max_size=1.0)\
+           .setTextSize(0.6 * (h_fab if param.num_pins == 1 and param.num_pin_rows <= 2 else w_fab))\
+           .text('user', '%R', rotation=(90 if h_fab >= w_fab else 0))\
+           .rect(w_fab, h_fab, bevel=(0.0 if param.pin1start_right else bevel, bevel if param.pin1start_right else 0.0, 0.0, 0.0))\
+           .setOrigin(-w_fab / 2.0, -h_fab / 2.0)
+
+        # add pin markers to fab layer
+        trl = w_fab + rmx_pin_length
+        if param.num_pin_rows == 2:
+            fab.jump(-rmx_pin_length / 2.0, -t_fab + rmh)
+            for r in range(1, param.num_pins + 1):
+                fab.rect(rmx_pin_length, param.pin_width, draw=(True, False, True, True))\
+                   .right(trl, draw=False)\
+                   .rect(rmx_pin_length, param.pin_width, draw=(True, True, True, False))\
+                   .left(trl, draw=False)\
+                   .down(param.pin_pitch, draw=False)
+        elif param.pin1start_right:
+            trl = -trl
+            fab.jump(w_fab + rmx_pin_length / 2.0, -t_fab + rmh)
+            for c in cright:
+                fab.rect(rmx_pin_length, param.pin_width, draw=(True, True, True, False))\
+                   .jump(trl, param.pin_pitch)
+                if even_pins or c != cright[-1]:
+                    fab.rect(rmx_pin_length, param.pin_width, draw=(True, False, True, True))\
+                       .jump(-trl, param.pin_pitch)
         else:
-            description += ", style 2 (pin 1 right)"
-            tags += " style2 pin1 right"
-            footprint_name += "_Pin1Right"
+            fab.jump(-rmx_pin_length / 2.0, -t_fab + rmh)
+            for c in cleft:
+                fab.rect(rmx_pin_length, param.pin_width, draw=(True, False, True, True))\
+                   .jump(trl, param.pin_pitch)
+                if even_pins or c != cleft[-1]:
+                    fab.rect(rmx_pin_length, param.pin_width, draw=(True, True, True, False))\
+                       .jump(-trl, param.pin_pitch)
 
-    if len(tags_additional) > 0:
-        for t in tags_additional:
-            footprint_name = footprint_name + "_" + t
-            description = description + ", " + t
-            tags = tags + " " + t
+        # add courtyard
+        crt.rect(w_crt, h_crt)
 
-    print "###################"
-    print footprint_name, "in", lib_name
+        # add model
+        kicad_modg.append(Model(filename="${KISYS3DMOD}/" + lib_name + ".3dshapes/" + footprint_name + ".wrl"))
 
-    # init kicad footprint
-    kicad_mod = Footprint(footprint_name)
-    kicad_mod.setDescription(description)
-    kicad_mod.setTags(tags)
-    kicad_mod.setAttribute('smd')
+        # write file
+        file_handler = KicadFileHandler(kicad_mod)
+        file_handler.writeFile(root_dir.saveTo(lib_name) + footprint_name + '.kicad_mod')
 
-    # anchor for SMD-symbols is in the center
-    kicad_modg = Translation(0.0, 0.0)
-    kicad_mod.append(kicad_modg)
-
-    rmh = rm / 2.0
-
-    # create layer canvases
-    silk    = Layer(kicad_modg, 'F.SilkS')
-    fab     = Layer(kicad_modg, 'F.Fab')
-    crt     = Layer(kicad_modg, 'F.CrtYd', offset=0.5) # offset 0.5 for connectors
-    pads    = PadLayer(kicad_modg, pad, Pad.TYPE_SMT, Pad.SHAPE_RECT, y_offset=(rows - 1) * -rmh)
-    keepout = Keepout(silk)
-
-    c_dist = coldist * (cols - 1)
-
-    h_fab = (rows - 1) * rm + overlen_top + overlen_bottom
-    w_fab = package_width
-    t_fab = -overlen_top
-
-    h_slk = h_fab + silk.offset * 2.0
-    w_slk = max(w_fab + silk.offset * 2.0, c_dist - pad[0] - silk.offset * 4.0)
-#    l_slk = (c_dist - w_slk) / 2.0
-    t_slk = -overlen_top - silk.offset
-
-    h_crt = max(h_fab, (rows - 1) * rm + pad[1]) + crt.offset * 2.0
-    w_crt = max(package_width, rmx_pad_offset * 2.0 + pad[0]) + crt.offset * 2.0
-
-    cleft = range(0, rows, 2) if start_left else range(1, rows, 2)
-    cright = range(1, rows, 2) if start_left else range(0, rows, 2)
-    even_pins = rows % 2.0 == 0.0
-
-    # create pads
-    if cols == 1:
-        for y in cleft:
-            pads.add(-rmx_pad_offset, y * rm, number=y + 1)
-        for y in cright:
-            pads.add(rmx_pad_offset, y * rm, number=y + 1)
-    elif cols == 2:
-        f = 1.0 if isSocket else -1.0
-        for y in range(0,rows):
-            pads.add(f * rmx_pad_offset, y * rm)\
-                .add(f * -rmx_pad_offset, y * rm)
-
-    # add pads to silk keepout
-    keepout.addPads()
-    keepout.debug_draw()
-
-    # add text and outline to silk layer
-    silk.goto(0.0, -(h_crt / 2.0) - silk.txt_offset)\
-        .text('reference', 'REF**')\
-        .setOrigin(-w_slk / 2.0, -h_slk / 2.0)\
-        .rect(w_slk, h_slk, origin = "topLeft")
-
-    # pin1 marker
-    pad1 = keepout.getPadBB(1)
-    f = 1 if isSocket ^ start_left else -1
-    
-    silk.gotoY(pad1.y)\
-        .jump(w_slk if f == 1 else 0.0, -pad1.height / 2.0)\
-        .right(f * (pad[0] - silk.line_width) / 2.0 - (silk.x - pad1.x))
-
-    # add text and outline to fab layer
-    bevel = min(Layer.getBevel(h_fab, w_fab), -t_fab - pin_width / 2.0)
-
-    fab.down((h_crt) / 2.0 + fab.txt_offset, draw=False)\
-       .text('value', footprint_name)\
-       .goHome()\
-       .setTextDefaults(max_size=1.0)\
-       .setTextSize(0.6 * (h_fab if rows == 1 and cols <= 2 else w_fab))\
-       .text('user', '%R', rotation=(90 if h_fab >= w_fab else 0))\
-       .rect(w_fab, h_fab, bevel=(bevel if start_left else 0.0, 0.0 if start_left else bevel, 0.0, 0.0))\
-       .setOrigin(-w_fab / 2.0, -h_fab / 2.0)
-
-    # add pin markers to fab layer
-    trl = w_fab + rmx_pin_length
-    if cols == 2:
-        fab.jump(-rmx_pin_length / 2.0, -t_fab)
-        for r in range(1, rows + 1):
-            fab.rect(rmx_pin_length, pin_width, draw=(True, False, True, True))\
-               .right(trl, draw=False)\
-               .rect(rmx_pin_length, pin_width, draw=(True, True, True, False))\
-               .left(trl, draw=False)\
-               .down(rm, draw=False)
-    elif start_left:
-        fab.jump(-rmx_pin_length / 2.0, -t_fab)
-        for c in cleft:
-            fab.rect(rmx_pin_length, pin_width, draw=(True, False, True, True))\
-               .jump(trl, rm)
-            if even_pins or c != cleft[-1]:
-                fab.rect(rmx_pin_length, pin_width, draw=(True, True, True, False))\
-                   .jump(-trl, rm)
-    else:
-        trl = -trl
-        fab.jump(w_fab + rmx_pin_length / 2.0, -t_fab)
-        for c in cright:
-            fab.rect(rmx_pin_length, pin_width, draw=(True, True, True, False))\
-               .jump(trl, rm)
-            if even_pins or c != cright[-1]:
-                fab.rect(rmx_pin_length, pin_width, draw=(True, False, True, True))\
-                   .jump(-trl, rm)
-
-    # add courtyard
-    crt.rect(w_crt, h_crt)
-
-    # add model
-    kicad_modg.append(Model(filename="${KISYS3DMOD}/" + lib_name + ".3dshapes/" + footprint_name + ".wrl"))
-
-    # write file
-    file_handler = KicadFileHandler(kicad_mod)
-    file_handler.writeFile(root_dir.saveTo(lib_name) + footprint_name + '.kicad_mod')
+### EOF ###


### PR DESCRIPTION
Single row SMD left/right sockets for 2.54 and 2.00 mm added. Updated
for KLC3 and new naming convention.

NOTE: most dimensions are from legacy footprints since there are many
variants available. There are references to dimensions and sources that
I have found that could be useful for adding more variants.

Also included are two wrapper classes in a separate module, this for
some of the core primitives. It allows simpler coding in a somewhat
similar style as CadQuery provides for 3D modeling.

A pull request will soon be made for the footprints, I will refer to that when it is done. Also, I have scripted 3D models at hand that I will make a PR for when the footprints are approved.

I have not updated the existing scripts as code is shared with pin headers and I did not want to affect those. The main reason is that the generator code is nearly 100% new and based on my wrapper classes.