### PR TITLE
Add support for kicad 5 primitives (roundrect, polygon, custom pad)

### DIFF
--- a/KicadModTree/KicadFileHandler.py
+++ b/KicadModTree/KicadFileHandler.py
@@ -242,7 +242,9 @@ class KicadFileHandler(FileHandler):
                 sexpr.append(['drill', 'oval', node.drill.x, node.drill.y])
 
         sexpr.append(['layers'] + node.layers)
-
+        if node.shape == Pad.SHAPE_ROUNDRECT:
+            sexpr.append(['roundrect_rratio', node.radius_ratio])
+        
         if node.solder_paste_margin_ratio != 0 or node.solder_mask_margin != 0:
             sexpr.append(SexprSerializer.NEW_LINE)
             if node.solder_mask_margin != 0:

--- a/KicadModTree/KicadFileHandler.py
+++ b/KicadModTree/KicadFileHandler.py
@@ -198,6 +198,7 @@ class KicadFileHandler(FileHandler):
                 ['start', start_pos.x, start_pos.y],
                 ['end', end_pos.x, end_pos.y]
                ]
+
     def _serialize_Line(self, node):
         start_pos = node.getRealPosition(node.start_pos)
         end_pos = node.getRealPosition(node.end_pos)
@@ -274,16 +275,16 @@ class KicadFileHandler(FileHandler):
             # gr_line, gr_arc, gr_circle or gr_poly
             sexpr.append(SexprSerializer.NEW_LINE)
             sexpr.append(['options',
-                ['clearance', node.shape_in_zone],
-                ['anchor', node.anchor_shape]
-                ])
+                         ['clearance', node.shape_in_zone],
+                         ['anchor', node.anchor_shape]
+                        ])  # NOQA
             sexpr.append(SexprSerializer.NEW_LINE)
             sexpr_primitives = []
             for p in node.primitives:
                 if isinstance(p, Polygon):
                     sp = ['gr_poly',
-                        self._serialize_PolygonPoints(p, newline_after_pts=True)
-                        ]
+                          self._serialize_PolygonPoints(p, newline_after_pts=True)
+                         ]  # NOQA
                 elif isinstance(p, Line):
                     sp = ['gr_line'] + self._serialize_LinePoints(p)
                 elif isinstance(p, Circle):
@@ -307,7 +308,7 @@ class KicadFileHandler(FileHandler):
 
         return sexpr
 
-    def _serialize_PolygonPoints(self, node, newline_after_pts = False):
+    def _serialize_PolygonPoints(self, node, newline_after_pts=False):
         node_points = ['pts']
         if newline_after_pts:
             node_points.append(SexprSerializer.NEW_LINE)

--- a/KicadModTree/KicadFileHandler.py
+++ b/KicadModTree/KicadFileHandler.py
@@ -244,7 +244,7 @@ class KicadFileHandler(FileHandler):
         sexpr.append(['layers'] + node.layers)
         if node.shape == Pad.SHAPE_ROUNDRECT:
             sexpr.append(['roundrect_rratio', node.radius_ratio])
-        
+
         if node.solder_paste_margin_ratio != 0 or node.solder_mask_margin != 0:
             sexpr.append(SexprSerializer.NEW_LINE)
             if node.solder_mask_margin != 0:

--- a/KicadModTree/KicadFileHandler.py
+++ b/KicadModTree/KicadFileHandler.py
@@ -254,7 +254,7 @@ class KicadFileHandler(FileHandler):
 
         return sexpr
 
-    def _serialize_Polygon(self, node):
+    def _serialize_PolygonPoints(self, node):
         node_points = ['pts']
         points_appended = 0
         for n in node.nodes:
@@ -265,6 +265,11 @@ class KicadFileHandler(FileHandler):
 
             n_pos = node.getRealPosition(n)
             node_points.append(['xy', n_pos.x, n_pos.y])
+
+        return node_points
+
+    def _serialize_Polygon(self, node):
+        node_points = self._serialize_PolygonPoints(node)
 
         sexpr = ['fp_poly',
                  node_points,

--- a/KicadModTree/Point.py
+++ b/KicadModTree/Point.py
@@ -16,6 +16,7 @@
 import warnings
 
 from KicadModTree.util.kicad_util import formatFloat
+from math import sqrt
 
 
 class Point2D(object):
@@ -135,6 +136,9 @@ class Point2D(object):
 
     def __str__(self):
         return "(x={x}, y={y})".format(**self.__dict__())
+
+    def distanceTo(self, other):
+        return sqrt((other.x - self.x)**2 + (other.y - self.y)**2)
 
 
 class Point3D(Point2D):

--- a/KicadModTree/Point.py
+++ b/KicadModTree/Point.py
@@ -76,6 +76,15 @@ class Point2D(object):
         return Point2D({'x': round(self.x / base) * base,
                         'y': round(self.y / base) * base})
 
+    def distance_to(self, value):
+        r"""Distance between selfe and another point
+
+        :param value: the other point
+        :return: distance between self and other point
+        """
+        other = Point2D.__arithmetic_parse(value)
+        return sqrt((other.x - self.x)**2 + (other.y - self.y)**2)
+
     @staticmethod
     def __arithmetic_parse(value):
         if isinstance(value, Point2D):
@@ -136,9 +145,6 @@ class Point2D(object):
 
     def __str__(self):
         return "(x={x}, y={y})".format(**self.__dict__())
-
-    def distanceTo(self, other):
-        return sqrt((other.x - self.x)**2 + (other.y - self.y)**2)
 
 
 class Point3D(Point2D):

--- a/KicadModTree/Point.py
+++ b/KicadModTree/Point.py
@@ -77,7 +77,7 @@ class Point2D(object):
                         'y': round(self.y / base) * base})
 
     def distance_to(self, value):
-        r"""Distance between selfe and another point
+        r"""Distance between this and another point
 
         :param value: the other point
         :return: distance between self and other point

--- a/KicadModTree/PolyPoint.py
+++ b/KicadModTree/PolyPoint.py
@@ -16,6 +16,7 @@
 from KicadModTree.Point import Point2D
 from KicadModTree.nodes.Node import Node
 
+
 class PolyPoint(object):
     r"""Representation of multiple points for creating polygons
 

--- a/KicadModTree/PolygonPoints.py
+++ b/KicadModTree/PolygonPoints.py
@@ -94,12 +94,12 @@ class PolygonPoints(object):
         return len(self.nodes)
 
     def findNearestPoints(self, other):
-        min_distance = self[0].distanceTo(other[0])
+        min_distance = self[0].distance_to(other[0])
         pi = 0
         pj = 0
         for i in range(len(self)):
             for j in range(len(other)):
-                d = self[i].distanceTo(other[j])
+                d = self[i].distance_to(other[j])
                 if d < min_distance:
                     pi = i
                     pj = j

--- a/KicadModTree/PolygonPoints.py
+++ b/KicadModTree/PolygonPoints.py
@@ -83,17 +83,17 @@ class PolygonPoints(object):
 
         return Node.calculateBoundingBox({'min': min, 'max': max})
 
-    def __iter__(self):
-        for n in self.nodes:
-            yield n
-
-    def __getitem__(self, idx):
-        return self.nodes[idx]
-
-    def __len__(self):
-        return len(self.nodes)
-
     def findNearestPoints(self, other):
+        r""" Find the nearest points for two polygons
+
+        Find the two points for both polygons that are nearest to each other.
+
+
+        :param other: the polygon points of the other polygon
+        :return: a tuble with the indexes of the two points
+                 (pint in self, point in other)
+        """
+
         min_distance = self[0].distance_to(other[0])
         pi = 0
         pj = 0
@@ -108,9 +108,26 @@ class PolygonPoints(object):
         return (pi, pj)
 
     def getPoints(self):
+        r""" get the points contained within self
+
+        :return: the array of points contained within this instance
+        """
         return self.nodes
 
     def cut(self, other):
+        r""" Cut other polygon points from self
+
+        As kicad has no native support for cuting one polygon from the other,
+        the cut is done by connecting the nearest points of the two polygons
+        with two lines on top of each other.
+
+        This function assumes that the other polygon is fully within this one.
+        It also assumes that connecting the two nearest points creates a valid
+        polygon. (There are no geomtry checks)
+
+        :param other: the polygon points that are cut from this polygon
+        """
+
         warnings.warn(
             "No geometry checks are implement for cutting polygons.\n"
             "Make sure the second polygon is fully inside the main polygon\n"
@@ -124,3 +141,13 @@ class PolygonPoints(object):
             self.nodes.insert(idx_self+1, other[(i+idx_other) % len(other)])
 
         self.nodes.insert(idx_self+1, other[idx_other])
+
+    def __iter__(self):
+        for n in self.nodes:
+            yield n
+
+    def __getitem__(self, idx):
+        return self.nodes[idx]
+
+    def __len__(self):
+        return len(self.nodes)

--- a/KicadModTree/PolygonPoints.py
+++ b/KicadModTree/PolygonPoints.py
@@ -112,7 +112,7 @@ class PolygonPoints(object):
 
     def cut(self, other):
         warnings.warn(
-            "No geometry checks are implement for cutting polygons.\n"\
+            "No geometry checks are implement for cutting polygons.\n"
             "Make sure the second polygon is fully inside the main polygon\n"
             "Check resulting polygon carefully.",
             Warning
@@ -121,6 +121,6 @@ class PolygonPoints(object):
 
         self.nodes.insert(idx_self+1, self[idx_self])
         for i in range(len(other)):
-            self.nodes.insert(idx_self+1, other[(i+idx_other)%len(other)])
+            self.nodes.insert(idx_self+1, other[(i+idx_other) % len(other)])
 
         self.nodes.insert(idx_self+1, other[idx_other])

--- a/KicadModTree/PolygonPoints.py
+++ b/KicadModTree/PolygonPoints.py
@@ -13,6 +13,8 @@
 #
 # (C) 2016-2018 by Thomas Pointhuber, <thomas.pointhuber@gmx.at>
 
+import warnings
+
 from KicadModTree.Point import Point2D
 from KicadModTree.nodes.Node import Node
 
@@ -48,6 +50,10 @@ class PolygonPoints(object):
             if 'polygone' in kwargs:
                 raise KeyError('Use of "nodes" and "polygone" parameter at the same time is not supported.')
         elif 'polygone' in kwargs:
+            warnings.warn(
+                "polygone argument is deprecated, use nodes instead",
+                DeprecationWarning
+            )
             for n in kwargs['polygone']:
                 self.nodes.append(Point2D(n))
         else:

--- a/KicadModTree/PolygonPoints.py
+++ b/KicadModTree/PolygonPoints.py
@@ -17,7 +17,7 @@ from KicadModTree.Point import Point2D
 from KicadModTree.nodes.Node import Node
 
 
-class PolyPoint(object):
+class PolygonPoints(object):
     r"""Representation of multiple points for creating polygons
 
     :Keyword Arguments:

--- a/KicadModTree/PolygonPoints.py
+++ b/KicadModTree/PolygonPoints.py
@@ -123,7 +123,7 @@ class PolygonPoints(object):
 
         This function assumes that the other polygon is fully within this one.
         It also assumes that connecting the two nearest points creates a valid
-        polygon. (There are no geomtry checks)
+        polygon. (There are no geometry checks)
 
         :param other: the polygon points that are cut from this polygon
         """

--- a/KicadModTree/PolygonPoints.py
+++ b/KicadModTree/PolygonPoints.py
@@ -92,3 +92,35 @@ class PolygonPoints(object):
 
     def __len__(self):
         return len(self.nodes)
+
+    def findNearestPoints(self, other):
+        min_distance = self[0].distanceTo(other[0])
+        pi = 0
+        pj = 0
+        for i in range(len(self)):
+            for j in range(len(other)):
+                d = self[i].distanceTo(other[j])
+                if d < min_distance:
+                    pi = i
+                    pj = j
+                    min_distance = d
+
+        return (pi, pj)
+
+    def getPoints(self):
+        return self.nodes
+
+    def cut(self, other):
+        warnings.warn(
+            "No geometry checks are implement for cutting polygons.\n"\
+            "Make sure the second polygon is fully inside the main polygon\n"
+            "Check resulting polygon carefully.",
+            Warning
+        )
+        idx_self, idx_other = self.findNearestPoints(other)
+
+        self.nodes.insert(idx_self+1, self[idx_self])
+        for i in range(len(other)):
+            self.nodes.insert(idx_self+1, other[(i+idx_other)%len(other)])
+
+        self.nodes.insert(idx_self+1, other[idx_other])

--- a/KicadModTree/nodes/base/Pad.py
+++ b/KicadModTree/nodes/base/Pad.py
@@ -218,4 +218,8 @@ class Pad(Node):
         return render_text
 
     def addPrimitive(self, p):
+        r""" add a primitve to a custom pad
+
+        :param p: the primitive to add
+        """
         self.primitives.append(p)

--- a/KicadModTree/nodes/base/Pad.py
+++ b/KicadModTree/nodes/base/Pad.py
@@ -64,8 +64,10 @@ class Pad(Node):
     SHAPE_CIRCLE = 'circle'
     SHAPE_OVAL = 'oval'
     SHAPE_RECT = 'rect'
+    SHAPE_ROUNDRECT = 'roundrect'
     SHAPE_TRAPEZE = 'trapezoid'
-    _SHAPES = [SHAPE_CIRCLE, SHAPE_OVAL, SHAPE_RECT, SHAPE_TRAPEZE]
+    SHAPE_CUSTOM = 'custom'
+    _SHAPES = [SHAPE_CIRCLE, SHAPE_OVAL, SHAPE_RECT, SHAPE_ROUNDRECT, SHAPE_TRAPEZE, SHAPE_CUSTOM]
 
     LAYERS_SMT = ['F.Cu', 'F.Mask', 'F.Paste']
     LAYERS_THT = ['*.Cu', '*.Mask']
@@ -84,6 +86,9 @@ class Pad(Node):
         self._initSolderPasteMargin(**kwargs)
         self._initSolderMaskMargin(**kwargs)
         self._initLayers(**kwargs)
+
+        if self.shape == Pad.SHAPE_ROUNDRECT:
+            self._initRadiusRatio(**kwargs)
 
     def _initNumber(self, **kwargs):
         self.number = kwargs.get('number', "")  # default to an un-numbered pad
@@ -147,6 +152,17 @@ class Pad(Node):
         if not kwargs.get('layers'):
             raise KeyError('layers not declared (like "layers=[\'*.Cu\', \'*.Mask\', \'F.SilkS\']")')
         self.layers = kwargs.get('layers')
+
+    def _initRadiusRatio(self, **kwargs):
+        if kwargs.get('radius_ratio') is None:
+            raise KeyError('radius ratio not declared for rounded rectangle pad.')
+        radius_ratio = kwargs.get('radius_ratio')
+        if type(radius_ratio) not in [int, float]:
+            raise TypeError('radius ratio needs to be of type int or float')
+        if radius_ratio >= 0 and radius_ratio <= 0.5:
+            self.radius_ratio = radius_ratio
+        else:
+            raise ValueError('radius ratio out of allowed range (0 < rr <= 0.5)')
 
     # calculate the outline of a pad
     def calculateBoundingBox(self):

--- a/KicadModTree/nodes/base/Pad.py
+++ b/KicadModTree/nodes/base/Pad.py
@@ -195,7 +195,8 @@ class Pad(Node):
     def _initShapeInZone(self, **kwargs):
         self.shape_in_zone = kwargs.get('shape_in_zone', Pad.SHAPE_IN_ZONE_OUTLINE)
         if self.shape_in_zone not in Pad._SHAPE_IN_ZONE:
-            raise ValueError('{shape} is an illegal specifier for the shape in zone option'.format(shape=self.shape_in_zone))
+            raise ValueError('{shape} is an illegal specifier for the shape in zone option'
+                             .format(shape=self.shape_in_zone))
 
     # calculate the outline of a pad
     def calculateBoundingBox(self):
@@ -218,7 +219,7 @@ class Pad(Node):
 
     def addPrimitive(self, p):
         if isinstance(p, Polygon) or isinstance(p, Line)\
-            or isinstance(p, Circle) or isinstance(p, Arc):
+                or isinstance(p, Circle) or isinstance(p, Arc):
             self.primitives.append(p)
         else:
             raise TypeError('Unsuported type of primitive for custom pad.')

--- a/KicadModTree/nodes/base/Pad.py
+++ b/KicadModTree/nodes/base/Pad.py
@@ -218,8 +218,4 @@ class Pad(Node):
         return render_text
 
     def addPrimitive(self, p):
-        if isinstance(p, Polygon) or isinstance(p, Line)\
-                or isinstance(p, Circle) or isinstance(p, Arc):
-            self.primitives.append(p)
-        else:
-            raise TypeError('Unsuported type of primitive for custom pad.')
+        self.primitives.append(p)

--- a/KicadModTree/nodes/base/Polygon.py
+++ b/KicadModTree/nodes/base/Polygon.py
@@ -69,4 +69,10 @@ class Polygon(Node):
         return render_text
 
     def cut(self, other):
+        r""" Cut other polygon from this polygon
+
+        More details see PolygonPoints.cut docstring.
+
+        :param other: the other polygon
+        """
         self.nodes.cut(other.nodes)

--- a/KicadModTree/nodes/base/Polygon.py
+++ b/KicadModTree/nodes/base/Polygon.py
@@ -13,6 +13,7 @@
 #
 # (C) 2018 by Thomas Pointhuber, <thomas.pointhuber@gmx.at>
 
+from KicadModTree.PolyPoint import *
 from KicadModTree.Point import *
 from KicadModTree.nodes.Node import Node
 
@@ -39,23 +40,13 @@ class Polygon(Node):
 
     def __init__(self, **kwargs):
         Node.__init__(self)
-        self.nodes = []
-        for n in kwargs['nodes']:
-            self.nodes.append(Point2D(n))
+        self.nodes = PolyPoint(**kwargs)
 
         self.layer = kwargs.get('layer', 'F.SilkS')
         self.width = kwargs.get('width')
 
     def calculateBoundingBox(self):
-        min = max = self.getRealPosition(self.nodes[0])
-
-        for n in self.nodes:
-            min.x = min([min.x, n.x])
-            min.y = min([min.y, n.y])
-            max.x = max([max.x, n.x])
-            max.y = max([max.y, n.y])
-
-        return Node.calculateBoundingBox({'min': min, 'max': max})
+        return nodes.calculateBoundingBox()
 
     def _getRenderTreeText(self):
         render_text = Node._getRenderTreeText(self)

--- a/KicadModTree/nodes/base/Polygon.py
+++ b/KicadModTree/nodes/base/Polygon.py
@@ -13,7 +13,7 @@
 #
 # (C) 2018 by Thomas Pointhuber, <thomas.pointhuber@gmx.at>
 
-from KicadModTree.PolyPoint import *
+from KicadModTree.PolygonPoints import *
 from KicadModTree.Point import *
 from KicadModTree.nodes.Node import Node
 
@@ -40,7 +40,7 @@ class Polygon(Node):
 
     def __init__(self, **kwargs):
         Node.__init__(self)
-        self.nodes = PolyPoint(**kwargs)
+        self.nodes = PolygonPoints(**kwargs)
 
         self.layer = kwargs.get('layer', 'F.SilkS')
         self.width = kwargs.get('width')

--- a/KicadModTree/nodes/base/Polygon.py
+++ b/KicadModTree/nodes/base/Polygon.py
@@ -67,3 +67,6 @@ class Polygon(Node):
         render_text += "]"
 
         return render_text
+
+    def cut(self, other):
+        self.nodes.cut(other.nodes)

--- a/KicadModTree/nodes/specialized/PolygoneLine.py
+++ b/KicadModTree/nodes/specialized/PolygoneLine.py
@@ -14,6 +14,7 @@
 # (C) 2016 by Thomas Pointhuber, <thomas.pointhuber@gmx.at>
 
 from KicadModTree.Point import *
+from KicadModTree.PolyPoint import *
 from KicadModTree.nodes.Node import Node
 from KicadModTree.nodes.base.Line import Line
 
@@ -44,28 +45,12 @@ class PolygoneLine(Node):
         self.layer = kwargs.get('layer', 'F.SilkS')
         self.width = kwargs.get('width')
 
-        self._initMirror(**kwargs)
+        self._initPolyPoint(**kwargs)
 
-        self._initPolygone(**kwargs)
+        self.virtual_childs = self._createChildNodes(self.poly_point)
 
-        self.virtual_childs = self._createChildNodes(self.polygone_line)
-
-    def _initMirror(self, **kwargs):
-        self.mirror = [None, None]
-        if kwargs.get('x_mirror') and type(kwargs['x_mirror']) in [float, int]:
-            self.mirror[0] = kwargs['x_mirror']
-        if kwargs.get('y_mirror') and type(kwargs['y_mirror']) in [float, int]:
-            self.mirror[1] = kwargs['y_mirror']
-
-    def _initPolygone(self, **kwargs):
-        self.polygone_line = kwargs['polygone']
-
-        for point in self.polygone_line:
-
-            if self.mirror[0] is not None:
-                point['x'] = 2 * self.mirror[0] - point['x']
-            if self.mirror[1] is not None:
-                point['y'] = 2 * self.mirror[1] - point['y']
+    def _initPolyPoint(self, **kwargs):
+        self.poly_point = PolyPoint(**kwargs)
 
     def _createChildNodes(self, polygone_line):
         nodes = []
@@ -85,7 +70,7 @@ class PolygoneLine(Node):
         render_text += " ["
 
         node_strings = []
-        for node in self.polygone_line:
+        for node in self.poly_point:
             node_position = Point2D(node)
             node_strings.append("[x: {x}, y: {y}]".format(x=node_position.x,
                                                           y=node_position.y))

--- a/KicadModTree/nodes/specialized/PolygoneLine.py
+++ b/KicadModTree/nodes/specialized/PolygoneLine.py
@@ -14,7 +14,7 @@
 # (C) 2016 by Thomas Pointhuber, <thomas.pointhuber@gmx.at>
 
 from KicadModTree.Point import *
-from KicadModTree.PolyPoint import *
+from KicadModTree.PolygonPoints import *
 from KicadModTree.nodes.Node import Node
 from KicadModTree.nodes.base.Line import Line
 
@@ -47,10 +47,10 @@ class PolygoneLine(Node):
 
         self._initPolyPoint(**kwargs)
 
-        self.virtual_childs = self._createChildNodes(self.poly_point)
+        self.virtual_childs = self._createChildNodes(self.nodes)
 
     def _initPolyPoint(self, **kwargs):
-        self.poly_point = PolyPoint(**kwargs)
+        self.nodes = PolygonPoints(**kwargs)
 
     def _createChildNodes(self, polygone_line):
         nodes = []
@@ -70,7 +70,7 @@ class PolygoneLine(Node):
         render_text += " ["
 
         node_strings = []
-        for node in self.poly_point:
+        for node in self.nodes:
             node_position = Point2D(node)
             node_strings.append("[x: {x}, y: {y}]".format(x=node_position.x,
                                                           y=node_position.y))

--- a/KicadModTree/tests/moduletests/__init__.py
+++ b/KicadModTree/tests/moduletests/__init__.py
@@ -14,3 +14,4 @@
 # (C) 2018 by Thomas Pointhuber, <thomas.pointhuber@gmx.at>
 
 from .test_simple_footprints import SimpleFootprintTests
+from .test_kicad5_padshapes import Kicad5PadsTests

--- a/KicadModTree/tests/moduletests/test_kicad5_padshapes.py
+++ b/KicadModTree/tests/moduletests/test_kicad5_padshapes.py
@@ -118,7 +118,6 @@ class Kicad5PadsTests(unittest.TestCase):
         kicad_mod.append(Text(type='reference', text='REF**', at=[0, 0], layer='F.SilkS'))
         kicad_mod.append(Text(type='value', text="round_rect_test", at=[0, 0], layer='F.Fab'))
 
-
         kicad_mod.append(Pad(number=1, type=Pad.TYPE_SMT, shape=Pad.SHAPE_CUSTOM,
                              at=[0, 0], size=[1, 1], layers=Pad.LAYERS_SMT,
                              primitives=[Polygon(nodes=[(-1, -1), (2, -1), (1, 1), (-1, 2)])]
@@ -138,33 +137,35 @@ class Kicad5PadsTests(unittest.TestCase):
         kicad_mod.append(Text(type='reference', text='REF**', at=[0, 0], layer='F.SilkS'))
         kicad_mod.append(Text(type='value', text="round_rect_test", at=[0, 0], layer='F.Fab'))
 
+        kicad_mod.append(
+            Pad(number=1, type=Pad.TYPE_SMT, shape=Pad.SHAPE_CUSTOM,
+                at=[0, 0], size=[1, 1], layers=Pad.LAYERS_SMT,
+                primitives=[
+                     Arc(center=(-1, 0), start=(-1, -0.5), angle=-180, width=0.15),
+                     Line(start=(-1, -0.5), end=(1.25, -0.5), width=0.15),
+                     Line(start=(1.25, 0.5), end=(-1, 0.5), width=0.15),
+                     Line(start=(1.25, -0.5), end=(1.25, 0.5), width=0.15)
+                     ]
+                ))
 
-        kicad_mod.append(Pad(number=1, type=Pad.TYPE_SMT, shape=Pad.SHAPE_CUSTOM,
-                         at=[0, 0], size=[1, 1], layers=Pad.LAYERS_SMT,
-                         primitives=[
-                             Arc(center=(-1, 0), start=(-1, -0.5), angle=-180, width=0.15),
-                             Line(start=(-1, -0.5), end=(1.25, -0.5), width=0.15),
-                             Line(start=(1.25, 0.5), end=(-1, 0.5), width=0.15),
-                             Line(start=(1.25, -0.5), end=(1.25, 0.5), width=0.15)
-                             ]
-                         ))
+        kicad_mod.append(
+            Pad(number=2, type=Pad.TYPE_SMT, shape=Pad.SHAPE_CUSTOM,
+                at=[0, 3], size=[1, 1], layers=Pad.LAYERS_SMT,
+                primitives=[
+                     Arc(center=(-1, 0), start=(-1, -0.5), angle=-180, width=0.15),
+                     Line(start=(-1, -0.5), end=(1.25, -0.5), width=0.15),
+                     Line(start=(1.25, 0.5), end=(-1, 0.5), width=0.15),
+                     Line(start=(1.25, -0.5), end=(1.25, 0.5), width=0.15)
+                     ]
+                ))
 
-        kicad_mod.append(Pad(number=2, type=Pad.TYPE_SMT, shape=Pad.SHAPE_CUSTOM,
-                         at=[0, 3], size=[1, 1], layers=Pad.LAYERS_SMT,
-                         primitives=[
-                             Arc(center=(-1, 0), start=(-1, -0.5), angle=-180, width=0.15),
-                             Line(start=(-1, -0.5), end=(1.25, -0.5), width=0.15),
-                             Line(start=(1.25, 0.5), end=(-1, 0.5), width=0.15),
-                             Line(start=(1.25, -0.5), end=(1.25, 0.5), width=0.15)
-                             ]
-                         ))
-
-        kicad_mod.append(Pad(number=3, type=Pad.TYPE_SMT, shape=Pad.SHAPE_CUSTOM,
-                         at=[0, -3], size=[1, 1], layers=Pad.LAYERS_SMT,
-                         primitives=[
-                                Circle(center=(0.5, 0.5), radius=0.5, width=0.15)
-                             ]
-                         ))
+        kicad_mod.append(
+            Pad(number=3, type=Pad.TYPE_SMT, shape=Pad.SHAPE_CUSTOM,
+                at=[0, -3], size=[1, 1], layers=Pad.LAYERS_SMT,
+                primitives=[
+                        Circle(center=(0.5, 0.5), radius=0.5, width=0.15)
+                     ]
+                ))
 
         file_handler = KicadFileHandler(kicad_mod)
         result = file_handler.serialize(timestamp=0)

--- a/KicadModTree/tests/moduletests/test_kicad5_padshapes.py
+++ b/KicadModTree/tests/moduletests/test_kicad5_padshapes.py
@@ -31,6 +31,55 @@ RESULT_ROUNDRECT_FP = """(module round_rect_test (layer F.Cu) (tedit 0)
   (pad 1 smd roundrect (at 0 0) (size 1 1) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0))
 )"""
 
+RESULT_SIMPLE_POLYGON_PAD = """(module round_rect_test (layer F.Cu) (tedit 0)
+  (descr "A example footprint")
+  (tags example)
+  (fp_text reference REF** (at 0 0) (layer F.SilkS)
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (fp_text value round_rect_test (at 0 0) (layer F.Fab)
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (pad 1 smd custom (at 0 0) (size 1 1) (layers F.Cu F.Mask F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_poly (pts
+         (xy -1 -1) (xy 2 -1) (xy 1 1) (xy -1 2)) (width 0))
+    ))
+)"""
+
+RESULT_SIMPLE_OTHER_CUSTOM_PAD = """(module round_rect_test (layer F.Cu) (tedit 0)
+  (descr "A example footprint")
+  (tags example)
+  (fp_text reference REF** (at 0 0) (layer F.SilkS)
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (fp_text value round_rect_test (at 0 0) (layer F.Fab)
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (pad 1 smd custom (at 0 0) (size 1 1) (layers F.Cu F.Mask F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_arc (start -1 0) (end -1 -0.5) (angle -180) (width 0.15))
+      (gr_line (start -1 -0.5) (end 1.25 -0.5) (width 0.15))
+      (gr_line (start 1.25 0.5) (end -1 0.5) (width 0.15))
+      (gr_line (start 1.25 -0.5) (end 1.25 0.5) (width 0.15))
+    ))
+  (pad 2 smd custom (at 0 3) (size 1 1) (layers F.Cu F.Mask F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_arc (start -1 0) (end -1 -0.5) (angle -180) (width 0.15))
+      (gr_line (start -1 -0.5) (end 1.25 -0.5) (width 0.15))
+      (gr_line (start 1.25 0.5) (end -1 0.5) (width 0.15))
+      (gr_line (start 1.25 -0.5) (end 1.25 0.5) (width 0.15))
+    ))
+  (pad 3 smd custom (at 0 -3) (size 1 1) (layers F.Cu F.Mask F.Paste)
+    (options (clearance outline) (anchor circle))
+    (primitives
+      (gr_circle (center 0.5 0.5) (end 1 0.5) (width 0.15))
+    ))
+)"""
+
 
 class Kicad5PadsTests(unittest.TestCase):
 
@@ -77,5 +126,47 @@ class Kicad5PadsTests(unittest.TestCase):
 
         file_handler = KicadFileHandler(kicad_mod)
         result = file_handler.serialize(timestamp=0)
+        # file_handler.writeFile('test.kicad_mod')
+        self.assertEqual(result, RESULT_SIMPLE_POLYGON_PAD)
+
+    def testCustomPadOtherPrimitives(self):
+        kicad_mod = Footprint("round_rect_test")
+
+        kicad_mod.setDescription("A example footprint")
+        kicad_mod.setTags("example")
+
+        kicad_mod.append(Text(type='reference', text='REF**', at=[0, 0], layer='F.SilkS'))
+        kicad_mod.append(Text(type='value', text="round_rect_test", at=[0, 0], layer='F.Fab'))
+
+
+        kicad_mod.append(Pad(number=1, type=Pad.TYPE_SMT, shape=Pad.SHAPE_CUSTOM,
+                         at=[0, 0], size=[1, 1], layers=Pad.LAYERS_SMT,
+                         primitives=[
+                             Arc(center=(-1, 0), start=(-1, -0.5), angle=-180, width=0.15),
+                             Line(start=(-1, -0.5), end=(1.25, -0.5), width=0.15),
+                             Line(start=(1.25, 0.5), end=(-1, 0.5), width=0.15),
+                             Line(start=(1.25, -0.5), end=(1.25, 0.5), width=0.15)
+                             ]
+                         ))
+
+        kicad_mod.append(Pad(number=2, type=Pad.TYPE_SMT, shape=Pad.SHAPE_CUSTOM,
+                         at=[0, 3], size=[1, 1], layers=Pad.LAYERS_SMT,
+                         primitives=[
+                             Arc(center=(-1, 0), start=(-1, -0.5), angle=-180, width=0.15),
+                             Line(start=(-1, -0.5), end=(1.25, -0.5), width=0.15),
+                             Line(start=(1.25, 0.5), end=(-1, 0.5), width=0.15),
+                             Line(start=(1.25, -0.5), end=(1.25, 0.5), width=0.15)
+                             ]
+                         ))
+
+        kicad_mod.append(Pad(number=3, type=Pad.TYPE_SMT, shape=Pad.SHAPE_CUSTOM,
+                         at=[0, -3], size=[1, 1], layers=Pad.LAYERS_SMT,
+                         primitives=[
+                                Circle(center=(0.5, 0.5), radius=0.5, width=0.15)
+                             ]
+                         ))
+
+        file_handler = KicadFileHandler(kicad_mod)
+        result = file_handler.serialize(timestamp=0)
         file_handler.writeFile('test.kicad_mod')
-        # self.assertEqual(result, RESULT_ROUNDRECT_FP)
+        self.assertEqual(result, RESULT_SIMPLE_OTHER_CUSTOM_PAD)

--- a/KicadModTree/tests/moduletests/test_kicad5_padshapes.py
+++ b/KicadModTree/tests/moduletests/test_kicad5_padshapes.py
@@ -62,16 +62,16 @@ RESULT_SIMPLE_OTHER_CUSTOM_PAD = """(module round_rect_test (layer F.Cu) (tedit 
     (primitives
       (gr_arc (start -1 0) (end -1 -0.5) (angle -180) (width 0.15))
       (gr_line (start -1 -0.5) (end 1.25 -0.5) (width 0.15))
-      (gr_line (start 1.25 0.5) (end -1 0.5) (width 0.15))
       (gr_line (start 1.25 -0.5) (end 1.25 0.5) (width 0.15))
+      (gr_line (start 1.25 0.5) (end -1 0.5) (width 0.15))
     ))
   (pad 2 smd custom (at 0 3) (size 1 1) (layers F.Cu F.Mask F.Paste)
     (options (clearance outline) (anchor circle))
     (primitives
       (gr_arc (start -1 0) (end -1 -0.5) (angle -180) (width 0.15))
       (gr_line (start -1 -0.5) (end 1.25 -0.5) (width 0.15))
-      (gr_line (start 1.25 0.5) (end -1 0.5) (width 0.15))
       (gr_line (start 1.25 -0.5) (end 1.25 0.5) (width 0.15))
+      (gr_line (start 1.25 0.5) (end -1 0.5) (width 0.15))
     ))
   (pad 3 smd custom (at 0 -3) (size 1 1) (layers F.Cu F.Mask F.Paste)
     (options (clearance outline) (anchor circle))
@@ -143,8 +143,8 @@ class Kicad5PadsTests(unittest.TestCase):
                 primitives=[
                      Arc(center=(-1, 0), start=(-1, -0.5), angle=-180, width=0.15),
                      Line(start=(-1, -0.5), end=(1.25, -0.5), width=0.15),
-                     Line(start=(1.25, 0.5), end=(-1, 0.5), width=0.15),
-                     Line(start=(1.25, -0.5), end=(1.25, 0.5), width=0.15)
+                     Line(start=(1.25, -0.5), end=(1.25, 0.5), width=0.15),
+                     Line(start=(1.25, 0.5), end=(-1, 0.5), width=0.15)
                      ]
                 ))
 
@@ -153,9 +153,7 @@ class Kicad5PadsTests(unittest.TestCase):
                 at=[0, 3], size=[1, 1], layers=Pad.LAYERS_SMT,
                 primitives=[
                      Arc(center=(-1, 0), start=(-1, -0.5), angle=-180, width=0.15),
-                     Line(start=(-1, -0.5), end=(1.25, -0.5), width=0.15),
-                     Line(start=(1.25, 0.5), end=(-1, 0.5), width=0.15),
-                     Line(start=(1.25, -0.5), end=(1.25, 0.5), width=0.15)
+                     PolygoneLine(nodes=[(-1, -0.5), (1.25, -0.5), (1.25, 0.5), (-1, 0.5)], width=0.15)
                      ]
                 ))
 

--- a/KicadModTree/tests/moduletests/test_kicad5_padshapes.py
+++ b/KicadModTree/tests/moduletests/test_kicad5_padshapes.py
@@ -59,3 +59,23 @@ class Kicad5PadsTests(unittest.TestCase):
         result = file_handler.serialize(timestamp=0)
         # file_handler.writeFile('test.kicad_mod')
         self.assertEqual(result, RESULT_ROUNDRECT_FP)
+
+    def testPolygonPad(self):
+        kicad_mod = Footprint("round_rect_test")
+
+        kicad_mod.setDescription("A example footprint")
+        kicad_mod.setTags("example")
+
+        kicad_mod.append(Text(type='reference', text='REF**', at=[0, 0], layer='F.SilkS'))
+        kicad_mod.append(Text(type='value', text="round_rect_test", at=[0, 0], layer='F.Fab'))
+
+
+        kicad_mod.append(Pad(number=1, type=Pad.TYPE_SMT, shape=Pad.SHAPE_CUSTOM,
+                             at=[0, 0], size=[1, 1], layers=Pad.LAYERS_SMT,
+                             primitives=[Polygon(nodes=[(-1, -1), (2, -1), (1, 1), (-1, 2)])]
+                             ))
+
+        file_handler = KicadFileHandler(kicad_mod)
+        result = file_handler.serialize(timestamp=0)
+        file_handler.writeFile('test.kicad_mod')
+        # self.assertEqual(result, RESULT_ROUNDRECT_FP)

--- a/KicadModTree/tests/moduletests/test_kicad5_padshapes.py
+++ b/KicadModTree/tests/moduletests/test_kicad5_padshapes.py
@@ -99,6 +99,7 @@ RESULT_CUT_POLYGON = """(module round_rect_test (layer F.Cu) (tedit 0)
     ))
 )"""
 
+
 class Kicad5PadsTests(unittest.TestCase):
 
     def testRoundRectPad(self):
@@ -185,7 +186,7 @@ class Kicad5PadsTests(unittest.TestCase):
 
         file_handler = KicadFileHandler(kicad_mod)
         result = file_handler.serialize(timestamp=0)
-        #file_handler.writeFile('test.kicad_mod')
+        # file_handler.writeFile('test.kicad_mod')
         self.assertEqual(result, RESULT_SIMPLE_OTHER_CUSTOM_PAD)
 
     def testCutPolygon(self):
@@ -208,5 +209,5 @@ class Kicad5PadsTests(unittest.TestCase):
 
         file_handler = KicadFileHandler(kicad_mod)
         result = file_handler.serialize(timestamp=0)
-        file_handler.writeFile('test.kicad_mod')
+        # file_handler.writeFile('test.kicad_mod')
         self.assertEqual(result, RESULT_CUT_POLYGON)

--- a/KicadModTree/tests/moduletests/test_kicad5_padshapes.py
+++ b/KicadModTree/tests/moduletests/test_kicad5_padshapes.py
@@ -26,9 +26,9 @@ RESULT_ROUNDRECT_FP = """(module round_rect_test (layer F.Cu) (tedit 0)
   (fp_text value round_rect_test (at 0 0) (layer F.Fab)
     (effects (font (size 1 1) (thickness 0.15)))
   )
-  (pad 3 smd roundrect (at 5 0 45) (size 1 1) (layers F.Cu F.Mask F.Paste)(roundrect_rratio 0.1))
-  (pad 2 smd roundrect (at -5 0) (size 1 1) (layers F.Cu F.Mask F.Paste)(roundrect_rratio 0.5))
-  (pad 1 smd roundrect (at 0 0) (size 1 1) (layers F.Cu F.Mask F.Paste)(roundrect_rratio 0))
+  (pad 3 smd roundrect (at 5 0 45) (size 1 1) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0.1))
+  (pad 2 smd roundrect (at -5 0) (size 1 1) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0.5))
+  (pad 1 smd roundrect (at 0 0) (size 1 1) (layers F.Cu F.Mask F.Paste) (roundrect_rratio 0))
 )"""
 
 
@@ -44,14 +44,18 @@ class Kicad5PadsTests(unittest.TestCase):
         kicad_mod.append(Text(type='value', text="round_rect_test", at=[0, 0], layer='F.Fab'))
 
         kicad_mod.append(Pad(number=3, type=Pad.TYPE_SMT, shape=Pad.SHAPE_ROUNDRECT,
-                             at=[5, 0], rotation=45, size=[1, 1], layers=Pad.LAYERS_SMT, radius_ratio = 0.1))
+                             at=[5, 0], rotation=45, size=[1, 1], layers=Pad.LAYERS_SMT,
+                             radius_ratio=0.1))
 
         kicad_mod.append(Pad(number=2, type=Pad.TYPE_SMT, shape=Pad.SHAPE_ROUNDRECT,
-                             at=[-5, 0], size=[1, 1], layers=Pad.LAYERS_SMT, radius_ratio = 0.5))
+                             at=[-5, 0], size=[1, 1], layers=Pad.LAYERS_SMT,
+                             radius_ratio=0.5))
 
         kicad_mod.append(Pad(number=1, type=Pad.TYPE_SMT, shape=Pad.SHAPE_ROUNDRECT,
-                             at=[0, 0], size=[1, 1], layers=Pad.LAYERS_SMT, radius_ratio = 0))
+                             at=[0, 0], size=[1, 1], layers=Pad.LAYERS_SMT,
+                             radius_ratio=0))
+
         file_handler = KicadFileHandler(kicad_mod)
         result = file_handler.serialize(timestamp=0)
-        print(result)
+        # file_handler.writeFile('test.kicad_mod')
         self.assertEqual(result, RESULT_ROUNDRECT_FP)

--- a/KicadModTree/tests/moduletests/test_kicad5_padshapes.py
+++ b/KicadModTree/tests/moduletests/test_kicad5_padshapes.py
@@ -1,0 +1,57 @@
+# KicadModTree is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# KicadModTree is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kicad-footprint-generator. If not, see < http://www.gnu.org/licenses/ >.
+#
+# (C) 2018 by Thomas Pointhuber, <thomas.pointhuber@gmx.at>
+
+import unittest
+
+from KicadModTree import *
+
+RESULT_ROUNDRECT_FP = """(module round_rect_test (layer F.Cu) (tedit 0)
+  (descr "A example footprint")
+  (tags example)
+  (fp_text reference REF** (at 0 0) (layer F.SilkS)
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (fp_text value round_rect_test (at 0 0) (layer F.Fab)
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  (pad 3 smd roundrect (at 5 0 45) (size 1 1) (layers F.Cu F.Mask F.Paste)(roundrect_rratio 0.1))
+  (pad 2 smd roundrect (at -5 0) (size 1 1) (layers F.Cu F.Mask F.Paste)(roundrect_rratio 0.5))
+  (pad 1 smd roundrect (at 0 0) (size 1 1) (layers F.Cu F.Mask F.Paste)(roundrect_rratio 0))
+)"""
+
+
+class Kicad5PadsTests(unittest.TestCase):
+
+    def testRoundRectPad(self):
+        kicad_mod = Footprint("round_rect_test")
+
+        kicad_mod.setDescription("A example footprint")
+        kicad_mod.setTags("example")
+
+        kicad_mod.append(Text(type='reference', text='REF**', at=[0, 0], layer='F.SilkS'))
+        kicad_mod.append(Text(type='value', text="round_rect_test", at=[0, 0], layer='F.Fab'))
+
+        kicad_mod.append(Pad(number=3, type=Pad.TYPE_SMT, shape=Pad.SHAPE_ROUNDRECT,
+                             at=[5, 0], rotation=45, size=[1, 1], layers=Pad.LAYERS_SMT, radius_ratio = 0.1))
+
+        kicad_mod.append(Pad(number=2, type=Pad.TYPE_SMT, shape=Pad.SHAPE_ROUNDRECT,
+                             at=[-5, 0], size=[1, 1], layers=Pad.LAYERS_SMT, radius_ratio = 0.5))
+
+        kicad_mod.append(Pad(number=1, type=Pad.TYPE_SMT, shape=Pad.SHAPE_ROUNDRECT,
+                             at=[0, 0], size=[1, 1], layers=Pad.LAYERS_SMT, radius_ratio = 0))
+        file_handler = KicadFileHandler(kicad_mod)
+        result = file_handler.serialize(timestamp=0)
+        print(result)
+        self.assertEqual(result, RESULT_ROUNDRECT_FP)


### PR DESCRIPTION
**Work in progress** Feedback welcome

ToDo:
- [x] Add pad type roundrect with its additional attribute round radius
   - [x] Add initializers and pad type to Pad node
   - [x] Add support in pad serializer
      - My kicad nightly version is a bit inconsistent with where it puts whitespace in the fileformat. It does not put a space between layer info and round rect radius ratio. (Ignored for now.)
- [x] Add support for graphical polygon
   - [x] Find out if it is feasible to refactor the polyline node such that it and the graphical polygon can share code?
       - It is possible. Is now implemented
   - [x] Implement node for graphical polygon
   - [x] Implement serializer
- [x] Add support for custom pads
   - [x] Add support in pad node
   - [x] Add support in serializer (re use serializer of other nodes)
      - [x] polygon
      - [x] line
      - [x] arc
      - [x] circle
- [ ] Advanced features
  - [ ] cut, combine polygons (The later is not really necessary, but could result in nicer looking files)
     - [x] smaller polygon fully within larger polygon 
        - [ ] raise exception if not
     - [ ] polygons only need to partly overlap
         - [ ] check if the resulting polygon is still a single polygon (fail otherwise)
  - [x] support specialized nodes
    - [x] PolygoneLine
    - [x] Filled Rect (Filled arcs and circles might also be a good idea to have.)
  - [ ] check that all primitives intersect each other ("orphaned" primitives are not allowed)
    - kicad can read files that have pads with orphaned primitives. But i assume there is a reason why the devs build in a function not to allow making such a pad(Maybe DRC can not deal with it)