### PR TITLE
Update scripts for reflecting the recent splitting of some of them

### DIFF
--- a/scripts/Capacitors_THT/make_Capacitors_THT.py
+++ b/scripts/Capacitors_THT/make_Capacitors_THT.py
@@ -26,7 +26,7 @@ from footprint_scripts_resistorlike import *
 if __name__ == '__main__':
     R_POW = 0
     specialtags=["Capacitor"]
-    
+
     ###########################################################
     # rectangular capacitors
     ###########################################################
@@ -43,7 +43,7 @@ if __name__ == '__main__':
 
         [  10,   3,  8.5,    7.5,      1,              ["FKS3","FKP3"],                      "http://www.wima.com/EN/WIMA_FKS_3.pdf"],
         [  10,   4,  8.5,    7.5,      1,              ["FKS3","FKP3"],                      "http://www.wima.com/EN/WIMA_FKS_3.pdf"],
-        
+
         [  18,   5,   15,     15,    1.2,              ["FKS3","FKP3"],                          "http://www.wima.com/EN/WIMA_FKS_3.pdf"],
         [  18,   6,   15,     15,    1.2,              ["FKS3","FKP3"],                          "http://www.wima.com/EN/WIMA_FKS_3.pdf"],
         [  18,   7,   15,     15,    1.2,              ["FKS3","FKP3"],                          "http://www.wima.com/EN/WIMA_FKS_3.pdf"],
@@ -78,7 +78,7 @@ if __name__ == '__main__':
         [  33,  13,   26,   27.5,    1.2,              ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
         [  33,  15,   26,   27.5,    1.2,              ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
         [  33,  20,   26,   27.5,    1.2,              ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
-        
+
         [41.5,   9,   44,   37.5,      1.4,            ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
         [41.5,  11,   44,   37.5,      1.4,            ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
         [41.5,  13,   44,   37.5,      1.4,            ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
@@ -92,14 +92,14 @@ if __name__ == '__main__':
         [41.5,  40,   44,   37.5,      1.4,            ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
 
 
-        
-               
+
+
         #[  56,  19, 48.5,      1.1,            ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
         #[  56,  23, 48.5,      1.1,            ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
         #[  56,  27, 48.5,      1.1,            ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
         #[  56,  33, 48.5,      1.1,            ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
         #[  56,  37, 48.5,      1.1,            ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
-        
+
         #[  57,  25, 52.5,      1.1,            ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
         #[  57,  45, 52.5,      1.1,            ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
         #[  57,  50, 52.5,      1.1,            ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
@@ -125,7 +125,7 @@ if __name__ == '__main__':
         [ 4.6, 3.8,    7,    2.5,      0.7,              ["MKS02", "FKP02"],                     "http://www.wima.de/DE/WIMA_MKS_02.pdf"],
         [ 4.6, 3.0,    7,    2.5,      0.7,              ["MKS02", "FKP02"],                     "http://www.wima.de/DE/WIMA_MKS_02.pdf"],
         [ 4.6,   2,    7,    2.5,      0.7,              ["MKS02", "FKP02"],                     "http://www.wima.de/DE/WIMA_MKS_02.pdf"],
-                                                                                                                              
+
         [ 7.2, 2.5,    9,      5,      0.8,              ["FKS2","FKP2","MKS2","MKP2"],                      "http://www.wima.com/EN/WIMA_FKS_2.pdf"],
         [ 7.2, 3.0,    9,      5,      0.8,              ["FKS2","FKP2","MKS2","MKP2"],                      "http://www.wima.com/EN/WIMA_FKS_2.pdf"],
         [ 7.2, 3.5,    9,      5,      0.8,              ["FKS2","FKP2","MKS2","MKP2"],                      "http://www.wima.com/EN/WIMA_FKS_2.pdf"],
@@ -145,7 +145,7 @@ if __name__ == '__main__':
         [10.3, 7.2,    9,    7.5,        1,              ["MKS4"],                          "http://www.wima.com/EN/WIMA_MKS_4.pdf"],
 
     ]
-    
+
     for w in [2.5, 2.6, 2.7, 3.2, 3.3, 3.4, 3.6, 3.8, 3.9, 4.0, 4.2, 4.9, 5.1, 5.7, 6.4, 6.7, 7.7, 8.5, 9.5, 9.8]:
         caps+=[   9, w,  8, 7.5,      0.8,            ["MKT"],                           "https://en.tdk.eu/inf/20/20/db/fc_2009/MKT_B32560_564.pdf"],
 
@@ -181,7 +181,7 @@ if __name__ == '__main__':
         makeResistorRadial(seriesname=seriesname, rm=rm, w=w, h=d, ddrill=ddrill, R_POW=R_POW,
                                     type=type, w2=w2, x_3d=[0, 0, 0], s_3d=[1, 1, 1], has3d=1,
                                     specialfpname="", add_description=add_description, name_additions=name_additions,
-                                    specialtags=specialtags, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT", script3d=scr, height3d=h3d)
+                                    specialtags=specialtags, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT_Rectangular", script3d=scr, height3d=h3d)
 
 
     ###########################################################
@@ -208,7 +208,7 @@ if __name__ == '__main__':
         makeResistorRadial(seriesname=seriesname, rm=rm, rm2=rm2, w=w, h=d, ddrill=ddrill, R_POW=R_POW,
                                     type=type, w2=w2, x_3d=[0, 0, 0], s_3d=[1, 1, 1], has3d=1,
                                     specialfpname="", add_description=add_description, name_additions=name_additions,
-                                    specialtags=specialtags, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT", script3d=scr, height3d=10)
+                                    specialtags=specialtags, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT_Rectangular", script3d=scr, height3d=10)
 
 
 
@@ -260,7 +260,7 @@ if __name__ == '__main__':
         [ 16.0,5.0,  7.5,        1,                          [],                              "http://www.vishay.com/docs/28535/vy2series.pdf"],
         [ 16.0,5.0,   10,        1,                          [],                              "http://www.vishay.com/docs/28535/vy2series.pdf"],
     ]
-    
+
     script3mkt="CQ_params_C_Disc.py"
 
     for c in caps:
@@ -276,18 +276,18 @@ if __name__ == '__main__':
         makeResistorRadial(seriesname=seriesname, rm=rm, w=w, h=d, ddrill=ddrill, R_POW=R_POW,
                            type=type, w2=w2, x_3d=[0, 0, 0], s_3d=[1, 1, 1], has3d=1,
                            specialfpname="", add_description=add_description, name_additions=name_additions,
-                           specialtags=specialtags, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT", script3d=script3mkt)
+                           specialtags=specialtags, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT_Round", script3d=script3mkt)
 
 
 
-    
-    
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
+
+
     ###########################################################
     # axial capacitors
     ###########################################################
@@ -301,14 +301,14 @@ if __name__ == '__main__':
         makeResistorAxialHorizontal(seriesname=seriesname, rm=rm, rmdisp=rm, w=w, d=d, ddrill=ddrill, R_POW=R_POW,
                                     type=type, d2=d2, x_3d=[0, 0, 0], s_3d=[1, 1, 1], has3d=1,
                                     specialfpname="", add_description=add_description, name_additions=name_additions,
-                                    specialtags=name_additions, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT", script3d=scriptaxh)
+                                    specialtags=name_additions, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT_Round", script3d=scriptaxh)
 
     seriesname = "Axial"; w = 5.1; d = 3.1; ddrill = 0.8; R_POW = 0; add_description = "http://www.vishay.com/docs/45231/arseries.pdf"; name_additions = []
     for rm in [7.5, 10, 12.5, 15]:
         makeResistorAxialHorizontal(seriesname=seriesname, rm=rm, rmdisp=rm, w=w, d=d, ddrill=ddrill, R_POW=R_POW,
                                     type=type, d2=d2, x_3d=[0, 0, 0], s_3d=[1, 1, 1], has3d=1,
                                     specialfpname="", add_description=add_description, name_additions=name_additions,
-                                    specialtags=name_additions, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT", script3d=scriptaxh)
+                                    specialtags=name_additions, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT_Round", script3d=scriptaxh)
     for w in [12,17,19,22]:
         if w == 12:
             rms = [15, 20]
@@ -328,31 +328,31 @@ if __name__ == '__main__':
                 makeResistorAxialHorizontal(seriesname=seriesname, rm=rm, rmdisp=rm, w=w, d=d, ddrill=ddrill, R_POW=R_POW,
                                             type=type, d2=d2, x_3d=[0, 0, 0], s_3d=[1, 1, 1], has3d=1,
                                             specialfpname="", add_description=add_description, name_additions=name_additions,
-                                            specialtags=name_additions, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT", script3d=scriptaxh)
+                                            specialtags=name_additions, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT_Round", script3d=scriptaxh)
     seriesname = "Axial"; w = 12; d = 6.5; ddrill = 0.8; R_POW = 0; add_description = "http://cdn-reichelt.de/documents/datenblatt/B300/STYROFLEX.pdf"; name_additions = []
     for rm in [15,20]:
         makeResistorAxialHorizontal(seriesname=seriesname, rm=rm, rmdisp=rm, w=w, d=d, ddrill=ddrill, R_POW=R_POW,
                                     type=type, d2=d2, x_3d=[0, 0, 0], s_3d=[1, 1, 1], has3d=1,
                                     specialfpname="", add_description=add_description, name_additions=name_additions,
-                                    specialtags=name_additions, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT", script3d=scriptaxh)
+                                    specialtags=name_additions, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT_Round", script3d=scriptaxh)
     seriesname = "Axial"; w = 12; d = 7.5; ddrill = 0.8; R_POW = 0; add_description = "http://cdn-reichelt.de/documents/datenblatt/B300/STYROFLEX.pdf"; name_additions = []
     for rm in [15,20]:
         makeResistorAxialHorizontal(seriesname=seriesname, rm=rm, rmdisp=rm, w=w, d=d, ddrill=ddrill, R_POW=R_POW,
                                     type=type, d2=d2, x_3d=[0, 0, 0], s_3d=[1, 1, 1], has3d=1,
                                     specialfpname="", add_description=add_description, name_additions=name_additions,
-                                    specialtags=name_additions, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT", script3d=scriptaxh)
+                                    specialtags=name_additions, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT_Round", script3d=scriptaxh)
     seriesname = "Axial"; w = 12; d = 8.5; ddrill = 0.8; R_POW = 0; add_description = "http://cdn-reichelt.de/documents/datenblatt/B300/STYROFLEX.pdf"; name_additions = []
     for rm in [15,20]:
         makeResistorAxialHorizontal(seriesname=seriesname, rm=rm, rmdisp=rm, w=w, d=d, ddrill=ddrill, R_POW=R_POW,
                                     type=type, d2=d2, x_3d=[0, 0, 0], s_3d=[1, 1, 1], has3d=1,
                                     specialfpname="", add_description=add_description, name_additions=name_additions,
-                                    specialtags=name_additions, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT", script3d=scriptaxh)
+                                    specialtags=name_additions, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT_Round", script3d=scriptaxh)
     seriesname = "Axial"; w = 12; d = 9.5; ddrill = 0.8; R_POW = 0; add_description = "http://cdn-reichelt.de/documents/datenblatt/B300/STYROFLEX.pdf"; name_additions = []
     for rm in [15,20]:
         makeResistorAxialHorizontal(seriesname=seriesname, rm=rm, rmdisp=rm, w=w, d=d, ddrill=ddrill, R_POW=R_POW,
                                     type=type, d2=d2, x_3d=[0, 0, 0], s_3d=[1, 1, 1], has3d=1,
                                     specialfpname="", add_description=add_description, name_additions=name_additions,
-                                    specialtags=name_additions, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT", script3d=scriptaxh)
+                                    specialtags=name_additions, classname="C", lib_name="${KISYS3DMOD}/Capacitor_THT_Round", script3d=scriptaxh)
 
 
 
@@ -384,9 +384,9 @@ if __name__ == '__main__':
         [      9.0,           5,      0.8,                          [],                "http://cdn-reichelt.de/documents/datenblatt/B300/TANTAL-TB-Serie%23.pdf"],
         [     10.5,         2.5,      0.8,                          [],                "http://cdn-reichelt.de/documents/datenblatt/B300/TANTAL-TB-Serie%23.pdf"],
         [     10.5,           5,      0.8,                          [],                "http://cdn-reichelt.de/documents/datenblatt/B300/TANTAL-TB-Serie%23.pdf"],
-        
+
     ]
-    
+
     scripttan="CQ_params_CP_Tantal.py"
     with open(scripttan, "w") as myfile:
         myfile.write("#\n# SCRIPT to generate 3D models\n#\n\n")
@@ -404,7 +404,7 @@ if __name__ == '__main__':
         makeResistorRadial(seriesname=seriesname, rm=rm, w=d, h=d, ddrill=ddrill, R_POW=R_POW,
                            type=type, w2=w2, x_3d=[0, 0, 0], s_3d=[1, 1, 1], has3d=1,
                            specialfpname="", add_description=add_description, name_additions=name_additions,
-                           specialtags=specialtags, classname="CP", lib_name="${KISYS3DMOD}/Capacitor_THT", deco=deco, script3d=scripttan)
+                           specialtags=specialtags, classname="CP", lib_name="${KISYS3DMOD}/Capacitor_THT_Round", deco=deco, script3d=scripttan)
 
     ###########################################################
     # radial electrolytic capacitors
@@ -469,7 +469,7 @@ if __name__ == '__main__':
         makeResistorRadial(seriesname=seriesname, rm=rm, rm2=rm2, w=d, h=d, ddrill=ddrill, R_POW=R_POW,
                            type=type, w2=w2, x_3d=[0, 0, 0], s_3d=[1, 1, 1], has3d=1,
                            specialfpname="", add_description=add_description, name_additions=name_additions,
-                           specialtags=special_tags, classname="CP", lib_name="${KISYS3DMOD}/Capacitor_THT", deco=deco,
+                           specialtags=special_tags, classname="CP", lib_name="${KISYS3DMOD}/Capacitor_THT_Round", deco=deco,
                            script3d=scriptcprad, height3d=h3d)
 
     ###########################################################
@@ -510,7 +510,7 @@ if __name__ == '__main__':
         makeResistorRadial(seriesname=seriesname, rm=rm, rm2=rm2, w=d, h=d, ddrill=ddrill, R_POW=R_POW,
                            type=type, w2=w2, x_3d=[0, 0, 0], s_3d=[1, 1, 1], has3d=1,
                            specialfpname="", add_description=add_description, name_additions=name_additions,
-                           specialtags=special_tags, classname="CP", lib_name="${KISYS3DMOD}/Capacitor_THT", deco=deco,
+                           specialtags=special_tags, classname="CP", lib_name="${KISYS3DMOD}/Capacitor_THT_Round", deco=deco,
                            script3d=scriptcprad3p, height3d=h3d, additionalPins=ap)
 
 
@@ -595,4 +595,4 @@ if __name__ == '__main__':
         makeResistorAxialHorizontal(seriesname=seriesname, rm=rm, rmdisp=rm, w=l, d=d, ddrill=ddrill, R_POW=R_POW,
                            type=type, x_3d=[0, 0, 0], s_3d=[1, 1, 1], has3d=1,
                            specialfpname="", add_description=add_description, name_additions=name_additions,
-                           specialtags=special_tags, classname="CP", lib_name="${KISYS3DMOD}/Capacitor_THT", deco=deco, script3d=scriptcpax)
+                           specialtags=special_tags, classname="CP", lib_name="${KISYS3DMOD}/Capacitor_THT_Round", deco=deco, script3d=scriptcpax)

--- a/scripts/Connector/Connector_PhoenixContact/config_phoenix_KLCv3.0.yaml
+++ b/scripts/Connector/Connector_PhoenixContact/config_phoenix_KLCv3.0.yaml
@@ -2,7 +2,7 @@
 # using this config file will create KLCv2.x compatible footprints.
 
 #lib_name_format_str: "Conn_Phoenix_{series:s}-{style:%s}_{pitch:.2f}"
-lib_name_format_str: "Connector_Phoenix_{series:s}"
+lib_name_format_str: "Connector_Phoenix_{series:s}{suffix:s}"
 manufacturer: "PhoenixContact"
 
 

--- a/scripts/Connector/Connector_PhoenixContact/mc.py
+++ b/scripts/Connector/Connector_PhoenixContact/mc.py
@@ -25,7 +25,9 @@ def generate_one_footprint(motel, params, configuration):
     # Through-hole type shrouded header, Top entry type
     subseries, connector_style = params.series_name.split('-')
     pitch_mpn = '-{:g}'.format(params.pin_pitch)
-    lib_name = configuration['lib_name_format_str'].format(series=series[0], style=series[1], pitch=params.pin_pitch)
+    suffix = '_HighVoltage' if params.pin_pitch >= 5.08 else ''
+    lib_name = configuration['lib_name_format_str'].format(series=series[0],
+        style=series[1], pitch=params.pin_pitch, suffix=suffix)
     mpn = configuration['mpn_format_string'].format(subseries=subseries, style = connector_style,
         rating=series[1], num_pins=params.num_pins, pitch=pitch_mpn)
     footprint_name = configuration['fp_name_format_string'].format(man = configuration['manufacturer'],

--- a/scripts/Connector/Connector_PhoenixContact/mstb.py
+++ b/scripts/Connector/Connector_PhoenixContact/mstb.py
@@ -29,7 +29,9 @@ def generate_one_footprint(model, params, configuration):
         pitch_mpn = '-5,08'
     elif params.pin_pitch == 7.62:
         pitch_mpn = '-7,62'
-    lib_name = configuration['lib_name_format_str'].format(series=series[0], style=series[1], pitch=params.pin_pitch)
+    lib_series = 'GMSTB' if params.pin_pitch >= 7.5 else 'MSTB'
+    lib_name = configuration['lib_name_format_str'].format(series=lib_series,
+        style=series[1], pitch=params.pin_pitch, suffix='')
     mpn = configuration['mpn_format_string'].format(subseries=subseries, style = connector_style,
         rating=series[1], num_pins=params.num_pins, pitch=pitch_mpn)
     footprint_name = configuration['fp_name_format_string'].format(man = configuration['manufacturer'], series = series[0], mpn = mpn, num_rows = 1,

--- a/scripts/Connector/Connector_Samtec/conn_samtec_hle.py
+++ b/scripts/Connector/Connector_Samtec/conn_samtec_hle.py
@@ -30,7 +30,7 @@ from KicadModTree import *
 sys.path.append(os.path.join(sys.path[0], "..", "..", "tools"))  # load parent path of tools
 from footprint_text_fields import addTextFields
 
-series = ''
+series = 'HLE'
 series_long = 'HLE .100" Tiger Beam Cost-effective Single Beam Socket Strip'
 manufacturer = 'Samtec'
 orientation = 'H'
@@ -59,7 +59,7 @@ pad_pitch_y_smd_be = 5.44
 pad_pitch_y_pe = 7.62
 
 pad_to_pad_clearance = 1.2
-max_annular_ring = 0.3 
+max_annular_ring = 0.3
 min_annular_ring = 0.15
 
 variant_params = {
@@ -156,7 +156,7 @@ def generate_one_footprint(pins_per_row, variant, configuration):
     orientation_str = configuration['orientation_options'][orientation]
     footprint_name = configuration['fp_name_format_string'].format(
         man=manufacturer,
-        series=series,
+        series='',
         mpn=mpn,
         num_rows=number_of_rows,
         pins_per_row=pins_per_row,
@@ -169,8 +169,8 @@ def generate_one_footprint(pins_per_row, variant, configuration):
     kicad_mod.setDescription("{manufacturer} {series}, {mpn}{alt_mpn}, {pins_per_row} Pins per row ({datasheet}), generated with kicad-footprint-generator".format(
         manufacturer = manufacturer,
         series = series_long,
-        mpn = mpn, 
-        alt_mpn = ' (compatible alternatives: {})'.format(', '.join(alt_mpn)) if len(alt_mpn) > 0 else "", 
+        mpn = mpn,
+        alt_mpn = ' (compatible alternatives: {})'.format(', '.join(alt_mpn)) if len(alt_mpn) > 0 else "",
         pins_per_row = pins_per_row,
         datasheet = ', '.join(variant_params[variant]['datasheets'])))
 
@@ -182,7 +182,7 @@ def generate_one_footprint(pins_per_row, variant, configuration):
         kicad_mod.setAttribute('smd')
 
     ########################## Dimensions ##############################
-    
+
     # Solder pads pitch
     pad_pitch_x = pitch
     pad_pitch_y = variant_params[variant].get('pad_pitch_y', pitch)
@@ -222,13 +222,13 @@ def generate_one_footprint(pins_per_row, variant, configuration):
         pad_layer = Pad.LAYERS_THT
         pad_drill = variant_params[variant].get('pad_drill', None)
         pad_type = Pad.TYPE_THT
-      
+
         pad_size = [pitch - pad_to_pad_clearance, pad_drill + 2*max_annular_ring]
         if pad_size[0] - pad_drill < 2*min_annular_ring:
             pad_size[0] = pad_drill + 2*min_annular_ring
         if pad_size[0] - pad_drill > 2*max_annular_ring:
             pad_size[0] = pad_drill + 2*max_annular_ring
-        
+
         if pad_size[1] - pad_drill < 2*min_annular_ring:
             pad_size[1] = pad_drill + 2*min_annular_ring
         if pad_size[1] - pad_drill > 2*max_annular_ring:
@@ -277,7 +277,7 @@ def generate_one_footprint(pins_per_row, variant, configuration):
                 kicad_mod.append(Pad(at=[pin1_x+x*pitch, pin_row1_y+y*pitch], number="",
                     type=Pad.TYPE_NPTH, shape=Pad.SHAPE_CIRCLE, size=npth_drill,
                     drill=npth_drill, layers=Pad.LAYERS_NPTH))
-        
+
     # Pads
     kicad_mod.append(PadArray(start=[pad1_x, pad_row1_y], initial=1,
         pincount=pins_per_row, increment=2,  x_spacing=pitch, size=pad_size,
@@ -364,7 +364,7 @@ def generate_one_footprint(pins_per_row, variant, configuration):
             {'x': body_edge['left'] - s_offset, 'y': body_edge['top'] - s_offset},
         ]
         kicad_mod.append(PolygoneLine(polygone=poly_s,
-            width=configuration['silk_line_width'], layer="F.SilkS"))        
+            width=configuration['silk_line_width'], layer="F.SilkS"))
 
     # ############################ CrtYd ##################################
 
@@ -394,8 +394,10 @@ def generate_one_footprint(pins_per_row, variant, configuration):
     ##################### Output and 3d model ############################
 
     model3d_path_prefix = configuration.get('3d_model_prefix','${KISYS3DMOD}/')
+    lib_name_suffix = '_SMD' if is_smd else '_THT'
 
-    lib_name = configuration['lib_name_format_string'].format(series=series, man=manufacturer)
+    lib_name = configuration['lib_name_format_string_full'].format(series=series, man=manufacturer, suffix=lib_name_suffix)
+
     model_name = '{model3d_path_prefix:s}{lib_name:s}.3dshapes/{fp_name:s}.wrl'.format(
         model3d_path_prefix=model3d_path_prefix, lib_name=lib_name, fp_name=footprint_name)
     kicad_mod.append(Model(filename=model_name))

--- a/scripts/Connector/conn_config_KLCv3.yaml
+++ b/scripts/Connector/conn_config_KLCv3.yaml
@@ -12,7 +12,7 @@ entry_direction:
 #keyword_fp_string: 'connector {man:s} {series:s} {mpn:s} {entry:s} {orientation:s}'
 keyword_fp_string: 'connector {man:s} {series:s} {entry:s}'
 
-#lib_name_format_string: 'Conn_{man:s}_{series:s}'
+lib_name_format_string_full: 'Conn_{man:s}_{series:s}{suffix:s}'
 lib_name_format_string: 'Connector_{man:s}'
 lib_name_specific_function_format_string: 'Connector_{category:s}'
 mounting_pad_number: "MP"


### PR DESCRIPTION
We noticed that some of the conector footprint libs over at the official lib have too many footprints in them. For this reason we decided to split them. This PR updates the scripts to include this change as well.

Footprint PRs:
- https://github.com/KiCad/kicad-footprints/pull/546
- https://github.com/KiCad/kicad-footprints/pull/548
- https://github.com/KiCad/kicad-footprints/pull/547
- https://github.com/KiCad/kicad-footprints/pull/550