### PR TITLE
Footprint name (mpn) fix for molex micro latch plus mark my scripts as python 3

### DIFF
--- a/scripts/Connector/Connector_Hirose/conn_ffc_hirose_fh12_smd_side.py
+++ b/scripts/Connector/Connector_Hirose/conn_ffc_hirose_fh12_smd_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_Hirose/conn_hirose_df13_tht_side.py
+++ b/scripts/Connector/Connector_Hirose/conn_hirose_df13_tht_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_Hirose/conn_hirose_df13_tht_top.py
+++ b/scripts/Connector/Connector_Hirose/conn_hirose_df13_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_Hirose/conn_hirose_df13c_smd_top.py
+++ b/scripts/Connector/Connector_Hirose/conn_hirose_df13c_smd_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_Hirose/conn_hirose_df63_tht_top.py
+++ b/scripts/Connector/Connector_Hirose/conn_hirose_df63_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Hirose/df33_straight_pth.py
+++ b/scripts/Connector/Connector_Hirose/df33_straight_pth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os
@@ -20,7 +20,7 @@ tags = "connector hirose df33 top straight vertical through thru hole"
 for pincount in range(2,16):
 
     part = "DF33C-{pincount:02}P-125DSA".format(pincount=pincount)
-    
+
     footprint_name = "{0}_{1}_{2:02}x{3:.2f}mm_{4}".format(manu,part,pincount,pitch,suffix)
 
     kicad_mod = KicadMod(footprint_name)
@@ -30,51 +30,51 @@ for pincount in range(2,16):
     # set general values
     kicad_mod.addText('reference', 'REF**', {'x':0, 'y':2.5}, 'F.SilkS')
     kicad_mod.addText('value', footprint_name, {'x':0, 'y':4}, 'F.Fab')
-    
+
     drill = 0.6
 
     x_dia = 0.95
     y_dia = 1.25
-    
+
     # create pads
     createNumberedPadsTHT(kicad_mod, pincount, pitch, drill, {'x':x_dia, 'y':y_dia})
-    
+
     A = (pincount - 1) * pitch
     B = A + 2.9
-    
+
     x1 = -(B-A) / 2
     y1 = -2.2
     x2 = x1 + B
     y2 = 1.2
-    
-    #line offset 
+
+    #line offset
     off = 0.1
-    
+
     x1 -= off
     y1 -= off
-    
+
     x2 += off
     y2 += off
-    
+
     #draw the main outline around the footprint
     kicad_mod.addRectLine({'x':x1,'y':y1},{'x':x2,'y':y2})
-    
+
     #add pin-1 marker
-    
+
     xm = 0
     ym = -2.8
-    
+
     m = 0.3
-    
+
     kicad_mod.addPolygoneLine([{'x':xm,'y':ym},
                                {'x':xm - m,'y':ym - 2 * m},
                                {'x':xm + m,'y':ym - 2 * m},
                                {'x':xm,'y':ym}])
-                               
+
     #side-wall thickness S
-    
+
     S = 0.5
-    
+
     #bottom line
     kicad_mod.addPolygoneLine([{'x':x1,'y':0},
                                {'x':x1+S,'y':0},
@@ -82,24 +82,24 @@ for pincount in range(2,16):
                                {'x':x2-S,'y':y2-S},
                                {'x':x2-S,'y':0},
                                {'x':x2,'y':0}])
-                               
+
     #left mark
-    
+
     #gap g
     g = 0.75
-    
+
     kicad_mod.addPolygoneLine([{'x':x1,'y':-g},
                                {'x':x1+S,'y':-g},
                                {'x':x1+S,'y':y1+S*1.5},
                                {'x':x1+2*S,'y':y1+S*1.5},
                                {'x':x1+2*S,'y':y1}])
-    
+
     kicad_mod.addPolygoneLine([{'x':x2,'y':-g},
                                {'x':x2-S,'y':-g},
                                {'x':x2-S,'y':y1+S*1.5},
                                {'x':x2-2*S,'y':y1+S*1.5},
                                {'x':x2-2*S,'y':y1}])
-                               
+
     #middle line
     kicad_mod.addPolygoneLine([{'x':x1+2*S,'y':y1+1.5*S},
                                {'x':0.2*pitch,'y':y1+1.5*S},
@@ -111,24 +111,24 @@ for pincount in range(2,16):
                                {'x':A-0.2*pitch,'y':y1+0.5*S},
                                {'x':A-0.2*pitch,'y':y1+1.5*S},
                                {'x':x2-2*S,'y':y1+1.5*S}])
-    
+
     """
     #add pictures of pins
     #pin-width w
     #pin-length l
     w = 0.32
     l = 3.5
-    
+
     py = -2.5
-    
+
     kicad_mod.addLine({'x':x1+T,'y':py},{'x':x2-T,'y':py})
-    
+
     kicad_mod.addLine({'x':x1+T,'y':py+1},{'x':x2-T,'y':py+1})
-    
+
     for p in range(pincount):
-        
+
         px = p * pitch
-        
+
         kicad_mod.addPolygoneLine([{'x': px,'y': py},
                                    {'x': px-w,'y': py},
                                    {'x': px-w,'y': py-l+0.25*w},
@@ -136,29 +136,29 @@ for pincount in range(2,16):
                                    {'x': px+w,'y': py-l+0.25*w},
                                    {'x': px+w,'y': py},
                                    {'x': px,'y': py}])
-    
-    
-    """           
+
+
+    """
     #add a courtyard
     cy = 0.5
-    
+
     kicad_mod.addRectLine({'x':x1-cy,'y':y1-cy},{'x':x2+cy,'y':y2+cy},"F.CrtYd",0.05)
-    
+
     kicad_mod.model = "Connectors_Hirose.3dshapes/" + footprint_name + ".wrl"
-    
+
     #shift the model along
-    
+
     if pincount % 2 == 0: #even
         xOff = (pincount / 2 - 0.5) * pitch
     else:
         xOff = (pincount / 2) * pitch
-        
+
     kicad_mod.model_pos['x'] = xOff / 25.4
     kicad_mod.model_rot['z'] = 180
-    
+
     # output kicad model
     f = open(footprint_name + ".kicad_mod","w")
-    
+
     f.write(kicad_mod.__str__())
 
     f.close()

--- a/scripts/Connector/Connector_Hirose/df63_angled.py
+++ b/scripts/Connector/Connector_Hirose/df63_angled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_JST/conn_jst_J2100_tht_side.py
+++ b/scripts/Connector/Connector_JST/conn_jst_J2100_tht_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_JST/conn_jst_J2100_tht_top.py
+++ b/scripts/Connector/Connector_JST/conn_jst_J2100_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_JST/conn_jst_JWPF_tht_top.py
+++ b/scripts/Connector/Connector_JST/conn_jst_JWPF_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_JST/conn_jst_NV_tht_top.py
+++ b/scripts/Connector/Connector_JST/conn_jst_NV_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_JST/conn_jst_PUD_tht_side.py
+++ b/scripts/Connector/Connector_JST/conn_jst_PUD_tht_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_JST/conn_jst_PUD_tht_top.py
+++ b/scripts/Connector/Connector_JST/conn_jst_PUD_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_JST/conn_jst_VH_tht_side-stabilizer.py
+++ b/scripts/Connector/Connector_JST/conn_jst_VH_tht_side-stabilizer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_JST/conn_jst_VH_tht_side.py
+++ b/scripts/Connector/Connector_JST/conn_jst_VH_tht_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_JST/conn_jst_VH_tht_top-shrouded.py
+++ b/scripts/Connector/Connector_JST/conn_jst_VH_tht_top-shrouded.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_JST/conn_jst_eh_tht_side.py
+++ b/scripts/Connector/Connector_JST/conn_jst_eh_tht_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_JST/conn_jst_eh_tht_top.py
+++ b/scripts/Connector/Connector_JST/conn_jst_eh_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_JST/conn_jst_ph_tht_side.py
+++ b/scripts/Connector/Connector_JST/conn_jst_ph_tht_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_JST/conn_jst_ph_tht_top.py
+++ b/scripts/Connector/Connector_JST/conn_jst_ph_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_JST/conn_jst_vh_tht_top.py
+++ b/scripts/Connector/Connector_JST/conn_jst_vh_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_JST/conn_jst_xh_tht_side.py
+++ b/scripts/Connector/Connector_JST/conn_jst_xh_tht_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_JST/conn_jst_xh_tht_top.py
+++ b/scripts/Connector/Connector_JST/conn_jst_xh_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_JST/conn_jst_ze_tht_side.py
+++ b/scripts/Connector/Connector_JST/conn_jst_ze_tht_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_JST/conn_jst_ze_tht_top.py
+++ b/scripts/Connector/Connector_JST/conn_jst_ze_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_Molex/conn_molex_SPOX_tht_top.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_SPOX_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_kk_254_tht_top.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_kk_254_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # KicadModTree is free software: you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as published by

--- a/scripts/Connector/Connector_Molex/conn_molex_mega-fit_tht_side_dual-row.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_mega-fit_tht_side_dual-row.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_mega-fit_tht_top_dual_row.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_mega-fit_tht_top_dual_row.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_micro-clasp_tht_top.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_micro-clasp_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_micro-fit-3.0_smd_side_dual_row.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_micro-fit-3.0_smd_side_dual_row.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_micro-fit-3.0_smd_top_dual_row.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_micro-fit-3.0_smd_top_dual_row.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_micro-latch_tht_side.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_micro-latch_tht_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or
@@ -70,8 +70,8 @@ if pad_size[1] == pad_size[0]:
 
 
 def generate_one_footprint(pins_per_row, configuration):
-    mpn = part_code.format(n=pins_per_row*2)
-    alt_mpn = [code.format(n=pins_per_row*2) for code in alternative_codes]
+    mpn = part_code.format(n=pins_per_row*number_of_rows)
+    alt_mpn = [code.format(n=pins_per_row*number_of_rows) for code in alternative_codes]
 
     # handle arguments
     orientation_str = configuration['orientation_options'][orientation]

--- a/scripts/Connector/Connector_Molex/conn_molex_micro-latch_tht_top.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_micro-latch_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or
@@ -70,8 +70,8 @@ if pad_size[1] == pad_size[0]:
 
 
 def generate_one_footprint(pins_per_row, configuration):
-    mpn = part_code.format(n=pins_per_row*2)
-    alt_mpn = [code.format(n=pins_per_row*2) for code in alternative_codes]
+    mpn = part_code.format(n=pins_per_row*number_of_rows)
+    alt_mpn = [code.format(n=pins_per_row*number_of_rows) for code in alternative_codes]
 
     # handle arguments
     orientation_str = configuration['orientation_options'][orientation]

--- a/scripts/Connector/Connector_Molex/conn_molex_mini-fit-sr_tht_side.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_mini-fit-sr_tht_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_mini-fit-sr_tht_top.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_mini-fit-sr_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_mini-fit-sr_tht_top_dual.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_mini-fit-sr_tht_top_dual.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_mini-fit_Jr_tht_side_dual-row.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_mini-fit_Jr_tht_side_dual-row.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_mini-fit_Jr_tht_top_dual-row.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_mini-fit_Jr_tht_top_dual-row.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_nano-fit_tht_side.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_nano-fit_tht_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_nano-fit_tht_top.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_nano-fit_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_picoblade_tht_side.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_picoblade_tht_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_picoblade_tht_top.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_picoblade_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_picoflex_smd_top.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_picoflex_smd_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_picoflex_tht_top.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_picoflex_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_sabre_tht_side.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_sabre_tht_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_sabre_tht_top.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_sabre_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Molex/conn_molex_slimstack-501920.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_slimstack-501920.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # KicadModTree is free software: you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as published by

--- a/scripts/Connector/Connector_Molex/conn_molex_slimstack-502426.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_slimstack-502426.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # KicadModTree is free software: you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as published by

--- a/scripts/Connector/Connector_Molex/conn_molex_slimstack-502430.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_slimstack-502430.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # KicadModTree is free software: you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as published by

--- a/scripts/Connector/Connector_Molex/conn_molex_slimstack-52991.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_slimstack-52991.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # KicadModTree is free software: you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as published by

--- a/scripts/Connector/Connector_Molex/conn_molex_slimstack-54722.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_slimstack-54722.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # KicadModTree is free software: you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as published by

--- a/scripts/Connector/Connector_Molex/conn_molex_slimstack-55560.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_slimstack-55560.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # KicadModTree is free software: you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as published by

--- a/scripts/Connector/Connector_PhoenixContact/mc.py
+++ b/scripts/Connector/Connector_PhoenixContact/mc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_PhoenixContact/mstb.py
+++ b/scripts/Connector/Connector_PhoenixContact/mstb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_SMD_single_row_plus_mounting_pad/smd_single_row_plus_mounting_pad.py
+++ b/scripts/Connector/Connector_SMD_single_row_plus_mounting_pad/smd_single_row_plus_mounting_pad.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
 # Generator for jst smd connectors (single row with two mounting pads)
 
 import sys

--- a/scripts/Connector/Connector_Samtec/conn_samtec_LSHM_smd_top.py
+++ b/scripts/Connector/Connector_Samtec/conn_samtec_LSHM_smd_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Samtec/mecf_connector.py
+++ b/scripts/Connector/Connector_Samtec/mecf_connector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_Samtec/mecf_socket.py
+++ b/scripts/Connector/Connector_Samtec/mecf_socket.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/scripts/Connector/Connector_TE-Connectivity/conn_ffc_te_84952-84953.py
+++ b/scripts/Connector/Connector_TE-Connectivity/conn_ffc_te_84952-84953.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # KicadModTree is free software: you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as published by

--- a/scripts/Connector/Connector_TE-Connectivity/conn_te_mate-n-lock_tht_side.py
+++ b/scripts/Connector/Connector_TE-Connectivity/conn_te_mate-n-lock_tht_side.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_TE-Connectivity/conn_te_mate-n-lock_tht_top.py
+++ b/scripts/Connector/Connector_TE-Connectivity/conn_te_mate-n-lock_tht_top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 kicad-footprint-generator is free software: you can redistribute it and/or

--- a/scripts/Connector/Connector_Wago/conn_wago_734_horizontal.py
+++ b/scripts/Connector/Connector_Wago/conn_wago_734_horizontal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # KicadModTree is free software: you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as published by

--- a/scripts/Connector/Connector_Wago/conn_wago_734_vertical.py
+++ b/scripts/Connector/Connector_Wago/conn_wago_734_vertical.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # KicadModTree is free software: you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Had a pins_per_row***2** instead of pins_per_row***number_of_rows** in the micro latch scripts. This resulted in a wrong mpn used within the footprint name.

Changed first line to `#!/usr/bin/env python3` as requested here https://github.com/pointhi/kicad-footprint-generator/pull/80#issuecomment-347279463.

Footprint PR: https://github.com/KiCad/kicad-footprints/pull/180
