### PR TITLE
Rename shielded connector footprints for new syntax

### DIFF
--- a/scripts/Connector/Connector_Samtec/conn_samtec_LSHM_smd_top.py
+++ b/scripts/Connector/Connector_Samtec/conn_samtec_LSHM_smd_top.py
@@ -48,12 +48,10 @@ variant_params = {
     'shileded': {
         'mpn_option': 'S',
         'shield_pad': True,
-        'fp_name_suffix': '_Shielded'
     },
     'plain': {
         'mpn_option': 'N',
         'shield_pad': False,
-        'fp_name_suffix': ''
     }
 }
 
@@ -79,13 +77,18 @@ def generate_one_footprint(pins_per_row, params, configuration):
 
     # handle arguments
     orientation_str = configuration['orientation_options'][orientation]
-    footprint_name = configuration['fp_name_format_string'].format(man=manufacturer,
-        series=series,
-        mpn=mpn, num_rows=number_of_rows, pins_per_row=pins_per_row,
-        pitch=pitch, orientation=orientation_str)
+    if params['shield_pad']:
+        footprint_name = configuration['fp_name_format_string_shielded'].format(man=manufacturer,
+            series=series,
+            mpn=mpn, num_rows=number_of_rows, pins_per_row=pins_per_row,
+            pitch=pitch, orientation=orientation_str, shield_pins=1)
+    else:
+        footprint_name = configuration['fp_name_format_string'].format(man=manufacturer,
+            series=series,
+            mpn=mpn, num_rows=number_of_rows, pins_per_row=pins_per_row,
+            pitch=pitch, orientation=orientation_str)
 
     footprint_name = footprint_name.replace('__','_')
-    footprint_name += params['fp_name_suffix']
 
     kicad_mod = Footprint(footprint_name)
     kicad_mod.setAttribute('smd')

--- a/scripts/Connector/conn_config_KLCv3.yaml
+++ b/scripts/Connector/conn_config_KLCv3.yaml
@@ -1,4 +1,5 @@
 fp_name_format_string: '{man:s}_{series:s}_{mpn:s}_{num_rows:d}x{pins_per_row:02d}_P{pitch:.2f}mm_{orientation:s}'
+fp_name_format_string_shielded: '{man:s}_{series:s}_{mpn:s}_{num_rows:d}x{pins_per_row:02d}-{shield_pins:d}SH_P{pitch:.2f}mm_{orientation:s}'
 fp_name_dual_pitch_format_string: '{man:s}_{series:s}_{mpn:s}_{num_rows:d}x{pins_per_row:02d}_P{pitch_x:.2f}x{pitch_y:.2f}mm_{orientation:s}'
 fp_name_unequal_row_format_string: '{man:s}_{series:s}_{mpn:s}_{num_rows:d}Rows-{pins:02d}Pins_P{pitch:.2f}mm_{orientation:s}'
 orientation_options:


### PR DESCRIPTION
This is the script change for https://github.com/KiCad/kicad-footprints/pull/359