### PR TITLE
Add newer ipc definitions for smd chip packages

### DIFF
--- a/scripts/SMD_chip_package_rlc-etc/SMD_chip_package_rlc-etc.py
+++ b/scripts/SMD_chip_package_rlc-etc/SMD_chip_package_rlc-etc.py
@@ -298,6 +298,7 @@ if __name__ == "__main__":
                         help='list of files holding information about what devices should be created.')
     parser.add_argument('--global_config', type=str, nargs='?', help='the config file defining how the footprint will look like. (KLC)', default='../tools/global_config_files/config_KLCv3.0.yaml')
     parser.add_argument('--series_config', type=str, nargs='?', help='the config file defining series parameters.', default='config_KLCv3.0.yaml')
+    parser.add_argument('--ipc_definition', type=str, nargs='?', help='the ipc definition file', default='ipc7351B_smd_two_terminal_chip.yaml')
     args = parser.parse_args()
 
     with open(args.global_config, 'r') as config_stream:
@@ -312,6 +313,7 @@ if __name__ == "__main__":
         except yaml.YAMLError as exc:
             print(exc)
     args = parser.parse_args()
+    configuration['ipc_definition'] = args.ipc_definition
 
     for filepath in args.files:
         two_terminal_smd =TwoTerminalSMDchip(filepath, configuration)

--- a/scripts/SMD_chip_package_rlc-etc/config_KLCv3.0.yaml
+++ b/scripts/SMD_chip_package_rlc-etc/config_KLCv3.0.yaml
@@ -3,7 +3,6 @@
 
 placement_tolerance: 0.05
 manufacturing_tolerance: 0.1
-ipc_definition: 'ipc_smd_two_terminal_chip.yaml'
 
 fp_name_format_string: '{prefix:s}_{code_imperial:s}_{code_metric:s}Metric{suffix:s}'
 fp_name_non_metric_format_string: '{prefix:s}_{code_imperial:s}{suffix:s}'

--- a/scripts/SMD_chip_package_rlc-etc/ipc7351B_smd_two_terminal_chip.yaml
+++ b/scripts/SMD_chip_package_rlc-etc/ipc7351B_smd_two_terminal_chip.yaml
@@ -8,7 +8,7 @@
 # ----------+---------+-----------+---------+-
 # Toe (JT)  |  0.1    |  0.2      |  0.3    | 0.02
 # Heel (JH) |  0.0    |  0.0      |  0.0    | 0.02
-# Side (JS) |  0.05   |  0.0      |  -0.05  | 0.02
+# Side (JS) |  -0.05  |  0.0      |  0.05   | 0.02
 # Courtyard |  0.1    |  0.15     |  0.2    |
 
 ipc_spec_smaller_0603:
@@ -99,10 +99,10 @@ ipc_spec_tantalumn:
         side: 0.05
 
 # castellated
-# The document is a bit strange with the castelated definitions.
+# The document is a bit strange with the castellated definitions.
 # They seem to exchange the toe and heel fillet.
-# For normall square ends the toe fillet is towards the outside = Z measurement
-# But for castelated they tell us that the heel fillet is responsible for the Z measurement.
+# For square terminated parts the toe fillet is towards the outside = Z measurement
+# But for castellated they tell us that the heel fillet is responsible for the Z measurement.
 # As the script interprets toe to point outwards (=Z dim) we change these two compared to the
 # ipc document.
 

--- a/scripts/SMD_chip_package_rlc-etc/ipc7351B_smd_two_terminal_chip.yaml
+++ b/scripts/SMD_chip_package_rlc-etc/ipc7351B_smd_two_terminal_chip.yaml
@@ -1,5 +1,4 @@
-# IPC IPC-7351 http://pcbget.ru/Files/Standarts/IPC_7351.pdf
-# Page 23
+# Dimensions taken from ipc7351b
 
 # < 0603 (1608 Metric)
 #           | Minimum | Median    | Maximum |
@@ -7,31 +6,32 @@
 #           | Density | Density   | Density | round
 # Lead Part | Level C | Level B   | Level A |  to
 # ----------+---------+-----------+---------+-
-# Toe (JT)  |  0.0    |  0.1      |  0.2    | 0.05
-# Heel (JH) | -0.05   | -0.05     | -0.05   | 0.05
-# Side (JS) |  0.00   | 0.00      |  0.05   | 0.05
-# Courtyard |  0.1    | 0.15      |  0.2    |
+# Toe (JT)  |  0.1    |  0.2      |  0.3    | 0.02
+# Heel (JH) |  0.0    |  0.0      |  0.0    | 0.02
+# Side (JS) |  0.05   |  0.0      |  -0.05  | 0.02
+# Courtyard |  0.1    |  0.15     |  0.2    |
 
 ipc_spec_smaller_0603:
     least:
-        toe: 0.0
-        heel: -0.05
-        side: 0.0
+        toe: 0.1
+        heel: 0
+        side: -0.05
         courtyard: 0.1
     nominal:
-        toe: 0.1
-        heel: -0.05
+        toe: 0.2
+        heel: 0
         side: 0.0
         courtyard: 0.15
     most:
-        toe: 0.2
-        heel: -0.05
+        toe: 0.3
+        heel: 0
         side: 0.05
         courtyard: 0.2
     round_base:
-        toe: 0.05
-        heel: 0.05
-        side: 0.05
+        toe: 0.02
+        heel: 0.02
+        side: 0.02
+
 
 # >= 0603 (1608 Metric)
 #           | Minimum | Median    | Maximum
@@ -40,30 +40,30 @@ ipc_spec_smaller_0603:
 # Lead Part | Level C | Level B   | Level A
 # ----------+---------+-----------+--------
 # Toe (JT)  |  0.15   |  0.35     |  0.55
-# Heel (JH) | -0.05   | -0.05     | -0.05
+# Heel (JH) |  0.0    |  0.0      |  0.0
 # Side (JS) |  -0.05  |  0.00     |  0.05
 # Courtyard |  0.1    |  0.25     |  0.5
 
 ipc_spec_larger_or_equal_0603:
     least:
         toe: 0.15
-        heel: -0.05
+        heel: 0.0
         side: -0.05
         courtyard: 0.1
     nominal:
         toe: 0.35
-        heel: -0.05
+        heel: 0.0
         side: 0.00
         courtyard: 0.25
     most:
         toe: 0.55
-        heel: -0.05
+        heel: 0.0
         side: 0.05
         courtyard: 0.5
     round_base:
-        toe: 0.02
-        heel: 0.02
-        side: 0.1
+        toe: 0.05
+        heel: 0.05
+        side: 0.05
 
 
 # tantalum cap
@@ -94,9 +94,9 @@ ipc_spec_tantalumn:
         side: 0.01
         courtyard: 0.5
     round_base:
-        toe: 0.02
-        heel: 0.02
-        side: 0.1
+        toe: 0.05
+        heel: 0.05
+        side: 0.05
 
 # castellated
 # The document is a bit strange with the castelated definitions.
@@ -133,6 +133,6 @@ ipc_spec_castellated:
         side: 0.05
         courtyard: 0.5
     round_base:
-        toe: 0.02
-        heel: 0.02
-        side: 0.01
+        toe: 0.05
+        heel: 0.05
+        side: 0.05

--- a/scripts/SMD_chip_package_rlc-etc/ipc_smd_two_terminal_chip.yaml
+++ b/scripts/SMD_chip_package_rlc-etc/ipc_smd_two_terminal_chip.yaml
@@ -99,10 +99,10 @@ ipc_spec_tantalumn:
         side: 0.1
 
 # castellated
-# The document is a bit strange with the castelated definitions.
+# The document is a bit strange with the castellated definitions.
 # They seem to exchange the toe and heel fillet.
-# For normall square ends the toe fillet is towards the outside = Z measurement
-# But for castelated they tell us that the heel fillet is responsible for the Z measurement.
+# For square terminated parts the toe fillet is towards the outside = Z measurement
+# But for castellated they tell us that the heel fillet is responsible for the Z measurement.
 # As the script interprets toe to point outwards (=Z dim) we change these two compared to the
 # ipc document.
 


### PR DESCRIPTION
As the title says, this adds the ipc definitions from the newer ipc7315b standard. The old 7315 definition is unchanged (other than removing a duplicate unneeded definition and adding an explanation about the fact that castelated exchanges the meaning of toe and heel in the ipc document.)

Footprint PR: https://github.com/KiCad/kicad-footprints/pull/642