### PR TITLE
Added BGA generator

### DIFF
--- a/scripts/Package_BGA/bga.py
+++ b/scripts/Package_BGA/bga.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+
+import math
+import os
+import sys
+
+# load parent path of KicadModTree
+sys.path.append(os.path.join(sys.path[0], "..", ".."))
+
+from KicadModTree import *
+
+def bga(args):
+    footprint_name = args["name"]
+    desc = args["description"]
+
+    pkgWidth = args["pkg_width"]
+    pkgHeight = args["pkg_height"]
+
+    pitch = args["pitch"]
+    padDiameter = args["pad_diameter"]
+    pasteRatio = args["paste_ratio"]
+    layoutX = args["layout_x"]
+    layoutY = args["layout_y"]
+    rowNames = args["row_names"]
+    rowSkips = args["row_skips"]
+
+    f = Footprint(footprint_name)
+    f.setDescription(desc)
+    f.setAttribute("smd")
+    # If this looks like a CSP footprint, use the CSP 3dshapes library
+    if 'BGA' not in footprint_name and 'CSP' in footprint_name:
+        f.append(Model(filename="${{KISYS3DMOD}}/Package_CSP.3dshapes"
+                                "/{}.wrl".format(footprint_name),
+                       at=[0.0, 0.0, 0.0],
+                       scale=[1.0, 1.0, 1.0],
+                       rotate=[0.0, 0.0, 0.0]))
+    else:
+        f.append(Model(filename="${{KISYS3DMOD}}/Package_BGA.3dshapes"
+                                "/{}.wrl".format(footprint_name),
+                       at=[0.0, 0.0, 0.0],
+                       scale=[1.0, 1.0, 1.0],
+                       rotate=[0.0, 0.0, 0.0]))
+
+    s1 = [1.0, 1.0]
+
+    t1 = 0.15
+
+    padShape = Pad.SHAPE_CIRCLE
+
+    chamfer = min(1.0, min(pkgWidth, pkgHeight)*0.25)
+    silkOffset = 0.125
+    crtYd = 1.0
+
+    def crtYdRound(x):
+        # Round away from zero for proper courtyard calculation
+        neg = x < 0
+        if neg:
+            x = -x
+        x = math.ceil(x * 100) / 100
+        if neg:
+            x = -x
+        return x
+
+    xCenter = 0.0
+    xLeftFab = xCenter - pkgWidth / 2
+    xRightFab = xCenter + pkgWidth / 2
+    xChamferFab = xLeftFab + chamfer
+    xPadLeft = xCenter - pitch * ((layoutX - 1) / 2)
+    xPadRight = xCenter + pitch * ((layoutX - 1) / 2)
+    xLeftCrtYd = crtYdRound(xCenter - (pkgWidth / 2 + crtYd))
+    xRightCrtYd = crtYdRound(xCenter + (pkgWidth / 2 + crtYd))
+
+    yCenter = 0.0
+    yTopFab = yCenter - pkgHeight / 2
+    yBottomFab = yCenter + pkgHeight / 2
+    yChamferFab = yTopFab + chamfer
+    yPadTop = yCenter - pitch * ((layoutY - 1) / 2)
+    yPadBottom = yCenter + pitch * ((layoutY - 1) / 2)
+    yTopCrtYd = crtYdRound(yCenter - (pkgHeight / 2 + crtYd))
+    yBottomCrtYd = crtYdRound(yCenter + (pkgHeight / 2 + crtYd))
+    yRef = yTopFab - 1.0
+    yValue = yBottomFab + 1.0
+
+    xLeftSilk = xLeftFab - silkOffset
+    xRightSilk = xRightFab + silkOffset
+    xChamferSilk = xLeftSilk + chamfer
+    yTopSilk = yTopFab - silkOffset
+    yBottomSilk = yBottomFab + silkOffset
+    yChamferSilk = yTopSilk + chamfer
+
+    wFab = 0.10
+    wCrtYd = 0.05
+    wSilkS = 0.12
+
+    # Text
+    f.append(Text(type="reference", text="REF**", at=[xCenter, yRef],
+                  layer="F.SilkS", size=s1, thickness=t1))
+    f.append(Text(type="value", text=footprint_name, at=[xCenter, yValue],
+                  layer="F.Fab", size=s1, thickness=t1))
+    f.append(Text(type="user", text="%R", at=[xCenter, yCenter],
+                  layer="F.Fab", size=s1, thickness=t1))
+
+    # Fab
+    f.append(PolygoneLine(polygone=[[xRightFab, yBottomFab],
+                                    [xLeftFab, yBottomFab],
+                                    [xLeftFab, yChamferFab],
+                                    [xChamferFab, yTopFab],
+                                    [xRightFab, yTopFab],
+                                    [xRightFab, yBottomFab]],
+                          layer="F.Fab", width=wFab))
+
+    # Courtyard
+    f.append(RectLine(start=[xLeftCrtYd, yTopCrtYd],
+                      end=[xRightCrtYd, yBottomCrtYd],
+                      layer="F.CrtYd", width=wCrtYd))
+
+    # Silk
+    f.append(PolygoneLine(polygone=[[xChamferSilk, yTopSilk],
+                                    [xRightSilk, yTopSilk],
+                                    [xRightSilk, yBottomSilk],
+                                    [xLeftSilk, yBottomSilk],
+                                    [xLeftSilk, yChamferSilk]],
+                          layer="F.SilkS", width=wSilkS))
+
+    # Pads
+    balls = layoutX * layoutY
+    if rowSkips == []:
+        for _ in range(layoutY):
+            rowSkips.append([])
+    for rowNum, row in zip(range(layoutY), rowNames):
+        rowSet = set(range(1, layoutX + 1))
+        for item in rowSkips[rowNum]:
+            try:
+                # If item is a range, remove that range
+                rowSet -= set(range(*item))
+                balls -= item[1] - item[0]
+            except TypeError:
+                # If item is an int, remove that int
+                rowSet -= {item}
+                balls -= 1
+        for col in rowSet:
+            f.append(Pad(number="{}{}".format(row, col), type=Pad.TYPE_SMT,
+                         shape=padShape,
+                         at=[xPadLeft + (col-1) * pitch, yPadTop + rowNum * pitch],
+                         size=[padDiameter, padDiameter],
+                         layers=Pad.LAYERS_SMT,
+                         solder_paste_margin_ratio=pasteRatio))
+
+    f.setTags("BGA {} {}".format(balls, pitch))
+
+    file_handler = KicadFileHandler(f)
+    file_handler.writeFile(footprint_name + ".kicad_mod")
+
+if __name__ == '__main__':
+    parser = ModArgparser(bga)
+    # the root node of .yml files is parsed as name
+    parser.add_parameter("name", type=str, required=True)
+    parser.add_parameter("description", type=str, required=True)
+    parser.add_parameter("pkg_width", type=float, required=True)
+    parser.add_parameter("pkg_height", type=float, required=True)
+    parser.add_parameter("pitch", type=float, required=True)
+    parser.add_parameter("pad_diameter", type=float, required=True)
+    parser.add_parameter("paste_ratio", type=float, required=False, default=0)
+    parser.add_parameter("layout_x", type=int, required=True)
+    parser.add_parameter("layout_y", type=int, required=True)
+    parser.add_parameter("row_names", type=list, required=False, default=[
+        "A", "B", "C", "D", "E", "F", "G", "H", "J", "K", "L", "M", "N", "P",
+        "R", "T", "U"])
+    parser.add_parameter("row_skips", type=list, required=False, default=[])
+
+    # now run our script which handles the whole part of parsing the files
+    parser.run()

--- a/scripts/Package_BGA/bga.yml
+++ b/scripts/Package_BGA/bga.yml
@@ -1,0 +1,110 @@
+LFBGA-100_10x10mm_Layout10x10_P0.8mm:
+  description: "LFBGA-100, 10x10 raster, 10x10mm package, pitch 0.8mm; see section 6.3 of http://www.st.com/resource/en/datasheet/stm32f103tb.pdf"
+  pkg_width: 10.0
+  pkg_height: 10.0
+  pitch: 0.8
+  pad_diameter: 0.5
+  layout_x: 10
+  layout_y: 10
+LFBGA-144_10x10mm_Layout12x12_P0.8mm:
+  description: "LFBGA-144, 12x12 raster, 10x10mm package, pitch 0.8mm; see section 6.1 of http://www.st.com/resource/en/datasheet/stm32f103ze.pdf"
+  pkg_width: 10.0
+  pkg_height: 10.0
+  pitch: 0.8
+  pad_diameter: 0.4
+  layout_x: 12
+  layout_y: 12
+TFBGA-64_5x5mm_Layout8x8_P0.5mm:
+  description: "TFBGA-64, 8x8 raster, 5x5mm package, pitch 0.5mm; see section 6.3 of http://www.st.com/resource/en/datasheet/stm32f100v8.pdf"
+  pkg_width: 5.0
+  pkg_height: 5.0
+  pitch: 0.5
+  pad_diameter: 0.28
+  layout_x: 8
+  layout_y: 8
+TFBGA-100_8x8mm_Layout10x10_P0.8mm:
+  description: "TFBGA-100, 10x10 raster, 8x8mm package, pitch 0.8mm; see section 6.2 of http://www.st.com/resource/en/datasheet/stm32f746zg.pdf"
+  pkg_width: 8.0
+  pkg_height: 8.0
+  pitch: 0.8
+  pad_diameter: 0.4
+  layout_x: 10
+  layout_y: 10
+TFBGA-216_13x13mm_Layout15x15_P0.8mm:
+  description: "TFBGA-216, 15x15 raster, 13x13mm package, pitch 0.8mm; see section 6.8 of http://www.st.com/resource/en/datasheet/stm32f746zg.pdf"
+  pkg_width: 13.0
+  pkg_height: 13.0
+  pitch: 0.8
+  pad_diameter: 0.4
+  layout_x: 15
+  layout_y: 15
+  row_skips: [[], [], [], [], [], [], [[7, 10]], [[7, 10]], [[7, 10]], [], [], [], [], [], []]
+TFBGA-265_14x14mm_Layout17x17_P0.8mm:
+  description: "TFBGA-265, 17x17 raster, 14x14mm package, pitch 0.8mm; see section 7.8 of http://www.st.com/resource/en/datasheet/DM00387108.pdf"
+  pkg_width: 14.0
+  pkg_height: 14.0
+  pitch: 0.8
+  pad_diameter: 0.325
+  paste_ratio: -.115
+  layout_x: 17
+  layout_y: 17
+  row_skips: [[], [], [], [], [], [[6, 13]], [6, 12], [6, 12], [6, 12], [6, 12], [6, 12], [[6, 13]], [], [], [], [], []]
+UFBGA-64_5x5mm_Layout8x8_P0.5mm:
+  description: "UFBGA-64, 8x8 raster, 5x5mm package, pitch 0.5mm; see section 7.1 of http://www.st.com/resource/en/datasheet/stm32f051t8.pdf"
+  pkg_width: 5.0
+  pkg_height: 5.0
+  pitch: 0.5
+  pad_diameter: 0.28
+  layout_x: 8
+  layout_y: 8
+UFBGA-100_7x7mm_Layout12x12_P0.5mm:
+  description: "UFBGA-100, 12x12 raster, 7x7mm package, pitch 0.5mm; see section 7.1 of http://www.st.com/resource/en/datasheet/stm32f103tb.pdf"
+  pkg_width: 7.0
+  pkg_height: 7.0
+  pitch: 0.5
+  pad_diameter: 0.28
+  layout_x: 12
+  layout_y: 12
+  row_skips: [[], [], [6, 7], [[4, 10]], [[4, 10]], [[3, 11]], [[3, 11]], [[4, 10]], [[4, 10]], [6, 7], [], []]
+UFBGA-132_7x7mm_Layout12x12_P0.5mm:
+  description: "UFBGA-132, 12x12 raster, 7x7mm package, pitch 0.5mm; see section 7.4 of http://www.st.com/resource/en/datasheet/stm32l152zc.pdf"
+  pkg_width: 7.0
+  pkg_height: 7.0
+  pitch: 0.5
+  pad_diameter: 0.27
+  layout_x: 12
+  layout_y: 12
+  row_skips: [[], [], [], [], [[5, 9]], [5, 8], [5, 8], [[5, 9]], [], [], [], []]
+UFBGA-144_7x7mm_Layout12x12_P0.5mm:
+  description: "UFBGA-144, 12x12 raster, 7x7mm package, pitch 0.5mm; see section 7.4 of http://www.st.com/resource/en/datasheet/stm32f446ze.pdf"
+  pkg_width: 7.0
+  pkg_height: 7.0
+  pitch: 0.5
+  pad_diameter: 0.28
+  layout_x: 12
+  layout_y: 12
+UFBGA-144_10x10mm_Layout12x12_P0.8mm:
+  description: "UFBGA-144, 12x12 raster, 10x10mm package, pitch 0.8mm; see section 7.5 of http://www.st.com/resource/en/datasheet/stm32f446ze.pdf"
+  pkg_width: 10.0
+  pkg_height: 10.0
+  pitch: 0.8
+  pad_diameter: 0.4
+  layout_x: 12
+  layout_y: 12
+UFBGA-169_7x7mm_Layout13x13_P0.5mm:
+  description: "UFBGA-169, 13x13 raster, 7x7mm package, pitch 0.5mm; see section 7.6 of http://www.st.com/resource/en/datasheet/stm32f429ng.pdf"
+  pkg_width: 7.0
+  pkg_height: 7.0
+  pitch: 0.5
+  pad_diameter: 0.27
+  layout_x: 13
+  layout_y: 13
+UFBGA-201_10x10mm_Layout15x15_P0.65mm:
+  description: "UFBGA-201, 15x15 raster, 10x10mm package, pitch 0.65mm; see section 7.6 of http://www.st.com/resource/en/datasheet/stm32f207vg.pdf"
+  pkg_width: 10.0
+  pkg_height: 10.0
+  pitch: 0.65
+  pad_diameter: 0.3
+  layout_x: 15
+  layout_y: 15
+  row_skips: [[], [], [], [], [[5, 12]], [5, 11], [5, 11], [5, 11], [5, 11], [5, 11], [[5, 12]], [], [], [], []]


### PR DESCRIPTION
I was surprised to find that this repository lacked a BGA generator.  Since I needed to make a bunch of BGA footprints for https://github.com/KiCad/kicad-footprints/issues/374, I figured I should make one, so here it is, along with data for a bunch of BGAs.  This generator is heavily based on the QFN generator.

Still largely a work-in-progress, as the footprints it generates haven't been reviewed by another librarian yet.  I will update this when I believe it's ready to merge.