### PR TITLE
Mask/paste global footprint support & new BGA entries

### DIFF
--- a/KicadModTree/KicadFileHandler.py
+++ b/KicadModTree/KicadFileHandler.py
@@ -87,7 +87,19 @@ class KicadFileHandler(FileHandler):
         if self.kicad_mod.attribute:
             sexpr.append(['attr', self.kicad_mod.attribute])
             sexpr.append(SexprSerializer.NEW_LINE)
-
+        
+        if self.kicad_mod.maskMargin:
+            sexpr.append(['solder_mask_margin', self.kicad_mod.maskMargin])
+            sexpr.append(SexprSerializer.NEW_LINE)
+        
+        if self.kicad_mod.pasteMargin:
+            sexpr.append(['solder_paste_margin', self.kicad_mod.pasteMargin])
+            sexpr.append(SexprSerializer.NEW_LINE)
+        
+        if self.kicad_mod.pasteMarginRatio:
+            sexpr.append(['solder_paste_ratio', self.kicad_mod.pasteMarginRatio])
+            sexpr.append(SexprSerializer.NEW_LINE)
+        
         sexpr.extend(self._serializeTree())
 
         return str(SexprSerializer(sexpr))

--- a/KicadModTree/KicadFileHandler.py
+++ b/KicadModTree/KicadFileHandler.py
@@ -87,19 +87,19 @@ class KicadFileHandler(FileHandler):
         if self.kicad_mod.attribute:
             sexpr.append(['attr', self.kicad_mod.attribute])
             sexpr.append(SexprSerializer.NEW_LINE)
-        
+
         if self.kicad_mod.maskMargin:
             sexpr.append(['solder_mask_margin', self.kicad_mod.maskMargin])
             sexpr.append(SexprSerializer.NEW_LINE)
-        
+
         if self.kicad_mod.pasteMargin:
             sexpr.append(['solder_paste_margin', self.kicad_mod.pasteMargin])
             sexpr.append(SexprSerializer.NEW_LINE)
-        
+
         if self.kicad_mod.pasteMarginRatio:
             sexpr.append(['solder_paste_ratio', self.kicad_mod.pasteMarginRatio])
             sexpr.append(SexprSerializer.NEW_LINE)
-        
+
         sexpr.extend(self._serializeTree())
 
         return str(SexprSerializer(sexpr))

--- a/KicadModTree/nodes/Footprint.py
+++ b/KicadModTree/nodes/Footprint.py
@@ -30,7 +30,7 @@ ADVANTAGES:
 '''
 
 # define in which order the general "lisp" operators are arranged
-render_order = ['descr', 'tags', 'attr', 'fp_text', 'fp_circle', 'fp_line', 'pad', 'model']
+render_order = ['descr', 'tags', 'attr', 'solder_mask_margin', 'solder_paste_margin', 'solder_paste_ratio', 'fp_text', 'fp_circle', 'fp_line', 'pad', 'model']
 # TODO: sort Text by type
 
 
@@ -45,6 +45,9 @@ class Footprint(Node):
         self.description = None
         self.tags = None
         self.attribute = None
+        self.maskMargin = None
+        self.pasteMargin = None
+        self.pasteMarginRatio = None
 
     def setName(self, name):
         self.name = name
@@ -57,3 +60,15 @@ class Footprint(Node):
 
     def setAttribute(self, value):
         self.attribute = value
+        
+    def setMaskMargin(self, value):
+        self.maskMargin = value
+
+    def setPasteMargin(self, value):
+        self.pasteMargin = value
+    
+    def setPasteMarginRatio(self, value):
+        # paste_margin_ratio is a percentage between 0 and 1 but user could enter exact ratio or percentage
+        if value > 1:
+            value = value / 100.0
+        self.pasteMarginRatio = value

--- a/KicadModTree/nodes/Footprint.py
+++ b/KicadModTree/nodes/Footprint.py
@@ -70,8 +70,8 @@ class Footprint(Node):
         self.pasteMargin = value
 
     def setPasteMarginRatio(self, value):
-        # paste_margin_ratio is unitless between 0 and 1
-        # GUI uses percentage so account for that input
+        # paste_margin_ratio is unitless between 0 and 1 while GUI uses percentage
         if abs(value) > 1:
-            value = value / 100.0
-        self.pasteMarginRatio = value
+            raise ValueError("Solder paste margin must be between -1 and 1. {} is too large.".format(value))
+        else
+            self.pasteMarginRatio = value

--- a/KicadModTree/nodes/Footprint.py
+++ b/KicadModTree/nodes/Footprint.py
@@ -73,5 +73,5 @@ class Footprint(Node):
         # paste_margin_ratio is unitless between 0 and 1
         # GUI uses percentage so account for that input
         if value > 1:
-            value = value / 100.0
+            value = abs(value) / 100.0
         self.pasteMarginRatio = value

--- a/KicadModTree/nodes/Footprint.py
+++ b/KicadModTree/nodes/Footprint.py
@@ -30,7 +30,9 @@ ADVANTAGES:
 '''
 
 # define in which order the general "lisp" operators are arranged
-render_order = ['descr', 'tags', 'attr', 'solder_mask_margin', 'solder_paste_margin', 'solder_paste_ratio', 'fp_text', 'fp_circle', 'fp_line', 'pad', 'model']
+render_order = ['descr', 'tags', 'attr', 'solder_mask_margin',
+                    'solder_paste_margin', 'solder_paste_ratio', 'fp_text',
+                    'fp_circle', 'fp_line', 'pad', 'model']
 # TODO: sort Text by type
 
 
@@ -60,15 +62,16 @@ class Footprint(Node):
 
     def setAttribute(self, value):
         self.attribute = value
-        
+
     def setMaskMargin(self, value):
         self.maskMargin = value
 
     def setPasteMargin(self, value):
         self.pasteMargin = value
-    
+
     def setPasteMarginRatio(self, value):
-        # paste_margin_ratio is a percentage between 0 and 1 but user could enter exact ratio or percentage
+        # paste_margin_ratio is unitless between 0 and 1
+        # GUI uses percentage so account for that input
         if value > 1:
             value = value / 100.0
         self.pasteMarginRatio = value

--- a/KicadModTree/nodes/Footprint.py
+++ b/KicadModTree/nodes/Footprint.py
@@ -71,7 +71,6 @@ class Footprint(Node):
 
     def setPasteMarginRatio(self, value):
         # paste_margin_ratio is unitless between 0 and 1 while GUI uses percentage
-        if abs(value) > 1:
-            raise ValueError("Solder paste margin must be between -1 and 1. {} is too large.".format(value))
-        else:
-            self.pasteMarginRatio = value
+        assert abs(value) <= 1,"Solder paste margin must be between -1 and 1. {} is too large.".format(value)
+        
+        self.pasteMarginRatio = value

--- a/KicadModTree/nodes/Footprint.py
+++ b/KicadModTree/nodes/Footprint.py
@@ -72,6 +72,6 @@ class Footprint(Node):
     def setPasteMarginRatio(self, value):
         # paste_margin_ratio is unitless between 0 and 1
         # GUI uses percentage so account for that input
-        if value > 1:
-            value = abs(value) / 100.0
+        if abs(value) > 1:
+            value = value / 100.0
         self.pasteMarginRatio = value

--- a/KicadModTree/nodes/Footprint.py
+++ b/KicadModTree/nodes/Footprint.py
@@ -31,8 +31,8 @@ ADVANTAGES:
 
 # define in which order the general "lisp" operators are arranged
 render_order = ['descr', 'tags', 'attr', 'solder_mask_margin',
-                    'solder_paste_margin', 'solder_paste_ratio', 'fp_text',
-                    'fp_circle', 'fp_line', 'pad', 'model']
+                'solder_paste_margin', 'solder_paste_ratio', 'fp_text',
+                'fp_circle', 'fp_line', 'pad', 'model']
 # TODO: sort Text by type
 
 
@@ -71,6 +71,6 @@ class Footprint(Node):
 
     def setPasteMarginRatio(self, value):
         # paste_margin_ratio is unitless between 0 and 1 while GUI uses percentage
-        assert abs(value) <= 1,"Solder paste margin must be between -1 and 1. {} is too large.".format(value)
-        
+        assert abs(value) <= 1, "Solder paste margin must be between -1 and 1. {} is too large.".format(value)
+
         self.pasteMarginRatio = value

--- a/KicadModTree/nodes/Footprint.py
+++ b/KicadModTree/nodes/Footprint.py
@@ -73,5 +73,5 @@ class Footprint(Node):
         # paste_margin_ratio is unitless between 0 and 1 while GUI uses percentage
         if abs(value) > 1:
             raise ValueError("Solder paste margin must be between -1 and 1. {} is too large.".format(value))
-        else
+        else:
             self.pasteMarginRatio = value

--- a/KicadModTree/nodes/base/Pad.py
+++ b/KicadModTree/nodes/base/Pad.py
@@ -35,7 +35,7 @@ class Pad(Node):
           number/name of the pad (default: \"\")
         * *type* (``Pad.TYPE_THT``, ``Pad.TYPE_SMT``, ``Pad.TYPE_CONNECT``, ``Pad.TYPE_NPTH``) --
           type of the pad
-        * *shape* (``Pad.SHAPE_CIRCLE``, ``Pad.SHAPE_OVAL``, ``Pad.SHAPE_RECT``, ``Pad.SHAPE_TRAPEZE``) --
+        * *shape* (``Pad.SHAPE_CIRCLE``, ``Pad.SHAPE_OVAL``, ``Pad.SHAPE_RECT``, ``SHAPE_ROUNDRECT``, ``Pad.SHAPE_TRAPEZE``, ``SHAPE_CUSTOM``) --
           shape of the pad
         * *at* (``Vector2D``) --
           center position of the pad
@@ -52,9 +52,9 @@ class Pad(Node):
           Ignored for every other shape.
         * *maximum_radius* (``float``) --
           The maximum radius for the rounded rectangle.
-          If the radius produced by the radius ratio parameter for this pad would
+          If the radius produced by the radius_ratio parameter for the pad would
           exceed the maximum radius, the ratio is reduced to limit the ratio.
-          (This is usefull for IPC-7351C complience as it suggests 25% ratio with limit 0.25mm)
+          (This is useful for IPC-7351C compliance as it suggests 25% ratio up to 0.25mm)
           Ignored for every other shape.
         * *solder_paste_margin_ratio* (``float``) --
           solder paste margin ratio of the pad (default: 0)
@@ -209,16 +209,16 @@ class Pad(Node):
         if radius_ratio >= 0 and radius_ratio <= 0.5:
             self.radius_ratio = radius_ratio
         else:
-            raise ValueError('radius ratio out of allowed range (0 < rr <= 0.5)')
+            raise ValueError('radius ratio out of allowed range (0 <= rr <= 0.5)')
 
         if kwargs.get('maximum_radius') is not None:
             maximum_radius = kwargs.get('maximum_radius')
             if type(maximum_radius) not in [int, float]:
                 raise TypeError('maximum radius needs to be of type int or float')
 
-            shortest_sidlength = min(self.size)
-            if self.radius_ratio*shortest_sidlength > maximum_radius:
-                self.radius_ratio = maximum_radius/shortest_sidlength
+            shortest_sidelength = min(self.size)
+            if self.radius_ratio*shortest_sidelength > maximum_radius:
+                self.radius_ratio = maximum_radius/shortest_sidelength
 
         if self.radius_ratio == 0:
             self.shape = Pad.SHAPE_RECT

--- a/KicadModTree/nodes/base/Pad.py
+++ b/KicadModTree/nodes/base/Pad.py
@@ -54,7 +54,7 @@ class Pad(Node):
           The maximum radius for the rounded rectangle.
           If the radius produced by the radius_ratio parameter for the pad would
           exceed the maximum radius, the ratio is reduced to limit the ratio.
-          (This is useful for IPC-7351C compliance as it suggests 25% ratio up to 0.25mm)
+          (This is useful for IPC-7351C compliance as it suggests 25% ratio with limit 0.25mm)
           Ignored for every other shape.
         * *solder_paste_margin_ratio* (``float``) --
           solder paste margin ratio of the pad (default: 0)

--- a/KicadModTree/nodes/base/Pad.py
+++ b/KicadModTree/nodes/base/Pad.py
@@ -35,7 +35,8 @@ class Pad(Node):
           number/name of the pad (default: \"\")
         * *type* (``Pad.TYPE_THT``, ``Pad.TYPE_SMT``, ``Pad.TYPE_CONNECT``, ``Pad.TYPE_NPTH``) --
           type of the pad
-        * *shape* (``Pad.SHAPE_CIRCLE``, ``Pad.SHAPE_OVAL``, ``Pad.SHAPE_RECT``, ``SHAPE_ROUNDRECT``, ``Pad.SHAPE_TRAPEZE``, ``SHAPE_CUSTOM``) --
+        * *shape* (``Pad.SHAPE_CIRCLE``, ``Pad.SHAPE_OVAL``, ``Pad.SHAPE_RECT``, ``SHAPE_ROUNDRECT``,
+        ``Pad.SHAPE_TRAPEZE``, ``SHAPE_CUSTOM``) --
           shape of the pad
         * *at* (``Vector2D``) --
           center position of the pad

--- a/scripts/Package_BGA/bga.py
+++ b/scripts/Package_BGA/bga.py
@@ -25,7 +25,7 @@ def bga(args):
     layoutY = args["layout_y"]
     rowNames = args["row_names"]
     rowSkips = args["row_skips"]
-    
+
     f = Footprint(footprint_name)
     f.setDescription(desc)
     f.setAttribute("smd")
@@ -33,9 +33,11 @@ def bga(args):
     f.setPasteMargin(pasteMargin)
     f.setPasteMarginRatio(pasteRatio)
     
+    package_type = 'CSP' if 'BGA' not in footprint_name and 'CSP' in footprint_name else 'BGA'
+    
     # If this looks like a CSP footprint, use the CSP 3dshapes library
     f.append(Model(filename="${{KISYS3DMOD}}/Package_{}.3dshapes/{}.wrl".format(
-                  'CSP' if 'BGA' not in footprint_name and 'CSP' in footprint_name else 'BGA', footprint_name)))
+                  package_type, footprint_name)))
 
     s1 = [1.0, 1.0]
     s2 = [min(1.0, round(pkgWidth / 4.3, 2))] * 2
@@ -65,8 +67,8 @@ def bga(args):
     xChamferFab = xLeftFab + chamfer
     xPadLeft = xCenter - pitch * ((layoutX - 1) / 2.0)
     xPadRight = xCenter + pitch * ((layoutX - 1) / 2.0)
-    xLeftCrtYd = crtYdRound(xCenter - (pkgWidth / 2 + crtYdOffset))
-    xRightCrtYd = crtYdRound(xCenter + (pkgWidth / 2 + crtYdOffset))
+    xLeftCrtYd = crtYdRound(xCenter - (pkgWidth / 2 + float(crtYdOffset)))
+    xRightCrtYd = crtYdRound(xCenter + (pkgWidth / 2 + float(crtYdOffset)))
 
     yCenter = 0.0
     yTopFab = yCenter - pkgHeight / 2.0
@@ -74,8 +76,8 @@ def bga(args):
     yChamferFab = yTopFab + chamfer
     yPadTop = yCenter - pitch * ((layoutY - 1) / 2.0)
     yPadBottom = yCenter + pitch * ((layoutY - 1) / 2.0)
-    yTopCrtYd = crtYdRound(yCenter - (pkgHeight / 2 + crtYdOffset))
-    yBottomCrtYd = crtYdRound(yCenter + (pkgHeight / 2 + crtYdOffset))
+    yTopCrtYd = crtYdRound(yCenter - (pkgHeight / 2 + float(crtYdOffset)))
+    yBottomCrtYd = crtYdRound(yCenter + (pkgHeight / 2 + float(crtYdOffset)))
     yRef = yTopFab - 1.0
     yValue = yBottomFab + 1.0
 
@@ -143,7 +145,7 @@ def bga(args):
                          size=[padDiameter, padDiameter],
                          layers=Pad.LAYERS_SMT))
 
-    f.setTags("{} {} {}".format('CSP' if 'BGA' not in footprint_name and 'CSP' in footprint_name else 'BGA', balls, pitch))
+    f.setTags("{} {} {}".format(package_type, balls, pitch))
     
     file_handler = KicadFileHandler(f)
     file_handler.writeFile(footprint_name + ".kicad_mod")

--- a/scripts/Package_BGA/bga.py
+++ b/scripts/Package_BGA/bga.py
@@ -67,8 +67,8 @@ def bga(args):
     xChamferFab = xLeftFab + chamfer
     xPadLeft = xCenter - pitch * ((layoutX - 1) / 2.0)
     xPadRight = xCenter + pitch * ((layoutX - 1) / 2.0)
-    xLeftCrtYd = crtYdRound(xCenter - (pkgWidth / 2 + float(crtYdOffset)))
-    xRightCrtYd = crtYdRound(xCenter + (pkgWidth / 2 + float(crtYdOffset)))
+    xLeftCrtYd = crtYdRound(xCenter - (pkgWidth / 2.0 + crtYdOffset))
+    xRightCrtYd = crtYdRound(xCenter + (pkgWidth / 2.0 + crtYdOffset))
 
     yCenter = 0.0
     yTopFab = yCenter - pkgHeight / 2.0
@@ -76,8 +76,8 @@ def bga(args):
     yChamferFab = yTopFab + chamfer
     yPadTop = yCenter - pitch * ((layoutY - 1) / 2.0)
     yPadBottom = yCenter + pitch * ((layoutY - 1) / 2.0)
-    yTopCrtYd = crtYdRound(yCenter - (pkgHeight / 2 + float(crtYdOffset)))
-    yBottomCrtYd = crtYdRound(yCenter + (pkgHeight / 2 + float(crtYdOffset)))
+    yTopCrtYd = crtYdRound(yCenter - (pkgHeight / 2.0 + crtYdOffset))
+    yBottomCrtYd = crtYdRound(yCenter + (pkgHeight / 2.0 + crtYdOffset))
     yRef = yTopFab - 1.0
     yValue = yBottomFab + 1.0
 

--- a/scripts/Package_BGA/bga.py
+++ b/scripts/Package_BGA/bga.py
@@ -20,7 +20,7 @@ def bga(args):
     padDiameter = args["pad_diameter"]
     maskMargin = args["mask_margin"]
     pasteMargin = args["paste_margin"]
-    pasteRatio = args["paste_ratio"] # '10.0' means paste ratio is 10% of pad size
+    pasteRatio = args["paste_ratio"]
     layoutX = args["layout_x"]
     layoutY = args["layout_y"]
     rowNames = args["row_names"]

--- a/scripts/Package_BGA/bga.yml
+++ b/scripts/Package_BGA/bga.yml
@@ -14,6 +14,34 @@ LFBGA-144_10x10mm_Layout12x12_P0.8mm:
   pad_diameter: 0.4
   layout_x: 12
   layout_y: 12
+Texas_DSBGA-49_3.33x3.488mm_Layout7x7_P0.4mm:
+  description: "Texas Instruments, DSBGA, 3.33x3.488x0.625mm, 49 ball 7x7 area grid, NSMD pad definition (http://www.ti.com/lit/ds/symlink/msp430f2234.pdf, http://www.ti.com/lit/an/snva009ag/snva009ag.pdf)"
+  pkg_width: 3.33
+  pkg_height: 3.488
+  pitch: 0.4
+  pad_diameter: 0.225
+  layout_x: 7
+  layout_y: 7
+  mask_margin: 0.05
+Texas_DSBGA-64_3.415x3.535mm_Layout8x8_P0.4mm:
+  description: "Texas Instruments, DSBGA, 3.415x3.535x0.625mm, 64 ball 8x8 area grid, NSMD pad definition (http://www.ti.com/lit/ds/slas718g/slas718g.pdf, http://www.ti.com/lit/an/snva009ag/snva009ag.pdf)"
+  pkg_width: 3.415
+  pkg_height: 3.535
+  pitch: 0.4
+  pad_diameter: 0.225
+  layout_x: 8
+  layout_y: 8
+  mask_margin: 0.05
+Texas_MicroStar_Junior_BGA-113_7.0x7.0mm_Layout12x12_P0.5mm:
+  description: "Texas Instruments, BGA Microstar Junior, 7x7mm, 113 ball 12x12 grid, NSMD pad definition (http://www.ti.com/lit/ml/mpbg674/mpbg674.pdf, http://www.ti.com/lit/wp/ssyz015b/ssyz015b.pdf)"
+  pkg_width: 7
+  pkg_height: 7
+  pitch: 0.5
+  pad_diameter: 0.25
+  layout_x: 12
+  layout_y: 12
+  mask_margin: 0.025
+  row_skips: [[], [], [[4, 11]], [3, 10], [3, 10], [3, 6, 7, 10], [3, 6, 7, 10], [3, 10], [3, 10], [[3, 11]], [], []]
 TFBGA-64_5x5mm_Layout8x8_P0.5mm:
   description: "TFBGA-64, 8x8 raster, 5x5mm package, pitch 0.5mm; see section 6.3 of http://www.st.com/resource/en/datasheet/stm32f100v8.pdf"
   pkg_width: 5.0
@@ -58,7 +86,7 @@ UFBGA-64_5x5mm_Layout8x8_P0.5mm:
   layout_x: 8
   layout_y: 8
 UFBGA-100_7x7mm_Layout12x12_P0.5mm:
-  description: "UFBGA-100, 12x12 raster, 7x7mm package, pitch 0.5mm; see section 7.1 of http://www.st.com/resource/en/datasheet/stm32f103tb.pdf"
+  description: "UFBGA-100, 12x12 raster, 7x7mm package, pitch 0.5mm; see section 6.5 of http://www.st.com/resource/en/datasheet/stm32f103tb.pdf"
   pkg_width: 7.0
   pkg_height: 7.0
   pitch: 0.5

--- a/scripts/Package_BGA/bga.yml
+++ b/scripts/Package_BGA/bga.yml
@@ -1,17 +1,21 @@
 LFBGA-100_10x10mm_Layout10x10_P0.8mm:
-  description: "LFBGA-100, 10x10 raster, 10x10mm package, pitch 0.8mm; see section 6.3 of http://www.st.com/resource/en/datasheet/stm32f103tb.pdf"
+  description: "LFBGA-100, 10x10 raster, 10x10mm package, pitch 0.8mm; http://www.st.com/resource/en/datasheet/stm32f103tb.pdf#page=87"
   pkg_width: 10.0
   pkg_height: 10.0
   pitch: 0.8
   pad_diameter: 0.5
+  mask_margin: 0.035
+  paste_margin: 0.000001
   layout_x: 10
   layout_y: 10
 LFBGA-144_10x10mm_Layout12x12_P0.8mm:
-  description: "LFBGA-144, 12x12 raster, 10x10mm package, pitch 0.8mm; see section 6.1 of http://www.st.com/resource/en/datasheet/stm32f103ze.pdf"
+  description: "LFBGA-144, 12x12 raster, 10x10mm package, pitch 0.8mm; http://www.st.com/resource/en/datasheet/stm32f103ze.pdf#page=114"
   pkg_width: 10.0
   pkg_height: 10.0
   pitch: 0.8
   pad_diameter: 0.4
+  mask_margin: 0.035
+  paste_margin: 0.000001
   layout_x: 12
   layout_y: 12
 Texas_DSBGA-49_3.33x3.488mm_Layout7x7_P0.4mm:
@@ -43,96 +47,117 @@ Texas_MicroStar_Junior_BGA-113_7.0x7.0mm_Layout12x12_P0.5mm:
   mask_margin: 0.025
   row_skips: [[], [], [[4, 11]], [3, 10], [3, 10], [3, 6, 7, 10], [3, 6, 7, 10], [3, 10], [3, 10], [[3, 11]], [], []]
 TFBGA-64_5x5mm_Layout8x8_P0.5mm:
-  description: "TFBGA-64, 8x8 raster, 5x5mm package, pitch 0.5mm; see section 6.3 of http://www.st.com/resource/en/datasheet/stm32f100v8.pdf"
+  description: "TFBGA-64, 8x8 raster, 5x5mm package, pitch 0.5mm; http://www.st.com/resource/en/datasheet/stm32f100v8.pdf#page=83"
   pkg_width: 5.0
   pkg_height: 5.0
   pitch: 0.5
   pad_diameter: 0.28
+  mask_margin: 0.045
+  paste_margin: 0.000001
   layout_x: 8
   layout_y: 8
 TFBGA-100_8x8mm_Layout10x10_P0.8mm:
-  description: "TFBGA-100, 10x10 raster, 8x8mm package, pitch 0.8mm; see section 6.2 of http://www.st.com/resource/en/datasheet/stm32f746zg.pdf"
+  description: "TFBGA-100, 10x10 raster, 8x8mm package, pitch 0.8mm; http://www.st.com/resource/en/datasheet/stm32f746zg.pdf#page=199"
   pkg_width: 8.0
   pkg_height: 8.0
   pitch: 0.8
   pad_diameter: 0.4
+  mask_margin: 0.035
+  paste_margin: 0.000001
   layout_x: 10
   layout_y: 10
 TFBGA-216_13x13mm_Layout15x15_P0.8mm:
-  description: "TFBGA-216, 15x15 raster, 13x13mm package, pitch 0.8mm; see section 6.8 of http://www.st.com/resource/en/datasheet/stm32f746zg.pdf"
+  description: "TFBGA-216, 15x15 raster, 13x13mm package, pitch 0.8mm; http://www.st.com/resource/en/datasheet/stm32f746zg.pdf#page=219"
   pkg_width: 13.0
   pkg_height: 13.0
   pitch: 0.8
   pad_diameter: 0.4
+  mask_margin: 0.035
+  paste_margin: 0.000001
   layout_x: 15
   layout_y: 15
   row_skips: [[], [], [], [], [], [], [[7, 10]], [[7, 10]], [[7, 10]], [], [], [], [], [], []]
 TFBGA-265_14x14mm_Layout17x17_P0.8mm:
-  description: "TFBGA-265, 17x17 raster, 14x14mm package, pitch 0.8mm; see section 7.8 of http://www.st.com/resource/en/datasheet/DM00387108.pdf"
+  description: "TFBGA-265, 17x17 raster, 14x14mm package, pitch 0.8mm; http://www.st.com/resource/en/datasheet/DM00387108.pdf#page=223"
   pkg_width: 14.0
   pkg_height: 14.0
   pitch: 0.8
   pad_diameter: 0.325
-  paste_ratio: -.115
+  mask_margin: 0.0325
+  paste_ratio: 0.0125
   layout_x: 17
   layout_y: 17
   row_skips: [[], [], [], [], [], [[6, 13]], [6, 12], [6, 12], [6, 12], [6, 12], [6, 12], [[6, 13]], [], [], [], [], []]
 UFBGA-64_5x5mm_Layout8x8_P0.5mm:
-  description: "UFBGA-64, 8x8 raster, 5x5mm package, pitch 0.5mm; see section 7.1 of http://www.st.com/resource/en/datasheet/stm32f051t8.pdf"
+  description: "UFBGA-64, 8x8 raster, 5x5mm package, pitch 0.5mm; http://www.st.com/resource/en/datasheet/stm32f051t8.pdf#page=91"
   pkg_width: 5.0
   pkg_height: 5.0
   pitch: 0.5
   pad_diameter: 0.28
+  mask_margin: 0.045
+  paste_margin: 0.000001
   layout_x: 8
   layout_y: 8
 UFBGA-100_7x7mm_Layout12x12_P0.5mm:
-  description: "UFBGA-100, 12x12 raster, 7x7mm package, pitch 0.5mm; see section 6.5 of http://www.st.com/resource/en/datasheet/stm32f103tb.pdf"
+  description: "UFBGA-100, 12x12 raster, 7x7mm package, pitch 0.5mm; http://www.st.com/resource/en/datasheet/stm32f103tb.pdf#page=93"
   pkg_width: 7.0
   pkg_height: 7.0
   pitch: 0.5
   pad_diameter: 0.28
+  mask_margin: 0.045
+  paste_margin: 0.000001
   layout_x: 12
   layout_y: 12
   row_skips: [[], [], [6, 7], [[4, 10]], [[4, 10]], [[3, 11]], [[3, 11]], [[4, 10]], [[4, 10]], [6, 7], [], []]
 UFBGA-132_7x7mm_Layout12x12_P0.5mm:
-  description: "UFBGA-132, 12x12 raster, 7x7mm package, pitch 0.5mm; see section 7.4 of http://www.st.com/resource/en/datasheet/stm32l152zc.pdf"
+  description: "UFBGA-132, 12x12 raster, 7x7mm package, pitch 0.5mm; http://www.st.com/resource/en/datasheet/stm32l152zc.pdf#page=123"
   pkg_width: 7.0
   pkg_height: 7.0
   pitch: 0.5
   pad_diameter: 0.27
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 12
   layout_y: 12
   row_skips: [[], [], [], [], [[5, 9]], [5, 8], [5, 8], [[5, 9]], [], [], [], []]
 UFBGA-144_7x7mm_Layout12x12_P0.5mm:
-  description: "UFBGA-144, 12x12 raster, 7x7mm package, pitch 0.5mm; see section 7.4 of http://www.st.com/resource/en/datasheet/stm32f446ze.pdf"
+  description: "UFBGA-144, 12x12 raster, 7x7mm package, pitch 0.5mm; http://www.st.com/resource/en/datasheet/stm32f446ze.pdf#page=186"
   pkg_width: 7.0
   pkg_height: 7.0
   pitch: 0.5
   pad_diameter: 0.28
+  mask_margin: 0.045
+  paste_margin: 0.000001
   layout_x: 12
   layout_y: 12
 UFBGA-144_10x10mm_Layout12x12_P0.8mm:
-  description: "UFBGA-144, 12x12 raster, 10x10mm package, pitch 0.8mm; see section 7.5 of http://www.st.com/resource/en/datasheet/stm32f446ze.pdf"
+  description: "UFBGA-144, 12x12 raster, 10x10mm package, pitch 0.8mm; http://www.st.com/resource/en/datasheet/stm32f446ze.pdf#page=189"
   pkg_width: 10.0
   pkg_height: 10.0
   pitch: 0.8
   pad_diameter: 0.4
+  mask_margin: 0.075
+  paste_margin: 0.000001
   layout_x: 12
   layout_y: 12
 UFBGA-169_7x7mm_Layout13x13_P0.5mm:
-  description: "UFBGA-169, 13x13 raster, 7x7mm package, pitch 0.5mm; see section 7.6 of http://www.st.com/resource/en/datasheet/stm32f429ng.pdf"
+  description: "UFBGA-169, 13x13 raster, 7x7mm package, pitch 0.5mm; http://www.st.com/resource/en/datasheet/stm32f429ng.pdf#page=218"
   pkg_width: 7.0
   pkg_height: 7.0
   pitch: 0.5
   pad_diameter: 0.27
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 13
   layout_y: 13
 UFBGA-201_10x10mm_Layout15x15_P0.65mm:
-  description: "UFBGA-201, 15x15 raster, 10x10mm package, pitch 0.65mm; see section 7.6 of http://www.st.com/resource/en/datasheet/stm32f207vg.pdf"
+  description: "UFBGA-201, 15x15 raster, 10x10mm package, pitch 0.65mm; http://www.st.com/resource/en/datasheet/stm32f207vg.pdf#page=166"
   pkg_width: 10.0
   pkg_height: 10.0
   pitch: 0.65
   pad_diameter: 0.3
+  mask_margin: 0.05
+  paste_margin: 0.000001
   layout_x: 15
   layout_y: 15
   row_skips: [[], [], [], [], [[5, 12]], [5, 11], [5, 11], [5, 11], [5, 11], [5, 11], [[5, 12]], [], [], [], []]

--- a/scripts/Package_BGA/csp.yml
+++ b/scripts/Package_BGA/csp.yml
@@ -109,44 +109,52 @@ ST_WLCSP-49_Die435:
   layout_x: 7
   layout_y: 7
 ST_WLCSP-49_Die438:
-  description: "WLCSP-49, 7x7 raster, 3.89x3.74mm package, pitch 0.5mm; see section 7.5 of http://www.st.com/resource/en/datasheet/stm32f303r8.pdf"
+  description: "WLCSP-49, 7x7 raster, 3.89x3.74mm package, pitch 0.5mm; http://www.st.com/resource/en/datasheet/stm32f303r8.pdf#page=112"
   pkg_width: 3.89
   pkg_height: 3.74
   pitch: 0.5
   pad_diameter: 0.29
-  paste_margin: 0.31
+  mask_margin: 0.03
+  paste_margin: 0.01
   layout_x: 7
   layout_y: 7
 ST_WLCSP-49_Die439:
-  description: "WLCSP-49, 7x7 raster, 3.417x3.151mm package, pitch 0.4mm; see section 7.1 of http://www.st.com/resource/en/datasheet/stm32f301r8.pdf"
+  description: "WLCSP-49, 7x7 raster, 3.417x3.151mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f301r8.pdf#page=117"
   pkg_width: 3.417
   pkg_height: 3.151
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 7
   layout_y: 7
 ST_WLCSP-49_Die447:
-  description: "WLCSP-49, 7x7 raster, 3.294x3.258mm package, pitch 0.4mm; see section 7.6 of http://www.st.com/resource/en/datasheet/stm32l072kz.pdf"
+  description: "WLCSP-49, 7x7 raster, 3.294x3.258mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32l072kz.pdf#page=134"
   pkg_width: 3.294
   pkg_height: 3.258
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 7
   layout_y: 7
 ST_WLCSP-49_Die448:
-  description: "WLCSP-49, 7x7 raster, 3.277x3.109mm package, pitch 0.4mm; see section 7.4 of http://www.st.com/resource/en/datasheet/stm32f071v8.pdf"
+  description: "WLCSP-49, 7x7 raster, 3.277x3.109mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f071v8.pdf#page=106"
   pkg_width: 3.277
   pkg_height: 3.109
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 7
   layout_y: 7
 ST_WLCSP-63_Die427:
-  description: "WLCSP-63, 7x9 raster, 3.228x4.164mm package, pitch 0.4mm; see section 7.6 of http://www.st.com/resource/en/datasheet/stm32l151cc.pdf"
+  description: "WLCSP-63, 7x9 raster, 3.228x4.164mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32l151cc.pdf#page=125"
   pkg_width: 3.228
   pkg_height: 4.164
   pitch: 0.4
   pad_diameter: 0.24
+  paste_margin: 0.000001
   layout_x: 7
   layout_y: 9
 ST_WLCSP-64_Die414:
@@ -236,6 +244,7 @@ ST_WLCSP-66_Die432:
   pkg_height: 4.229
   pitch: 0.4
   pad_diameter: 0.24
+  paste_margin: 0.000001
   layout_x: 8
   layout_y: 9
   row_skips: [[], [], [], [4, 5], [4, 5], [4, 5], [], [], []]
@@ -377,6 +386,8 @@ ST_WLCSP-168_Die434:
   pkg_height: 5.692
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 12
   layout_y: 14
 ST_WLCSP-180_Die451:

--- a/scripts/Package_BGA/csp.yml
+++ b/scripts/Package_BGA/csp.yml
@@ -12,7 +12,7 @@ ST_WLCSP-25_Die444:
   pkg_height: 2.325
   pitch: 0.4
   pad_diameter: 0.225
-  paste_diameter: 0.25
+  paste_margin: 0.25
   layout_x: 5
   layout_y: 5
 ST_WLCSP-25_Die457:
@@ -21,7 +21,7 @@ ST_WLCSP-25_Die457:
   pkg_height: 2.070
   pitch: 0.4
   pad_diameter: 0.225
-  paste_diameter: 0.25
+  paste_margin: 0.25
   layout_x: 5
   layout_y: 5
 ST_WLCSP-36_Die417:
@@ -54,7 +54,7 @@ ST_WLCSP-36_Die458:
   pkg_height: 2.579
   pitch: 0.4
   pad_diameter: 0.225
-  paste_diameter: 0.25
+  paste_margin: 0.25
   layout_x: 6
   layout_y: 6
 ST_WLCSP-49_Die423:
@@ -87,7 +87,7 @@ ST_WLCSP-49_Die435:
   pkg_height: 3.127
   pitch: 0.4
   pad_diameter: 0.225
-  paste_diameter: 0.25
+  paste_margin: 0.25
   layout_x: 7
   layout_y: 7
 ST_WLCSP-49_Die438:
@@ -96,7 +96,7 @@ ST_WLCSP-49_Die438:
   pkg_height: 3.74
   pitch: 0.5
   pad_diameter: 0.29
-  paste_diameter: 0.31
+  paste_margin: 0.31
   layout_x: 7
   layout_y: 7
 ST_WLCSP-49_Die439:
@@ -137,7 +137,7 @@ ST_WLCSP-64_Die414:
   pkg_height: 4.395
   pitch: 0.5
   pad_diameter: 0.25
-  paste_diameter: 0.32
+  paste_margin: 0.32
   layout_x: 8
   layout_y: 8
 ST_WLCSP-64_Die427:
@@ -154,7 +154,7 @@ ST_WLCSP-64_Die435:
   pkg_height: 3.127
   pitch: 0.35
   pad_diameter: 0.21
-  paste_diameter: 0.235
+  paste_margin: 0.235
   layout_x: 8
   layout_y: 8
 ST_WLCSP-64_Die436:
@@ -171,7 +171,7 @@ ST_WLCSP-64_Die441:
   pkg_height: 3.651
   pitch: 0.4
   pad_diameter: 0.225
-  paste_diameter: 0.25
+  paste_margin: 0.25
   layout_x: 8
   layout_y: 8
 ST_WLCSP-64_Die442:
@@ -188,7 +188,7 @@ ST_WLCSP-64_Die462:
   pkg_height: 3.657
   pitch: 0.4
   pad_diameter: 0.225
-  paste_diameter: 0.25
+  paste_margin: 0.25
   layout_x: 8
   layout_y: 8
 ST_WLCSP-66_Die411:
@@ -197,7 +197,7 @@ ST_WLCSP-66_Die411:
   pkg_height: 3.971
   pitch: 0.4
   pad_diameter: 0.225
-  paste_diameter: 0.25
+  paste_margin: 0.25
   layout_x: 9
   layout_y: 9
   row_skips: [[], [], [[4, 7]], [[4, 7]], [[4, 7]], [[4, 7]], [[4, 7]], [], []]
@@ -216,7 +216,7 @@ ST_WLCSP-72_Die415:
   pkg_height: 3.7594
   pitch: 0.4
   pad_diameter: 0.225
-  paste_diameter: 0.25
+  paste_margin: 0.25
   layout_x: 9
   layout_y: 9
   row_skips: [[], [], [], [[4, 7]], [[4, 7]], [[4, 7]], [], [], []]
@@ -226,7 +226,7 @@ ST_WLCSP-81_Die415:
   pkg_height: 3.7594
   pitch: 0.4
   pad_diameter: 0.225
-  paste_diameter: 0.25
+  paste_margin: 0.25
   layout_x: 9
   layout_y: 9
 ST_WLCSP-81_Die421:
@@ -235,7 +235,7 @@ ST_WLCSP-81_Die421:
   pkg_height: 3.815
   pitch: 0.4
   pad_diameter: 0.225
-  paste_diameter: 0.25
+  paste_margin: 0.25
   layout_x: 9
   layout_y: 9
 ST_WLCSP-81_Die463:
@@ -244,7 +244,7 @@ ST_WLCSP-81_Die463:
   pkg_height: 3.951
   pitch: 0.4
   pad_diameter: 0.225
-  paste_diameter: 0.25
+  paste_margin: 0.25
   layout_x: 9
   layout_y: 9
 ST_WLCSP-90_Die413:
@@ -310,7 +310,7 @@ ST_WLCSP-143_Die449:
   pkg_height: 5.849
   pitch: 0.4
   pad_diameter: 0.225
-  paste_diameter: 0.25
+  paste_margin: 0.25
   layout_x: 11
   layout_y: 13
 ST_WLCSP-144_Die470:
@@ -319,7 +319,7 @@ ST_WLCSP-144_Die470:
   pkg_height: 5.24
   pitch: 0.4
   pad_diameter: 0.225
-  paste_diameter: 0.25
+  paste_margin: 0.25
   layout_x: 12
   layout_y: 12
 ST_WLCSP-168_Die434:
@@ -336,7 +336,7 @@ ST_WLCSP-180_Die451:
   pkg_height: 6.095
   pitch: 0.4
   pad_diameter: 0.225
-  paste_diameter: 0.25
+  paste_margin: 0.25
   layout_x: 13
   layout_y: 14
   row_skips: [[], [], [], [], [], [], [7], [7], [], [], [], [], [], []]

--- a/scripts/Package_BGA/csp.yml
+++ b/scripts/Package_BGA/csp.yml
@@ -154,6 +154,7 @@ ST_WLCSP-63_Die427:
   pkg_height: 4.164
   pitch: 0.4
   pad_diameter: 0.24
+  mask_margin: 0.0325
   paste_margin: 0.000001
   layout_x: 7
   layout_y: 9
@@ -244,6 +245,7 @@ ST_WLCSP-66_Die432:
   pkg_height: 4.229
   pitch: 0.4
   pad_diameter: 0.24
+  mask_margin: 0.0325
   paste_margin: 0.000001
   layout_x: 8
   layout_y: 9

--- a/scripts/Package_BGA/csp.yml
+++ b/scripts/Package_BGA/csp.yml
@@ -1,93 +1,111 @@
 ST_WLCSP-25_Die425:
-  description: "WLCSP-25, 5x5 raster, 2.097x2.493mm package, pitch 0.4mm; see section 7.6 of http://www.st.com/resource/en/datasheet/stm32l031f6.pdf"
+  description: "WLCSP-25, 5x5 raster, 2.097x2.493mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32l031f6.pdf#page=112"
   pkg_width: 2.097
   pkg_height: 2.493
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 5
   layout_y: 5
 ST_WLCSP-25_Die444:
-  description: "WLCSP-25, 5x5 raster, 2.423x2.325mm package, pitch 0.4mm; see section 7.5 of http://www.st.com/resource/en/datasheet/stm32f031k6.pdf"
+  description: "WLCSP-25, 5x5 raster, 2.423x2.325mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f031k6.pdf#page=93"
   pkg_width: 2.423
   pkg_height: 2.325
   pitch: 0.4
   pad_diameter: 0.225
-  paste_margin: 0.25
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 5
   layout_y: 5
 ST_WLCSP-25_Die457:
-  description: "WLCSP-25, 5x5 raster, 2.133x2.070mm package, pitch 0.4mm; see section 7.3 of http://www.st.com/resource/en/datasheet/stm32l011k3.pdf"
+  description: "WLCSP-25, 5x5 raster, 2.133x2.070mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32l011k3.pdf#page=100"
   pkg_width: 2.133
   pkg_height: 2.070
   pitch: 0.4
   pad_diameter: 0.225
-  paste_margin: 0.25
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 5
   layout_y: 5
 ST_WLCSP-36_Die417:
-  description: "WLCSP-36, 6x6 raster, 2.61x2.88mm package, pitch 0.4mm; see section 7.4 of http://www.st.com/resource/en/datasheet/stm32l052t8.pdf"
+  description: "WLCSP-36, 6x6 raster, 2.61x2.88mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32l052t8.pdf#page=123"
   pkg_width: 2.61
   pkg_height: 2.88
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 6
   layout_y: 6
 ST_WLCSP-36_Die440:
-  description: "WLCSP-36, 6x6 raster, 2.605x2.703mm package, pitch 0.4mm; see section 7.5 of http://www.st.com/resource/en/datasheet/stm32f051t8.pdf"
+  description: "WLCSP-36, 6x6 raster, 2.605x2.703mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f051t8.pdf#page=103"
   pkg_width: 2.605
   pkg_height: 2.703
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 6
   layout_y: 6
 ST_WLCSP-36_Die445:
-  description: "WLCSP-36, 6x6 raster, 2.605x2.703mm package, pitch 0.4mm; see section 7.3 of http://www.st.com/resource/en/datasheet/stm32f042k6.pdf"
+  description: "WLCSP-36, 6x6 raster, 2.605x2.703mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f042k6.pdf#page=96"
   pkg_width: 2.605
   pkg_height: 2.703
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 6
   layout_y: 6
 ST_WLCSP-36_Die458:
-  description: "WLCSP-36, 6x6 raster, 2.553x2.579mm package, pitch 0.4mm; see section 7.1 of http://www.st.com/resource/en/datasheet/stm32f410t8.pdf"
+  description: "WLCSP-36, 6x6 raster, 2.553x2.579mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f410t8.pdf#page=119"
   pkg_width: 2.553
   pkg_height: 2.579
   pitch: 0.4
   pad_diameter: 0.225
-  paste_margin: 0.25
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 6
   layout_y: 6
 ST_WLCSP-49_Die423:
-  description: "WLCSP-49, 7x7 raster, 2.965x2.965mm package, pitch 0.4mm; see section 7.1 of http://www.st.com/resource/en/datasheet/stm32f401vc.pdf"
+  description: "WLCSP-49, 7x7 raster, 2.965x2.965mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f401vc.pdf#page=115"
   pkg_width: 2.965
   pkg_height: 2.965
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 7
   layout_y: 7
 ST_WLCSP-49_Die431:
-  description: "WLCSP-49, 7x7 raster, 2.999x3.185mm package, pitch 0.4mm; see section 7.1 of http://www.st.com/resource/en/datasheet/stm32f411vc.pdf"
+  description: "WLCSP-49, 7x7 raster, 2.999x3.185mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f411vc.pdf#page=124"
   pkg_width: 2.999
   pkg_height: 3.185
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 7
   layout_y: 7
 ST_WLCSP-49_Die433:
-  description: "WLCSP-49, 7x7 raster, 3.029x3.029mm package, pitch 0.4mm; see section 7.1.1 of http://www.st.com/resource/en/datasheet/stm32f401ce.pdf"
+  description: "WLCSP-49, 7x7 raster, 3.029x3.029mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f401ce.pdf#page=116"
   pkg_width: 3.029
   pkg_height: 3.029
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 7
   layout_y: 7
 ST_WLCSP-49_Die435:
-  description: "WLCSP-49, 7x7 raster, 3.141x3.127mm package, pitch 0.4mm; see section 7.6 of http://www.st.com/resource/en/datasheet/DM00257211.pdf"
+  description: "WLCSP-49, 7x7 raster, 3.141x3.127mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/DM00257211.pdf#page=191"
   pkg_width: 3.141
   pkg_height: 3.127
   pitch: 0.4
   pad_diameter: 0.225
-  paste_margin: 0.25
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 7
   layout_y: 7
 ST_WLCSP-49_Die438:
@@ -132,77 +150,88 @@ ST_WLCSP-63_Die427:
   layout_x: 7
   layout_y: 9
 ST_WLCSP-64_Die414:
-  description: "WLCSP-64, 8x8 raster, 4.466x4.395mm package, pitch 0.5mm; see section 6.3 of http://www.st.com/resource/en/datasheet/stm32f103ze.pdf"
+  description: "WLCSP-64, 8x8 raster, 4.466x4.395mm package, pitch 0.5mm; http://www.st.com/resource/en/datasheet/stm32f103ze.pdf#page=120"
   pkg_width: 4.466
   pkg_height: 4.395
   pitch: 0.5
   pad_diameter: 0.25
-  paste_margin: 0.32
+  mask_margin: 0.025
+  paste_margin: 0.035
   layout_x: 8
   layout_y: 8
 ST_WLCSP-64_Die427:
-  description: "WLCSP-64, 8x8 raster, 4.539x4.911mm package, pitch 0.4mm; see section 7.5 of http://www.st.com/resource/en/datasheet/stm32l152zc.pdf"
+  description: "WLCSP-64, 8x8 raster, 4.539x4.911mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32l152zc.pdf#page=126"
   pkg_width: 4.539
   pkg_height: 4.911
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 8
   layout_y: 8
 ST_WLCSP-64_Die435:
-  description: "WLCSP-64, 8x8 raster, 3.141x3.127mm package, pitch 0.35mm; see section 7.5 of http://www.st.com/resource/en/datasheet/DM00257211.pdf"
+  description: "WLCSP-64, 8x8 raster, 3.141x3.127mm package, pitch 0.35mm; http://www.st.com/resource/en/datasheet/DM00257211.pdf#page=188"
   pkg_width: 3.141
   pkg_height: 3.127
   pitch: 0.35
   pad_diameter: 0.21
-  paste_margin: 0.235
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 8
   layout_y: 8
 ST_WLCSP-64_Die436:
-  description: "WLCSP-64, 8x8 raster, 4.539x4.911mm package, pitch 0.4mm; see section 7.5 of http://www.st.com/resource/en/datasheet/stm32l152zd.pdf"
+  description: "WLCSP-64, 8x8 raster, 4.539x4.911mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32l152zd.pdf#page=143"
   pkg_width: 4.539
   pkg_height: 4.911
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 8
   layout_y: 8
 ST_WLCSP-64_Die441:
-  description: "WLCSP-64, 8x8 raster, 3.623x3.651mm package, pitch 0.4mm; see section 7.1 of http://www.st.com/resource/en/datasheet/DM00213872.pdf"
+  description: "WLCSP-64, 8x8 raster, 3.623x3.651mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/DM00213872.pdf#page=167"
   pkg_width: 3.623
   pkg_height: 3.651
   pitch: 0.4
   pad_diameter: 0.225
-  paste_margin: 0.25
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 8
   layout_y: 8
 ST_WLCSP-64_Die442:
-  description: "WLCSP-64, 8x8 raster, 3.347x3.585mm package, pitch 0.4mm; see section 7.4 of http://www.st.com/resource/en/datasheet/stm32f091vb.pdf"
+  description: "WLCSP-64, 8x8 raster, 3.347x3.585mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f091vb.pdf#page=109"
   pkg_width: 3.347
   pkg_height: 3.585
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 8
   layout_y: 8
 ST_WLCSP-64_Die462:
-  description: "WLCSP-64, 8x8 raster, 3.357x3.657mm package, pitch 0.4mm; see section 7.5 of http://www.st.com/resource/en/datasheet/DM00340475.pdf"
+  description: "WLCSP-64, 8x8 raster, 3.357x3.657mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/DM00340475.pdf#page=189"
   pkg_width: 3.357
   pkg_height: 3.657
   pitch: 0.4
   pad_diameter: 0.225
-  paste_margin: 0.25
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 8
   layout_y: 8
 ST_WLCSP-66_Die411:
-  description: "WLCSP-66, 9x9 raster, 3.639x3.971mm package, pitch 0.4mm; see section 7.2 of http://www.st.com/resource/en/datasheet/stm32f207vg.pdf"
+  description: "WLCSP-66, 9x9 raster, 3.639x3.971mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f207vg.pdf#page=154"
   pkg_width: 3.639
   pkg_height: 3.971
   pitch: 0.4
   pad_diameter: 0.225
-  paste_margin: 0.25
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 9
   layout_y: 9
   row_skips: [[], [], [[4, 7]], [[4, 7]], [[4, 7]], [[4, 7]], [[4, 7]], [], []]
 ST_WLCSP-66_Die432:
-  description: "WLCSP-66, 8x9 raster, 3.767x4.229mm package, pitch 0.4mm; see section 7.2 of http://www.st.com/resource/en/datasheet/stm32f378vc.pdf"
+  description: "WLCSP-66, 8x9 raster, 3.767x4.229mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f378vc.pdf#page=114"
   pkg_width: 3.767
   pkg_height: 4.229
   pitch: 0.4
@@ -211,119 +240,139 @@ ST_WLCSP-66_Die432:
   layout_y: 9
   row_skips: [[], [], [], [4, 5], [4, 5], [4, 5], [], [], []]
 ST_WLCSP-72_Die415:
-  description: "WLCSP-72, 9x9 raster, 4.4084x3.7594mm package, pitch 0.4mm; see section 7.5 of http://www.st.com/resource/en/datasheet/stm32l476me.pdf"
+  description: "WLCSP-72, 9x9 raster, 4.4084x3.7594mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32l476me.pdf#page=255"
   pkg_width: 4.4084
   pkg_height: 3.7594
   pitch: 0.4
   pad_diameter: 0.225
-  paste_margin: 0.25
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 9
   layout_y: 9
   row_skips: [[], [], [], [[4, 7]], [[4, 7]], [[4, 7]], [], [], []]
 ST_WLCSP-81_Die415:
-  description: "WLCSP-81, 9x9 raster, 4.4084x3.7594mm package, pitch 0.4mm; see section 7.4 of http://www.st.com/resource/en/datasheet/stm32l476me.pdf"
+  description: "WLCSP-81, 9x9 raster, 4.4084x3.7594mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32l476me.pdf#page=252"
   pkg_width: 4.4084
   pkg_height: 3.7594
   pitch: 0.4
   pad_diameter: 0.225
-  paste_margin: 0.25
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 9
   layout_y: 9
 ST_WLCSP-81_Die421:
-  description: "WLCSP-81, 9x9 raster, 3.693x3.815mm package, pitch 0.4mm; see section 7.6 of http://www.st.com/resource/en/datasheet/stm32f446ze.pdf"
+  description: "WLCSP-81, 9x9 raster, 3.693x3.815mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f446ze.pdf#page=192"
   pkg_width: 3.693
   pkg_height: 3.815
   pitch: 0.4
   pad_diameter: 0.225
-  paste_margin: 0.25
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 9
   layout_y: 9
 ST_WLCSP-81_Die463:
-  description: "WLCSP-81, 9x9 raster, 4.039x3.951mm package, pitch 0.4mm; see section 7.1 of http://www.st.com/resource/en/datasheet/DM00282249.pdf"
+  description: "WLCSP-81, 9x9 raster, 4.039x3.951mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/DM00282249.pdf#page=175"
   pkg_width: 4.039
   pkg_height: 3.951
   pitch: 0.4
   pad_diameter: 0.225
-  paste_margin: 0.25
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 9
   layout_y: 9
 ST_WLCSP-90_Die413:
-  description: "WLCSP-90, 10x9 raster, 4.223x3.969mm package, pitch 0.4mm; see section 6.1 of http://www.st.com/resource/en/datasheet/stm32f405og.pdf"
+  description: "WLCSP-90, 10x9 raster, 4.223x3.969mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f405og.pdf#page=164"
   pkg_width: 4.223
   pkg_height: 3.969
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 10
   layout_y: 9
 ST_WLCSP-100_Die422:
-  description: "WLCSP-100, 10x10 raster, 4.201x4.663mm package, pitch 0.4mm; see section 7.4 of http://www.st.com/resource/en/datasheet/stm32f302vc.pdf"
+  description: "WLCSP-100, 10x10 raster, 4.201x4.663mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f302vc.pdf#page=133"
   pkg_width: 4.201
   pkg_height: 4.663
   pitch: 0.4
   pad_diameter: 0.225
+  mask_margin: 0.0325
+  paste_margin: 0.000001
   layout_x: 10
   layout_y: 10
 ST_WLCSP-100_Die446:
-  description: "WLCSP-100, 10x10 raster, 4.775x5.041mm package, pitch 0.4mm; see section 7.5 of http://www.st.com/resource/en/datasheet/stm32f303zd.pdf"
+  description: "WLCSP-100, 10x10 raster, 4.775x5.041mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f303zd.pdf#page=162"
   pkg_width: 4.775
   pkg_height: 5.041
   pitch: 0.4
   pad_diameter: 0.225
+  mask_margin: 0.0325
+  paste_margin: 0.000001
   layout_x: 10
   layout_y: 10
 ST_WLCSP-100_Die452:
-  description: "WLCSP-100, 10x10 raster, 4.201x4.663mm package, pitch 0.4mm; see section 7.7 of http://www.st.com/resource/en/datasheet/DM00330506.pdf"
+  description: "WLCSP-100, 10x10 raster, 4.201x4.663mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/DM00330506.pdf#page=218"
   pkg_width: 4.201
   pkg_height: 4.663
   pitch: 0.4
   pad_diameter: 0.225
+  mask_margin: 0.0325
+  paste_margin: 0.000001
   layout_x: 10
   layout_y: 10
 ST_WLCSP-100_Die461:
-  description: "WLCSP-100, 10x10 raster, 4.618x4.142mm package, pitch 0.4mm; see section 7.5 of http://www.st.com/resource/en/datasheet/DM00284211.pdf"
+  description: "WLCSP-100, 10x10 raster, 4.618x4.142mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/DM00284211.pdf#page=259"
   pkg_width: 4.618
   pkg_height: 4.142
   pitch: 0.4
   pad_diameter: 0.225
+  mask_margin: 0.0325
+  paste_margin: 0.000001
   layout_x: 10
   layout_y: 10
 ST_WLCSP-104_Die437:
-  description: "WLCSP-104, 9x12 raster, 4.095x5.094mm package, pitch 0.4mm; see section 7.5 of http://www.st.com/resource/en/datasheet/stm32l152ze.pdf"
+  description: "WLCSP-104, 9x12 raster, 4.095x5.094mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32l152ze.pdf#page=127"
   pkg_width: 4.095
   pkg_height: 5.094
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 9
   layout_y: 12
   row_skips: [[], [], [], [], [5], [5], [5], [5], [], [], [], []]
 ST_WLCSP-143_Die419:
-  description: "WLCSP-143, 11x13 raster, 4.521x5.547mm package, pitch 0.4mm; see section 7.2 of http://www.st.com/resource/en/datasheet/stm32f429ng.pdf"
+  description: "WLCSP-143, 11x13 raster, 4.521x5.547mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f429ng.pdf#page=203"
   pkg_width: 4.521
   pkg_height: 5.547
   pitch: 0.4
   pad_diameter: 0.22
+  mask_margin: 0.04
+  paste_margin: 0.000001
   layout_x: 11
   layout_y: 13
 ST_WLCSP-143_Die449:
-  description: "WLCSP-143, 11x13 raster, 4.539x5.849mm package, pitch 0.4mm; see section 6.3 of http://www.st.com/resource/en/datasheet/stm32f746zg.pdf"
+  description: "WLCSP-143, 11x13 raster, 4.539x5.849mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f746zg.pdf#page=202"
   pkg_width: 4.539
   pkg_height: 5.849
   pitch: 0.4
   pad_diameter: 0.225
-  paste_margin: 0.25
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 11
   layout_y: 13
 ST_WLCSP-144_Die470:
-  description: "WLCSP-144, 12x12 raster, 5.24x5.24mm package, pitch 0.4mm; see section 7.4 of http://www.st.com/resource/en/datasheet/DM00366448.pdf"
+  description: "WLCSP-144, 12x12 raster, 5.24x5.24mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/DM00366448.pdf#page=295"
   pkg_width: 5.24
   pkg_height: 5.24
   pitch: 0.4
   pad_diameter: 0.225
-  paste_margin: 0.25
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 12
   layout_y: 12
 ST_WLCSP-168_Die434:
-  description: "WLCSP-168, 12x14 raster, 4.891x5.692mm package, pitch 0.4mm; see section 6.3 of http://www.st.com/resource/en/datasheet/stm32f469ni.pdf"
+  description: "WLCSP-168, 12x14 raster, 4.891x5.692mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/stm32f469ni.pdf#page=198"
   pkg_width: 4.891
   pkg_height: 5.692
   pitch: 0.4
@@ -331,12 +380,13 @@ ST_WLCSP-168_Die434:
   layout_x: 12
   layout_y: 14
 ST_WLCSP-180_Die451:
-  description: "WLCSP-180, 13x14 raster, 5.537x6.095mm package, pitch 0.4mm; see section 6.6 of http://www.st.com/resource/en/datasheet/DM00273119.pdf"
+  description: "WLCSP-180, 13x14 raster, 5.537x6.095mm package, pitch 0.4mm; http://www.st.com/resource/en/datasheet/DM00273119.pdf#page=240"
   pkg_width: 5.537
   pkg_height: 6.095
   pitch: 0.4
   pad_diameter: 0.225
-  paste_margin: 0.25
+  mask_margin: 0.0325
+  paste_margin: 0.0125
   layout_x: 13
   layout_y: 14
   row_skips: [[], [], [], [], [], [], [7], [7], [], [], [], [], [], []]


### PR DESCRIPTION
When added the footprints at https://github.com/KiCad/kicad-footprints/pull/718, @Ratfink mentioned that I should use his generator. He was right.

I added the footprint entries, then found two things:
1. KiCad comes with Python 2.7 and I used that for broadest compatibility (why they've not gone to 3 I don't know...).
2. This framework didn't support the global settings for pad mask/paste.

This commit adds the BGAs info the YAML file, updates the BGA script to support global mask/paste settings, and also updates the framework to support the same.

Clay, you probably should take a look here. Does everything look OK to you? I realized it really make no sense to use per-pad mask/paste settings since it would be applied to every single pad in the footprint, and so this only made sense. I also aligned some of the variable terminology with the framework.

Quick per-file breakdown of changes:
bga.yml
- Added entries for 3 TI footprints

bga.py
- Made denominators floats for Python 2.7 compatibility
- Simplified CSP BGA 3D model repo determination
- Support CSP in keywords if appropriate
- Silkscreen offset to 0.11mm (was 0.12mm)
- Support mask/paste clearance parameters for whole footprint (not per pad)

Pad.py
- Fixed typo
- Minor wordsmithing
- Used a more explicit variable name since elsewhere is full words

Footprint.py / KicadFileHandler.py:
- Support mask margin, paste margin, and paste margin ratio