### PR TITLE
Exposed PADs for LGA, add TexasInstuments MicroSiP Packages

### DIFF
--- a/scripts/Packages/Package_LGA/MicroSiP.yaml
+++ b/scripts/Packages/Package_LGA/MicroSiP.yaml
@@ -1,0 +1,118 @@
+Texas_MicroSiP-10-1EP_3.8x3.0mm_P0.6mm_EP0.7x2.9mm_ThermalVia:
+  device_type: 'MicroSiP'
+  manufacturer: 'Texas'
+  part_number: 'SIL0010A'
+  size_source: 'http://www.ti.com/lit/ml/mpds579b/mpds579b.pdf'
+  ipc_class: 'LGA'
+  #ipc_density: 'least' #overwrite global value for this device.
+  # custom_name_format:
+
+  body_size_x:
+    nominal: 3.8
+    tolerance: 0.1
+  body_size_y:
+    nominal: 3
+    tolerance: 0.1
+
+  lead_width:
+    nominal: 0.3
+    tolerance: 0.1
+  lead_len:
+    nominal: 0.65
+    tolerance: 0.1
+  # this will result in a pad 0.8x0.45 (max tolerance + placement_tolerance)
+  lead_center_pos_x:
+    nominal: 1.525
+    tolerance: 0
+
+  EP_size_x_min: 0.6
+  EP_size_x_max: 0.8
+  EP_size_y_min: 2.8
+  EP_size_y_max: 3.0
+  EP_center_x:
+    nominal: -0.175
+  EP_center_y:
+    nominal: 0
+  #EP_paste_coverage: 0.86
+  EP_num_paste_pads: [1, 3]
+  #heel_reduction: 0.05 #for relatively large EP pads (increase clearance)
+
+  thermal_vias:
+    count: [1, 3]
+    grid: 1.03
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    EP_num_paste_pads: [1, 3]
+    #paste_between_vias: 1
+    #paste_rings_outside: 1
+    EP_paste_coverage: 0.86
+    #grid: [1, 1]
+    # bottom_pad_size:
+    paste_avoid_via: False
+
+  pitch: 0.6
+  num_pins_x: 0
+  num_pins_y: 5
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: ''
+  include_suffix_in_3dpath: 'False'
+
+Texas_MicroSiP-8-1EP_2.8x3.0mm_P0.65mm_EP1.9x1.1mm_ThermalVia:
+  device_type: 'MicroSiP'
+  manufacturer: 'Texas'
+  part_number: 'SIL0008D'
+  size_source: 'http://www.ti.com/lit/ds/symlink/tps82130.pdf#page19'
+  ipc_class: 'LGA'
+  #ipc_density: 'least' #overwrite global value for this device.
+  # custom_name_format:
+
+  body_size_x:
+    nominal: 2.8
+    tolerance: 0.1
+  body_size_y:
+    nominal: 3
+    tolerance: 0.1
+
+  lead_width:
+    nominal: 0.5
+    tolerance: 0.02
+  lead_len:
+    nominal: 0.4
+    tolerance: 0.02
+  lead_center_pos_x:
+    nominal: 1.05
+    tolerance: 0
+
+
+  EP_size_x_min: 1.0
+  EP_size_x_max: 1.2
+  EP_size_y_min: 1.8
+  EP_size_y_max: 2.0
+  EP_num_paste_pads: [1, 3]
+  #heel_reduction: 0.05 #for relatively large EP pads (increase clearance)
+
+  thermal_vias:
+    count: [1, 3]
+    grid: 0.75
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    EP_num_paste_pads: [1, 3]
+    #paste_between_vias: 1
+    #paste_rings_outside: 1
+    EP_paste_coverage: 0.85
+    #grid: [1, 1]
+    # bottom_pad_size:
+    paste_avoid_via: False
+
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 4
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: ''
+  include_suffix_in_3dpath: 'False'


### PR DESCRIPTION
As recommended in https://github.com/KiCad/kicad-footprints/pull/953, I made a .yaml file for the MicroSiP Packages. Some changes to the script were required to allow LGA Packages with an exposed pad.

This could also be used for https://github.com/KiCad/kicad-footprints/pull/931
I added the part in the yaml file as well.
