### PR TITLE
Added SSOP-32_11.305x20.495mm_P1.27mm

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/ssop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/ssop.yaml
@@ -22,3 +22,24 @@ SSOP-20_5.3x7.2mm_P0.65mm:
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 10
+
+SSOP-32_11.3x20.5mm_P1.27mm:
+  size_source: 'http://www.issi.com/WW/pdf/61-64C5128AL.pdf'
+  body_size_x:
+    minimum: 11.18
+    maximum: 11.43
+  body_size_y:
+    minimum: 20.24
+    maximum: 20.75
+  overall_size_x:
+    minimum: 13.79
+    maximum: 14.45
+  lead_width:
+    minimum: 0.33
+    maximum: 0.51
+  lead_len:
+    minimum: 0.38
+    maximum: 1.27
+  pitch: 1.27
+  num_pins_x: 0
+  num_pins_y: 16


### PR DESCRIPTION
Push of 
SSOP-32_11.305x20.495mm_P1.27mm
Used by 
IS61C5128AL/AS
IS64C5128AL/AS
http://www.issi.com/WW/pdf/61-64C5128AL.pdf

in push 
https://github.com/KiCad/kicad-symbols/pull/888

fp push is here
https://github.com/KiCad/kicad-footprints/pull/944

