### PR TITLE
Added TSOP-I-32_11.8x8mm_P0.5mm and TSOP-II-44_10.16x18.41mm_P0.8mm

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tsop-i.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tsop-i.yaml
@@ -1,0 +1,24 @@
+FileHeader:
+  library_Suffix: 'SO'
+  device_type: 'TSOP-I'
+
+TSOP-I-32_11.80x8.00mm_P0.50mm:
+  size_source: 'http://www.issi.com/WW/pdf/61-64C5128AL.pdf'
+  body_size_x:
+    minimum: 11.70
+    maximum: 11.90
+  body_size_y:
+    minimum: 7.90
+    maximum: 8.10
+  overall_size_x:
+    minimum: 13.10
+    maximum: 13.70
+  lead_width:
+    minimum: 0.16
+    maximum: 0.27
+  lead_len:
+    minimum: 0.30
+    maximum: 0.70
+  pitch: 0.50
+  num_pins_x: 0
+  num_pins_y: 16

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tsop-ii.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tsop-ii.yaml
@@ -1,0 +1,24 @@
+FileHeader:
+  library_Suffix: 'SO'
+  device_type: 'TSOP-II'
+
+TSOP-II-44_10.16x18.41mm_P0.80mm:
+  size_source: 'http://www.issi.com/WW/pdf/61-64C5128AL.pdf'
+  body_size_x:
+    minimum: 10.03
+    maximum: 10.29
+  body_size_y:
+    minimum: 18.28
+    maximum: 18.54
+  overall_size_x:
+    minimum: 11.56
+    maximum: 11.96
+  lead_width:
+    minimum: 0.30
+    maximum: 0.45
+  lead_len:
+    minimum: 0.40
+    maximum: 0.69
+  pitch: 0.80
+  num_pins_x: 0
+  num_pins_y: 22


### PR DESCRIPTION
Push of 
TSOP-I-32_11.8x8mm_P0.5mm
TSOP-II-44_10.16x18.41mm_P0.8mm
Used by 
IS61C5128AL/AS
IS64C5128AL/AS
http://www.issi.com/WW/pdf/61-64C5128AL.pdf

in push 
https://github.com/KiCad/kicad-symbols/pull/888

fp push is here
https://github.com/KiCad/kicad-footprints/pull/943

