### PR TITLE
The top entry xh connectors should have the suffix vertical

### DIFF
--- a/scripts/Connector/Connector_JST/conn_jst_xh_tht_top.py
+++ b/scripts/Connector/Connector_JST/conn_jst_xh_tht_top.py
@@ -32,7 +32,7 @@ from itertools import chain
 
 series = "XH"
 manufacturer = 'JST'
-orientation = 'H'
+orientation = 'V'
 number_of_rows = 1
 datasheet = 'http://www.jst-mfg.com/product/pdf/eng/eXH.pdf'
 


### PR DESCRIPTION
Fix of a copy paste error
Footprint PR: https://github.com/KiCad/kicad-footprints/pull/162