### PR TITLE
Fix footprints of RECOM DC/DC converters.

### DIFF
--- a/scripts/Recom_DCDC/Recom_SIP.py
+++ b/scripts/Recom_DCDC/Recom_SIP.py
@@ -30,34 +30,34 @@ def recom_78_3pin():
     left_offset=3.21
     top_offset=2
     makeSIPVertical(pins=pins, rm=rm, ddrill=ddrill_large, pad=pad_large, package_size=package_size, left_offset=left_offset, top_offset=top_offset, 
-            footprint_name='DCDC-Conv_RECOM_R-78B-2.0', 
+            footprint_name='Converter_DCDC_RECOM_R-78B-2.0_THT', 
             description="DCDC-Converter, RECOM, RECOM_R-78B-2.0, SIP-{0}, pitch {1:3.2f}mm, package size {2}x{3}x{4}mm^3, https://www.recom-power.com/pdf/Innoline/R-78Bxx-2.0.pdf".format(pins,rm,package_size[0],package_size[1],package_size[2]), 
             tags="dc-dc recom buck sip-{0} pitch {1:3.2f}mm".format(pins,rm), 
-            lib_name='Converters_DCDC_ACDC')
+            lib_name='Converter_DCDC')
 
     package_size=[11.6,8.5,10.4]
     left_offset=package_size[0]-3.21-5.08
     top_offset=package_size[1]-2
     makeSIPVertical(pins=pins, rm=rm, ddrill=ddrill_small, pad=pad_small, package_size=package_size, left_offset=left_offset, top_offset=top_offset, 
-            footprint_name='DCDC-Conv_RECOM_R-78E-0.5', 
+            footprint_name='Converter_DCDC_RECOM_R-78E-0.5_THT', 
             description="DCDC-Converter, RECOM, RECOM_R-78E-0.5, SIP-{0}, pitch {1:3.2f}mm, package size {2}x{3}x{4}mm^3, https://www.recom-power.com/pdf/Innoline/R-78Exx-0.5.pdf".format(pins,rm,package_size[0],package_size[1],package_size[2]), 
             tags="dc-dc recom buck sip-{0} pitch {1:3.2f}mm".format(pins,rm), 
-            lib_name='Converters_DCDC_ACDC')
+            lib_name='Converter_DCDC')
 
     package_size=[11.5,8.5,17.5]
     left_offset=3.21
     top_offset=2
     pin_bottom_offset=1.5
     makeSIPVertical(pins=pins, rm=rm, ddrill=ddrill_small, pad=pad_small, package_size=package_size, left_offset=left_offset, top_offset=top_offset, 
-            footprint_name='DCDC-Conv_RECOM_R-78HB-0.5', 
+            footprint_name='Converter_DCDC_RECOM_R-78HB-0.5_THT', 
             description="DCDC-Converter, RECOM, RECOM_R-78HB-0.5, SIP-{0}, pitch {1:3.2f}mm, package size {2}x{3}x{4}mm^3, https://www.recom-power.com/pdf/Innoline/R-78HBxx-0.5_L.pdf".format(pins,rm,package_size[0],package_size[1],package_size[2]), 
             tags="dc-dc recom buck sip-{0} pitch {1:3.2f}mm".format(pins,rm), 
-            lib_name='Converters_DCDC_ACDC')
+            lib_name='Converter_DCDC')
     makeSIPHorizontal(pins=pins, rm=rm, ddrill=ddrill_small, pad=pad_small, package_size=package_size, left_offset=left_offset, pin_bottom_offset=pin_bottom_offset, 
-            footprint_name='DCDC-Conv_RECOM_R-78HB-0.5L', 
+            footprint_name='Converter_DCDC_RECOM_R-78HB-0.5L_THT', 
             description="DCDC-Converter, RECOM, RECOM_R-78HB-0.5L, SIP-{0}, Horizontally Mounted, pitch {1:3.2f}mm, package size {2}x{3}x{4}mm^3, https://www.recom-power.com/pdf/Innoline/R-78HBxx-0.5_L.pdf".format(pins,rm,package_size[0],package_size[1],package_size[2]), 
             tags="dc-dc recom buck sip-{0} pitch {1:3.2f}mm".format(pins,rm), 
-            lib_name='Converters_DCDC_ACDC')
+            lib_name='Converter_DCDC')
 
 def recom_78_4pin(): 
     pins=4
@@ -70,10 +70,10 @@ def recom_78_4pin():
     left_offset=2
     top_offset=package_size[1]-2
     makeSIPVertical(pins=pins, rm=rm, ddrill=ddrill, pad=pad, package_size=package_size, left_offset=left_offset, top_offset=top_offset, 
-            footprint_name='DCDC-Conv_RECOM_R-78S-0.1', 
+            footprint_name='Converter_DCDC_RECOM_R-78S-0.1_THT', 
             description="DCDC-Converter, RECOM, RECOM_R-78S-0.1, SIP-{0}, pitch {1:3.2f}mm, package size {2}x{3}x{4}mm^3, https://www.recom-power.com/pdf/Innoline/R-78Sxx-0.1.pdf".format(pins,rm,package_size[0],package_size[1],package_size[2]), 
             tags="dc-dc recom buck sip-{0} pitch {1:3.2f}mm".format(pins,rm), 
-            lib_name='Converters_DCDC_ACDC')
+            lib_name='Converter_DCDC')
 
 def recom_r5():
     pins=12
@@ -86,15 +86,15 @@ def recom_r5():
     top_offset=0.8
     pin_bottom_offset=2
     makeSIPVertical(pins=pins, rm=rm, ddrill=ddrill, pad=pad, package_size=package_size, left_offset=left_offset, top_offset=top_offset, 
-            footprint_name='DCDC-Conv_RECOM_R5xxxPA', 
+            footprint_name='Converter_DCDC_RECOM_R5xxxPA_THT', 
             description="DCDC-Converter, RECOM, RECOM_R5xxxPA, SIP-{0}, pitch {1:3.2f}mm, package size {2}x{3}x{4}mm^3, https://www.recom-power.com/pdf/Innoline/R-5xxxPA_DA.pdf".format(pins,rm,package_size[0],package_size[1],package_size[2]), 
             tags="dc-dc recom buck sip-{0} pitch {1:3.2f}mm".format(pins,rm), 
-            lib_name='Converters_DCDC_ACDC')
+            lib_name='Converter_DCDC')
     makeSIPHorizontal(pins=pins, rm=rm, ddrill=ddrill, pad=pad, package_size=package_size, left_offset=left_offset, pin_bottom_offset=pin_bottom_offset, 
-            footprint_name='DCDC-Conv_RECOM_R5xxxDA', 
+            footprint_name='Converter_DCDC_RECOM_R5xxxDA_THT', 
             description="DCDC-Converter, RECOM, RECOM_R5xxxDA, SIP-{0}, Horizontally Mounted, pitch {1:3.2f}mm, package size {2}x{3}x{4}mm^3, https://www.recom-power.com/pdf/Innoline/R-5xxxPA_DA.pdf".format(pins,rm,package_size[0],package_size[1],package_size[2]), 
             tags="dc-dc recom buck sip-{0} pitch {1:3.2f}mm".format(pins,rm), 
-            lib_name='Converters_DCDC_ACDC')
+            lib_name='Converter_DCDC')
 
 if __name__ == '__main__':
     recom_78_3pin()

--- a/scripts/Recom_DCDC/Recom_SIP.py
+++ b/scripts/Recom_DCDC/Recom_SIP.py
@@ -15,52 +15,58 @@ from KicadModTree import *  # NOQA
 from drawing_tools import *
 from footprint_scripts_sip import *
 
+rm=2.54
 
-if __name__ == '__main__':
+def recom_78_3pin():
     pins=3
-    rm=2.54
-    ddrill=1.2
-    pad=[1.7, 2.5]
+    
+    ddrill_large=1.2
+    pad_large=[1.7, 2.5]
+
+    ddrill_small=1.0
+    pad_small=[1.5, 2.3]    
+
     package_size=[11.5,8.5,17.5]
     left_offset=3.21
-    top_offset=package_size[1]-2
-    makeSIPVertical(pins=pins, rm=rm, ddrill=ddrill, pad=pad, package_size=package_size, left_offset=left_offset, top_offset=top_offset, 
+    top_offset=2
+    makeSIPVertical(pins=pins, rm=rm, ddrill=ddrill_large, pad=pad_large, package_size=package_size, left_offset=left_offset, top_offset=top_offset, 
             footprint_name='DCDC-Conv_RECOM_R-78B-2.0', 
             description="DCDC-Converter, RECOM, RECOM_R-78B-2.0, SIP-{0}, pitch {1:3.2f}mm, package size {2}x{3}x{4}mm^3, https://www.recom-power.com/pdf/Innoline/R-78Bxx-2.0.pdf".format(pins,rm,package_size[0],package_size[1],package_size[2]), 
             tags="dc-dc recom buck sip-{0} pitch {1:3.2f}mm".format(pins,rm), 
             lib_name='Converters_DCDC_ACDC')
-            
-    package_size=[11.5,8.5,10.4]
-    ddrill=1.0
-    pad=[1.5, 2.3]
-    makeSIPVertical(pins=pins, rm=rm, ddrill=ddrill, pad=pad, package_size=package_size, left_offset=left_offset, top_offset=top_offset, 
+
+    package_size=[11.6,8.5,10.4]
+    left_offset=package_size[0]-3.21-5.08
+    top_offset=package_size[1]-2
+    makeSIPVertical(pins=pins, rm=rm, ddrill=ddrill_small, pad=pad_small, package_size=package_size, left_offset=left_offset, top_offset=top_offset, 
             footprint_name='DCDC-Conv_RECOM_R-78E-0.5', 
             description="DCDC-Converter, RECOM, RECOM_R-78E-0.5, SIP-{0}, pitch {1:3.2f}mm, package size {2}x{3}x{4}mm^3, https://www.recom-power.com/pdf/Innoline/R-78Exx-0.5.pdf".format(pins,rm,package_size[0],package_size[1],package_size[2]), 
             tags="dc-dc recom buck sip-{0} pitch {1:3.2f}mm".format(pins,rm), 
             lib_name='Converters_DCDC_ACDC')
-            
 
     package_size=[11.5,8.5,17.5]
-    ddrill=1.0
-    pad=[1.5, 2.3]
+    left_offset=3.21
     top_offset=2
     pin_bottom_offset=1.5
-    makeSIPVertical(pins=pins, rm=rm, ddrill=ddrill, pad=pad, package_size=package_size, left_offset=left_offset, top_offset=top_offset, 
+    makeSIPVertical(pins=pins, rm=rm, ddrill=ddrill_small, pad=pad_small, package_size=package_size, left_offset=left_offset, top_offset=top_offset, 
             footprint_name='DCDC-Conv_RECOM_R-78HB-0.5', 
             description="DCDC-Converter, RECOM, RECOM_R-78HB-0.5, SIP-{0}, pitch {1:3.2f}mm, package size {2}x{3}x{4}mm^3, https://www.recom-power.com/pdf/Innoline/R-78HBxx-0.5_L.pdf".format(pins,rm,package_size[0],package_size[1],package_size[2]), 
             tags="dc-dc recom buck sip-{0} pitch {1:3.2f}mm".format(pins,rm), 
             lib_name='Converters_DCDC_ACDC')
-    makeSIPHorizontal(pins=pins, rm=rm, ddrill=ddrill, pad=pad, package_size=package_size, left_offset=left_offset, pin_bottom_offset=pin_bottom_offset, 
+    makeSIPHorizontal(pins=pins, rm=rm, ddrill=ddrill_small, pad=pad_small, package_size=package_size, left_offset=left_offset, pin_bottom_offset=pin_bottom_offset, 
             footprint_name='DCDC-Conv_RECOM_R-78HB-0.5L', 
             description="DCDC-Converter, RECOM, RECOM_R-78HB-0.5L, SIP-{0}, Horizontally Mounted, pitch {1:3.2f}mm, package size {2}x{3}x{4}mm^3, https://www.recom-power.com/pdf/Innoline/R-78HBxx-0.5_L.pdf".format(pins,rm,package_size[0],package_size[1],package_size[2]), 
             tags="dc-dc recom buck sip-{0} pitch {1:3.2f}mm".format(pins,rm), 
             lib_name='Converters_DCDC_ACDC')
-            
 
+def recom_78_4pin(): 
     pins=4
-    package_size=[11.5,8.5,17.5]
+
     ddrill=1.0
     pad=[1.5, 2.3]
+
+    package_size=[11.6,8.5,10.4]
+
     left_offset=2
     top_offset=package_size[1]-2
     makeSIPVertical(pins=pins, rm=rm, ddrill=ddrill, pad=pad, package_size=package_size, left_offset=left_offset, top_offset=top_offset, 
@@ -69,13 +75,16 @@ if __name__ == '__main__':
             tags="dc-dc recom buck sip-{0} pitch {1:3.2f}mm".format(pins,rm), 
             lib_name='Converters_DCDC_ACDC')
 
+def recom_r5():
     pins=12
-    package_size=[32.2,9.1,15]
+
     ddrill=1.0
     pad=[1.5, 2.3]
-    left_offset=2.13
-    top_offset=0.7
-    pin_bottom_offset=0.5
+    
+    package_size=[32.2,9.1,15]
+    left_offset=2.1
+    top_offset=0.8
+    pin_bottom_offset=2
     makeSIPVertical(pins=pins, rm=rm, ddrill=ddrill, pad=pad, package_size=package_size, left_offset=left_offset, top_offset=top_offset, 
             footprint_name='DCDC-Conv_RECOM_R5xxxPA', 
             description="DCDC-Converter, RECOM, RECOM_R5xxxPA, SIP-{0}, pitch {1:3.2f}mm, package size {2}x{3}x{4}mm^3, https://www.recom-power.com/pdf/Innoline/R-5xxxPA_DA.pdf".format(pins,rm,package_size[0],package_size[1],package_size[2]), 
@@ -86,3 +95,8 @@ if __name__ == '__main__':
             description="DCDC-Converter, RECOM, RECOM_R5xxxDA, SIP-{0}, Horizontally Mounted, pitch {1:3.2f}mm, package size {2}x{3}x{4}mm^3, https://www.recom-power.com/pdf/Innoline/R-5xxxPA_DA.pdf".format(pins,rm,package_size[0],package_size[1],package_size[2]), 
             tags="dc-dc recom buck sip-{0} pitch {1:3.2f}mm".format(pins,rm), 
             lib_name='Converters_DCDC_ACDC')
+
+if __name__ == '__main__':
+    recom_78_3pin()
+    recom_78_4pin()
+    recom_r5()

--- a/scripts/tools/footprint_scripts_sip.py
+++ b/scripts/tools/footprint_scripts_sip.py
@@ -126,7 +126,10 @@ def makeSIPHorizontal(pins, rm, ddrill, pad, package_size, left_offset, pin_bott
     h_crt = h_fab+pin_bottom_offset+pad[1]/2 + 2 * crt_offset
     l_crt = min(l_fab, -padx / 2) - crt_offset
     t_crt = t_fab  - crt_offset
-    
+
+    # Pin 1 maker
+    l_pin1 = l_slk + left_offset - padx / 2 - 2 * lw_slk
+    h_pin1 = pin_bottom_offset + pady / 2 - lw_slk
     
     print(footprint_name)
     
@@ -165,10 +168,10 @@ def makeSIPHorizontal(pins, rm, ddrill, pad, package_size, left_offset, pin_bott
     # create SILKSCREEN-layer
     addRectWithKeepout(kicad_mod, l_slk, t_slk, w_slk, h_slk, keepouts=keepout, layer='F.SilkS', width=lw_slk)
     addPolyLineWithKeepout(kicad_mod, [
-                                        [l_slk-2*lw_slk, t_slk], 
-                                        [l_slk-2*lw_slk, t_slk+h_slk], 
-                                        ], keepouts=keepout, layer='F.SilkS', width=lw_slk)
-    
+                                        [l_pin1, t_slk + h_slk],
+                                        [l_pin1, t_slk + h_slk + h_pin1]
+                                        ], layer='F.SilkS', width=lw_slk)
+
     # create courtyard
     kicad_mod.append(
         RectLine(start=[roundCrt(l_crt), roundCrt(t_crt)], end=[roundCrt(l_crt + w_crt), roundCrt(t_crt + h_crt)],


### PR DESCRIPTION
Some had their pins towards the front instead of towards the back, some had a wrong  pin 1 offset, and other had wrong widths.

Also refactored the script to put different families of controllers into different functions.

See https://github.com/KiCad/kicad-footprints/pull/688 for the original pull request which triggered this one.