### PR TITLE
Fix TQFN-24 footprint name

### DIFF
--- a/scripts/Packages/Package_DFN_QFN/size_definitions/qfn-2x.yaml
+++ b/scripts/Packages/Package_DFN_QFN/size_definitions/qfn-2x.yaml
@@ -491,7 +491,7 @@ QFN-24-1EP_4x4mm_P0.5mm_EP2.7x2.7mm:
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
 
-TQFN-24-1EP_4x4mm_Pitch0.5mm_EP52.8x2.8mm_PullBack_ThermalVias:
+TQFN-24-1EP_4x4mm_Pitch0.5mm_EP52.8x2.8mm_PullBack:
   device_type: 'TQFN'
   #manufacturer: 'man'
   #part_number: 'mpn'

--- a/scripts/Packages/Package_DFN_QFN/size_definitions/qfn-2x.yaml
+++ b/scripts/Packages/Package_DFN_QFN/size_definitions/qfn-2x.yaml
@@ -496,6 +496,7 @@ TQFN-24-1EP_4x4mm_Pitch0.5mm_EP52.8x2.8mm_PullBack_ThermalVias:
   #manufacturer: 'man'
   #part_number: 'mpn'
   size_source: 'https://ams.com/documents/20143/36005/AS1115_DS000206_1-00.pdf/3d3e6d35-b184-1329-adf9-2d769eb2404f'
+  custom_name_format: 'TQFN-24-1EP_4x4mm_Pitch0.5mm_EP52.8x2.8mm_PullBack{vias:s}'
   ipc_class: 'qfn_pull_back'
   #ipc_density: 'least' #overwrite global value for this device.
   # custom_name_format:
@@ -543,7 +544,6 @@ TQFN-24-1EP_4x4mm_Pitch0.5mm_EP52.8x2.8mm_PullBack_ThermalVias:
   #chamfer_edge_pins: 0.25
   #pin_count_grid:
   #pad_length_addition: 0.5
-  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
 
 ####################################################################################

--- a/scripts/Packages/Package_DFN_QFN/size_definitions/qfn-2x.yaml
+++ b/scripts/Packages/Package_DFN_QFN/size_definitions/qfn-2x.yaml
@@ -491,12 +491,12 @@ QFN-24-1EP_4x4mm_P0.5mm_EP2.7x2.7mm:
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
 
-TQFN-24-1EP_4x4mm_Pitch0.5mm_EP52.8x2.8mm_PullBack:
+TQFN-24-1EP_4x4mm_P0.5mm_EP2.8x2.8mm_PullBack:
   device_type: 'TQFN'
   #manufacturer: 'man'
   #part_number: 'mpn'
   size_source: 'https://ams.com/documents/20143/36005/AS1115_DS000206_1-00.pdf/3d3e6d35-b184-1329-adf9-2d769eb2404f'
-  custom_name_format: 'TQFN-24-1EP_4x4mm_Pitch0.5mm_EP52.8x2.8mm_PullBack{vias:s}'
+  custom_name_format: 'TQFN-24-1EP_4x4mm_P0.5mm_EP2.8x2.8mm_PullBack{vias:s}'
   ipc_class: 'qfn_pull_back'
   #ipc_density: 'least' #overwrite global value for this device.
   # custom_name_format:

--- a/scripts/Packages/Package_DFN_QFN/size_definitions/qfn-2x.yaml
+++ b/scripts/Packages/Package_DFN_QFN/size_definitions/qfn-2x.yaml
@@ -491,7 +491,7 @@ QFN-24-1EP_4x4mm_P0.5mm_EP2.7x2.7mm:
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
 
-TQFN-24-1EP_4x4mm_Pitch0.5mm_EP52.8x2.8mm_ThermalVias:
+TQFN-24-1EP_4x4mm_Pitch0.5mm_EP52.8x2.8mm_PullBack_ThermalVias:
   device_type: 'TQFN'
   #manufacturer: 'man'
   #part_number: 'mpn'


### PR DESCRIPTION
This is a simple one. As discussed at https://github.com/KiCad/kicad-footprints/pull/853.