### PR TITLE
Make manage.sh use greadlink on OS X

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-BASE_DIR=$(dirname `readlink -f $0`)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+command -v greadlink >/dev/null 2>&1 || { echo >&2 "greadlink not found. Install using 'brew install coreutils'"; exit 1; }
+BASE_DIR="$(dirname "$(greadlink -f "$0")")"
+else
+BASE_DIR="$(dirname "$(readlink -f "$0")")"
+fi
+
 PYTHONPATH=$BASE_DIR
 KICADMODTREE_DIR="$BASE_DIR/KicadModTree"
 ACTION=$1


### PR DESCRIPTION
readlink on OS X is different (https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/readlink.1.html) than on Linux. Use the GNU's readlink available through homebrew (https://brew.sh/index_de.html) instead.