### PR TITLE
Update footprint convention and add TO-220F-4 3.18mm

### DIFF
--- a/scripts/Packages/TO_SOT_THT/TO_SOT_THT_generate.py
+++ b/scripts/Packages/TO_SOT_THT/TO_SOT_THT_generate.py
@@ -1,3 +1,10 @@
+'''
+StaggerType1 = StaggerOdd
+StaggerType2 = StaggerEven
+
+TODO: TabUp with staggered leads
+'''
+
 #usr/bin/env python
 
 import sys
@@ -47,18 +54,20 @@ def makeVERT(lib_name, pck, has3d=False, x_3d=[0, 0, 0], s_3d=[1,1,1], lptext="_
     y1=0
     y2=0
     maxpiny=0
-    if pck.staggered_type == 1:
+    if pck.staggered_type == 1: # odd
         y1 = pck.staggered_rm[0]
         yshift = -pck.staggered_rm[0]
         y2 = 0
         maxpiny = pck.staggered_rm[0]
+        pin1_length = maxpiny - t_fabp - h_fabp
         if len(pck.staggered_pad)>0:
             padsize=pck.staggered_pad
-    elif pck.staggered_type == 2:
+    elif pck.staggered_type == 2: # even
         y1 = 0
         yshift = 0
         y2=pck.staggered_rm[0]
         maxpiny = pck.staggered_rm[0]
+        pin1_length = abs(t_fabp + h_fabp)
         if len(pck.staggered_pad) > 0:
             padsize = pck.staggered_pad
 
@@ -92,14 +101,18 @@ def makeVERT(lib_name, pck, has3d=False, x_3d=[0, 0, 0], s_3d=[1,1,1], lptext="_
     footprint_name = pck.name
     for t in pck.more_packnames:
         footprint_name = footprint_name + "_" + t
-    footprint_name = footprint_name + "_Vertical"
+    #footprint_name = footprint_name + "_Vertical"
+    if pck.staggered_type>0:
+        #footprint_name = footprint_name + "_Py{0}mm".format(pck.staggered_rm[0],3)
+        footprint_name = footprint_name + "_P{}x{}mm".format(pck.rm * 2,pck.staggered_rm[0],3)
     for t in pck.fpnametags:
         footprint_name = footprint_name + "_" + t
     if pck.staggered_type>0:
-        footprint_name = footprint_name + "_Py{0}mm".format(pck.staggered_rm[0],3)
+        footprint_name = footprint_name + "_Lead{}mm".format(pin1_length,3)
     if pck.largepads:
         tag_items.append("large Pads")
         footprint_name = footprint_name + lptext
+    footprint_name = footprint_name + "_Vertical"
 
     print(footprint_name)
 
@@ -244,18 +257,20 @@ def makeHOR(lib_name, pck, has3d=False, x_3d=[0, 0, 0], s_3d=[1,1,1], lptext="_L
     y1 = 0
     y2 = 0
     maxpiny = 0
-    if pck.staggered_type == 1:
+    if pck.staggered_type == 1: # odd
         y1 = pck.staggered_rm[1]
         yshift = -pck.staggered_rm[1]
         y2 = 0
         maxpiny = pck.staggered_rm[1]
+        pin1_length = abs(t_fabp) + abs(pck.staggered_rm[1])
         if len(pck.staggered_pad) > 0:
             padsize = pck.staggered_pad
-    elif pck.staggered_type == 2:
+    elif pck.staggered_type == 2: # even
         y1 = 0
         yshift = 0
         y2 = pck.staggered_rm[1]
         maxpiny = pck.staggered_rm[1]
+        pin1_length = abs(t_fabp)
         if len(pck.staggered_pad) > 0:
             padsize = pck.staggered_pad
 
@@ -302,19 +317,23 @@ def makeHOR(lib_name, pck, has3d=False, x_3d=[0, 0, 0], s_3d=[1,1,1], lptext="_L
     txt_b = maxpiny+padsize[1] / 2 + txt_offset
     if len(pck.additional_pin_pad_size) > 0:
         txt_t = txt_t - (pck.additional_pin_pad[1] + pck.additional_pin_pad_size[1] / 2 - h_fabm)
-    tag_items = ["Horizontal", "RM {0}mm".format(pck.rm)]
+    #tag_items = ["Horizontal", "RM {0}mm".format(pck.rm)]
+    tag_items = ["Tab Down", "RM {0}mm".format(pck.rm)]
 
     footprint_name = pck.name
     if len(pck.additional_pin_pad_size) > 0:
         footprint_name = footprint_name + "-1EP"
     for t in pck.more_packnames:
         footprint_name = footprint_name + "_" + t
-    footprint_name = footprint_name + "_Horizontal_TabDown"
+    #footprint_name = footprint_name + "_Horizontal_TabDown"
+    if pck.staggered_type>0:
+        #footprint_name = footprint_name + "_Py{0}mm".format(pck.staggered_rm[1],3)
+        footprint_name = footprint_name + "_P{}x{}mm".format(pck.rm * 2, pck.staggered_rm[1],3)
     for t in pck.fpnametags:
         footprint_name = footprint_name + "_" + t
-
     if pck.staggered_type>0:
-        footprint_name = footprint_name + "_Py{0}mm".format(pck.staggered_rm[1],3)
+        footprint_name = footprint_name + "_Lead{}mm".format(pin1_length,3)
+    footprint_name = footprint_name + "_TabDown"
 
     if pck.largepads:
         tag_items.append("large Pads")
@@ -448,6 +467,7 @@ def makeHOR(lib_name, pck, has3d=False, x_3d=[0, 0, 0], s_3d=[1,1,1], lptext="_L
 
 
 # vertical, mounted-from-Lowerside symbols for rectangular transistors
+# this should not be used since footprints can be mirrored to the bottom side
 def makeVERTLS(lib_name, pck, has3d=False, x_3d=[0, 0, 0], s_3d=[1,1,1], lptext="_LargePads", r_3d=[0, 0, 0]):
     l_fabp = -pck.pin_offset_x
     t_fabp = -pck.pin_offset_z
@@ -484,13 +504,14 @@ def makeVERTLS(lib_name, pck, has3d=False, x_3d=[0, 0, 0], s_3d=[1,1,1], lptext=
     footprint_name = pck.name
     for t in pck.more_packnames:
         footprint_name = footprint_name + "_" + t
-    footprint_name = footprint_name + "_Vertical"
+    #footprint_name = footprint_name + "_Vertical"
     for t in pck.fpnametags:
         footprint_name = footprint_name + "_" + t
-    footprint_name = footprint_name + "_MountFromLS"
+    #footprint_name = footprint_name + "_MountFromLS"
     if pck.largepads:
         tag_items.append("large Pads")
         footprint_name = footprint_name + lptext
+    footprint_name = footprint_name + "_Vertical"
 
     print(footprint_name)
 
@@ -622,6 +643,7 @@ def makeVERTLS(lib_name, pck, has3d=False, x_3d=[0, 0, 0], s_3d=[1,1,1], lptext=
 
 
 # horizontal, mounted-from-Lowerside symbols for rectangular transistors
+# this should not be used since footprint can be mirrored
 def makeHORLS(lib_name, pck, has3d=False, x_3d=[0, 0, 0], s_3d=[1,1,1], lptext="_LargePads", r_3d=[0, 0, 0]):
     l_fabp = -pck.pin_offset_x
     t_fabp = -pck.pin_minlength
@@ -671,10 +693,11 @@ def makeHORLS(lib_name, pck, has3d=False, x_3d=[0, 0, 0], s_3d=[1,1,1], lptext="
         footprint_name = footprint_name + "-1EP"
     for t in pck.more_packnames:
         footprint_name = footprint_name + "_" + t
-    footprint_name = footprint_name + "_Horizontal"
+    #footprint_name = footprint_name + "_Horizontal"
     for t in pck.fpnametags:
         footprint_name = footprint_name + "_" + t
-    footprint_name = footprint_name + "_TabUp_MountFromLS"
+    #footprint_name = footprint_name + "_TabUp_MountFromLS"
+    footprint_name = footprint_name + "_TabUp"
     if pck.largepads:
         tag_items.append("large Pads")
         footprint_name = footprint_name + lptext
@@ -867,9 +890,10 @@ def makeHORREV(lib_name, pck, has3d=False, x_3d=[0, 0, 0], s_3d=[1 ,1,1], lptext
     footprint_name = pck.name
     for t in pck.more_packnames:
         footprint_name = footprint_name + "_" + t
-    footprint_name = footprint_name + "_Horizontal" + "_TabUp"
+    #footprint_name = footprint_name + "_Horizontal" + "_TabUp"
     for t in pck.fpnametags:
         footprint_name = footprint_name + "_" + t
+    footprint_name = footprint_name + "_TabUp"
     if pck.largepads:
         tag_items.append("large Pads")
         footprint_name = footprint_name + lptext

--- a/scripts/Packages/TO_SOT_THT/TO_THT_packages.py
+++ b/scripts/Packages/TO_SOT_THT/TO_THT_packages.py
@@ -229,15 +229,15 @@ class pack:
         self.mounting_hole_pos = [0, 0]  # position of mounting hole from bottom-left
         self.mounting_hole_diameter = 0  # diameter of mounting hole in package
         self.mounting_hole_drill = 0  # diameter of mounting hole drill
-        self.pin_minlength = 0  # min. elongation of pins before 90° bend
+        self.pin_minlength = 0  # min. elongation of pins before 90 deg bend
         self.pinw = [0, 0];  # width,height of pins
         self.tags = []  # description/keywords
         self.pin_offset_x = 0
         self.pin_offset_z = 0
         self.largepads =False
         self.fpnametags =[]
-        self.additional_pin_pad =[] # Position des Zusatz-SMD-Pads
-        self.additional_pin_pad_size = [] # Größe des Zusatz-SMD-Pads
+        self.additional_pin_pad =[] # Position of additional SMD pads
+        self.additional_pin_pad_size = [] # size of additional SMD pads
         self.plastic_angled=[]
         self.metal_angled = []
         self.staggered_type=0 # 0=no staggering, 1=type1-staggering (pin1=fron), 2=type2-staggering (pin1=back)
@@ -250,8 +250,8 @@ class pack:
         self.webpage="";
 
     def __init__(self ,name ,pins=3 ,rm=0, staggered_type=0,largepads=False,pitchy=0,ypinoffset=0):
-        self. additional_pin_pad =[] # Position des Zusatz-SMD-Pads
-        self.additional_pin_pad_size = [] # Größe des Zusatz-SMD-Pads
+        self. additional_pin_pad =[] # Position of additional SMD pads
+        self.additional_pin_pad_size = [] # size of additional SMD pads
         self.largepads =largepads
         self.fpnametags = []
         self.metal_offset_x = 0  # offset of metal from left
@@ -280,7 +280,7 @@ class pack:
             self.mounting_hole_pos = [self.plastic[0] / 2, 16.2]  # position of mounting hole from bottom-left
             self.mounting_hole_diameter = 4.23  # diameter of mounting hole in package
             self.mounting_hole_drill = 4.04  # diameter of mounting hole drill
-            self.pin_minlength = 2.35  # min. elongation of pins before 90° bend
+            self.pin_minlength = 2.35  # min. elongation of pins before 90 deg bend
             self.pinw = [1.15, 0.4];  # width,height of pins
             self.tags = ["SOT-93"]  # description/keywords
             #self.more_packnames.append("SOT-93")
@@ -303,7 +303,7 @@ class pack:
                                       self.plastic[1] - 3.5]  # position of mounting hole from bottom-left
             self.mounting_hole_diameter = 3.2  # diameter of mounting hole in package
             self.mounting_hole_drill = 3.4  # diameter of mounting hole drill
-            self.pin_minlength = 3.0  # min. elongation of pins before 90° bend
+            self.pin_minlength = 3.0  # min. elongation of pins before 90 deg bend
             self.pinw = [1.0, 0.6];  # width,height of pins
             self.tags = []
             self.metal_angled=[1.15,2]
@@ -328,7 +328,7 @@ class pack:
                                       self.plastic[1] - 3.5]  # position of mounting hole from bottom-left
             self.mounting_hole_diameter = 3.2  # diameter of mounting hole in package
             self.mounting_hole_drill = 3.4  # diameter of mounting hole drill
-            self.pin_minlength = 1.6  # min. elongation of pins before 90° bend
+            self.pin_minlength = 1.6  # min. elongation of pins before 90 deg bend
             self.pinw = [1.0, 0.6];  # width,height of pins
             self.tags = []
             self.metal_angled=[1.3,2.3]
@@ -356,7 +356,7 @@ class pack:
                                       self.plastic[1] - 6]  # position of mounting hole from bottom-left
             self.mounting_hole_diameter = 3.3  # diameter of mounting hole in package
             self.mounting_hole_drill = 3.3  # diameter of mounting hole drill
-            self.pin_minlength = 5.08  # min. elongation of pins before 90° bend
+            self.pin_minlength = 5.08  # min. elongation of pins before 90 deg bend
             self.pinw = [1, 0.6];  # width,height of pins
             self.tags = []  # description/keywords
             self.pin_offset_z = self.plastic[2] - (2.8 + 0.3)
@@ -381,7 +381,7 @@ class pack:
                                       self.plastic[1] - 6.17]  # position of mounting hole from bottom-left
             self.mounting_hole_diameter = 3.61  # diameter of mounting hole in package
             self.mounting_hole_drill = 3.6  # diameter of mounting hole drill
-            self.pin_minlength = 5.08  # min. elongation of pins before 90° bend
+            self.pin_minlength = 5.08  # min. elongation of pins before 90 deg bend
             self.pinw = [1.2, 0.6];  # width,height of pins
             self.tags = []
             if (pins==4):
@@ -415,7 +415,7 @@ class pack:
                                       self.metal[1] - 2.8]  # position of mounting hole from bottom-left
             self.mounting_hole_diameter = 3.7  # diameter of mounting hole in package
             self.mounting_hole_drill = 3.5  # diameter of mounting hole drill
-            self.pin_minlength = 3.81  # min. elongation of pins before 90° bend
+            self.pin_minlength = 3.81  # min. elongation of pins before 90 deg bend
             self.pinw = [0.75, 0.5];  # width,height of pins
             self.tags = []  # description/keywords
             self.pin_offset_z = 3.15
@@ -456,7 +456,7 @@ class pack:
                 self.mounting_hole_pos = [self.plastic[0] / 2, 17.5-2.8]  # position of mounting hole from bottom-left
                 self.mounting_hole_diameter = 3.7  # diameter of mounting hole in package
                 self.mounting_hole_drill = 3.5  # diameter of mounting hole drill
-                self.pin_minlength = 3.81  # min. elongation of pins before 90° bend
+                self.pin_minlength = 3.81  # min. elongation of pins before 90 deg bend
                 self.pinw = [0.7, 0.5];  # width,height of pins
                 self.tags = []  # description/keywords
                 self.pin_offset_z = 4.55
@@ -470,12 +470,15 @@ class pack:
                 self.largepads = True
 
         elif (name == "TO-220F"):
+            self.staggered_rm = [3.7,3.8]# y-distance between pins
             if pins==2:
                 self.webpage="http://www.onsemi.com/pub/Collateral/FFPF10F150S-D.pdf"
             if pins==3:
                 self.webpage="http://www.st.com/resource/en/datasheet/stp20nm60.pdf"
             if pins==4:
                 self.webpage="https://www.njr.com/semicon/PDF/package/TO-220F-4_E.pdf"
+                #uncomment below line to generate 3.18mm offset for https://www.fairchildsemi.com/datasheets/KA/KA5M0265R.pdf
+                #self.staggered_rm = [3.18,3.8]
             self.plastic = [10.26, 15.87-6.68, 4.7]  # width,heigth,depth of plastic package, starting at bottom-left
             self.metal = [self.plastic[0], 15.87, 2.52]  # width,heigth,thickness of metal plate, starting at metal_offset from bottom-left
             self.pins = 3  # number of pins
@@ -487,11 +490,10 @@ class pack:
                                       self.metal[1] - 3.3]  # position of mounting hole from bottom-left
             self.mounting_hole_diameter = 3.7  # diameter of mounting hole in package
             self.mounting_hole_drill = 3.5  # diameter of mounting hole drill
-            self.pin_minlength = 3.23  # min. elongation of pins before 90° bend
+            self.pin_minlength = 3.23  # min. elongation of pins before 90 deg bend
             self.pinw = [0.6, 0.7];  # width,height of pins
             self.tags = []  # description/keywords
             self.pin_offset_z = 2.76+0.575/2
-            self.staggered_rm = [3.7,3.8]# y-distance between pins
             self.staggered_pin_offset_z = 4.5  # z-offset of back-pins in staggered mode
             self.staggered_pin_minlength = 2.05  # y-offset of back-pins in staggered mode
             self.staggered_pad = [1.8, 1.8]  # width/height of pads
@@ -523,7 +525,7 @@ class pack:
                 self.mounting_hole_pos = [self.plastic[0] / 2, 17.5-2.8]  # position of mounting hole from bottom-left
                 self.mounting_hole_diameter = 3.7  # diameter of mounting hole in package
                 self.mounting_hole_drill = 3.5  # diameter of mounting hole drill
-                self.pin_minlength = 3.81  # min. elongation of pins before 90° bend
+                self.pin_minlength = 3.81  # min. elongation of pins before 90 deg bend
                 self.pinw = [0.7, 0.5];  # width,height of pins
                 self.tags = []  # description/keywords
                 self.pin_offset_z = 4.29
@@ -552,7 +554,7 @@ class pack:
             self.mounting_hole_pos = [self.plastic[0] / 2, 17.5-2.8]  # position of mounting hole from bottom-left
             self.mounting_hole_diameter = 3.7  # diameter of mounting hole in package
             self.mounting_hole_drill = 3.5  # diameter of mounting hole drill
-            self.pin_minlength = 3.81  # min. elongation of pins before 90° bend
+            self.pin_minlength = 3.81  # min. elongation of pins before 90 deg bend
             self.pinw = [0.7, 0.5];  # width,height of pins
             self.tags = []  # description/keywords
             self.pin_offset_z = 4.55
@@ -583,7 +585,7 @@ class pack:
                                       self.plastic[1] - 3.9]  # position of mounting hole from bottom-left
             self.mounting_hole_diameter = 3.2  # diameter of mounting hole in package
             self.mounting_hole_drill = 3.2  # diameter of mounting hole drill
-            self.pin_minlength = 4  # min. elongation of pins before 90° bend
+            self.pin_minlength = 4  # min. elongation of pins before 90 deg bend
             self.pinw = [0.75, 0.5];  # width,height of pins
             self.tags = []  # description/keywords
             self.pin_offset_z = 2
@@ -605,20 +607,20 @@ class pack:
                                       self.plastic[1] - 3.9]  # position of mounting hole from bottom-left
             self.mounting_hole_diameter = 0  # diameter of mounting hole in package
             self.mounting_hole_drill = 0  # diameter of mounting hole drill
-            self.pin_minlength = 2.5  # min. elongation of pins before 90° bend
+            self.pin_minlength = 2.5  # min. elongation of pins before 90 deg bend
             self.pinw = [0.75, 0.5];  # width,height of pins
             self.tags = ["IPAK"]  # description/keywords
             #self.more_packnames.append("IPAK")
             self.pin_offset_z = 1.27
-            self.additional_pin_pad_size = [5.7, 6.2]  # Größe des Zusatz-SMD-Pads
+            self.additional_pin_pad_size = [5.7, 6.2]  # size of additional SMD pads
             self.metal_offset_x = (self.plastic[0] - self.metal[0]) / 2  # offset of metal from left
             if largepads:
                 self.tags.append("large pads")
                 self.pad = [1.8, 1.8]
-                self.additional_pin_pad_size = [6.3, 6.5]  # Größe des Zusatz-SMD-Pads
+                self.additional_pin_pad_size = [6.3, 6.5]  # size of additional SMD pads
                 self.largepads = True
             self.additional_pin_pad = [self.plastic[0] / 2, self.metal[1] - self.additional_pin_pad_size[
-                1] / 3]  # Position des Zusatz-SMD-Pads
+                1] / 3]  # Position of additional SMD pads
 
         elif (name == "SIPAK"):
             self.plastic = [6.6, 6.4, 2.3]  # width,heigth,depth of plastic package, starting at bottom-left
@@ -632,20 +634,20 @@ class pack:
                                       self.plastic[1] - 3.9]  # position of mounting hole from bottom-left
             self.mounting_hole_diameter = 0  # diameter of mounting hole in package
             self.mounting_hole_drill = 0  # diameter of mounting hole drill
-            self.pin_minlength = 1.02  # min. elongation of pins before 90° bend
+            self.pin_minlength = 1.02  # min. elongation of pins before 90 deg bend
             self.pinw = [0.9, 0.5];  # width,height of pins
             self.tags = []   # description/keywords
             self.pin_offset_z = 1.17+0.25
             self.addpinstext=False
-            self.additional_pin_pad_size = [5.5, 6.2]  # Größe des Zusatz-SMD-Pads
+            self.additional_pin_pad_size = [5.5, 6.2]  # size of additional SMD pads
             self.metal_offset_x = (self.plastic[0] - self.metal[0]) / 2  # offset of metal from left
             if largepads:
                 self.tags.append("large pads")
                 self.pad = [1.8, 1.8]
-                self.additional_pin_pad_size = [6.3, 6.5]  # Größe des Zusatz-SMD-Pads
+                self.additional_pin_pad_size = [6.3, 6.5]  # size of additional SMD pads
                 self.largepads = True
             self.additional_pin_pad = [self.plastic[0] / 2, self.metal[1] - self.additional_pin_pad_size[
-                1] / 3]  # Position des Zusatz-SMD-Pads
+                1] / 3]  # Position of additional SMD pads
 
 
         elif (name == "TO-262"):
@@ -663,20 +665,20 @@ class pack:
                                       self.plastic[1] - 3.9]  # position of mounting hole from bottom-left
             self.mounting_hole_diameter = 0  # diameter of mounting hole in package
             self.mounting_hole_drill = 0  # diameter of mounting hole drill
-            self.pin_minlength = 3.25  # min. elongation of pins before 90° bend
+            self.pin_minlength = 3.25  # min. elongation of pins before 90 deg bend
             self.pinw = [0.8, 0.5];  # width,height of pins
             self.tags = ["IIPAK", "I2PAK"]  # description/keywords
             #self.more_packnames.append("I2PAK")
             self.pin_offset_z = 2.65
-            self.additional_pin_pad_size = [10, 8]  # Größe des Zusatz-SMD-Pads
+            self.additional_pin_pad_size = [10, 8]  # size of additional SMD pads
             self.metal_offset_x = (self.plastic[0] - self.metal[0]) / 2  # offset of metal from left
             if largepads:
                 self.tags.append("large pads")
                 self.pad = [1.8, 1.8]
-                self.additional_pin_pad_size = [6.3, 6.5]  # Größe des Zusatz-SMD-Pads
+                self.additional_pin_pad_size = [6.3, 6.5]  # size of additional SMD pads
                 self.largepads = True
             self.additional_pin_pad = [self.plastic[0] / 2, self.metal[1] - self.additional_pin_pad_size[
-                1] / 3]  # Position des Zusatz-SMD-Pads
+                1] / 3]  # Position of additional SMD pads
         else:
             print("DID NOT FIND '", name,"'")
             self.__init__()
@@ -701,11 +703,11 @@ class pack:
         if self.largepads:
             self.tags.append("large pads")
         if self.staggered_type==1:
-            self.tags.append("staggered type-1")
-            self.fpnametags=["StaggeredType1"]+self.fpnametags
+            self.tags.append("staggered odd")
+            self.fpnametags=["StaggeredOdd"]+self.fpnametags
         if self.staggered_type==2:
-            self.tags.append("staggered type-2")
-            self.fpnametags=["StaggeredType2"] + self.fpnametags
+            self.tags.append("staggered even")
+            self.fpnametags=["StaggeredEven"] + self.fpnametags
 
         if pitchy>0:
             self.staggered_rm = [pitchy,pitchy]  # y-distance between pins

--- a/scripts/Packages/TO_SOT_THT/tools.py
+++ b/scripts/Packages/TO_SOT_THT/tools.py
@@ -216,7 +216,7 @@ def addRectAngledBottom(kicad_mod, x1, x2, angled_delta, layer, width, roun=0.00
                                [roundG(xma, roun),roundG(ymi, roun)],
                                [roundG(xmi, roun),roundG(ymi, roun)]], layer=layer, width=width))
 
-# add a circle which is filled with 45° lines
+# add a circle which is filled with 45 deg lines
 def addCircleLF(kicad_mod, center, radius, layer, width, linedist=0.3, roun=0.001):
     trans=Translation(center[0], center[1])
     kicad_mod.append(trans)


### PR DESCRIPTION
To support https://github.com/KiCad/kicad-footprints/pull/765 and the issues/PRs linked there, here is a script update. I used a hacky method to add the TO-220F-4 footprint with 3.18mm Y spacing, translated from German to English, and remove special characters from the file that didn't have encoding specified.

This script is rather unlike the others (using a separate YAML file for data and obtusely-written), but I think this should suffice. This and other scripts written like it should be re-written from scratch.