### PR TITLE
Script to generate through-hole PTC fuse footprints.

### DIFF
--- a/scripts/Fuse/ptc-fuse-tht.py
+++ b/scripts/Fuse/ptc-fuse-tht.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+
+# load parent path of KicadModTree
+sys.path.append(os.path.join(sys.path[0], "..", ".."))
+sys.path.append(os.path.join(sys.path[0], "..", "tools"))
+
+from KicadModTree import *
+from drawing_tools import *
+
+def ptc_fuse_tht(args):
+    footprint_name = args["name"]
+    datasheet = args["datasheet"]
+    ihold = args["ihold"]
+    itrip = args["itrip"]
+    drill = args["drill"]
+    w = args["width"]
+    h = args["height"]
+    pitch = args["pitch"]
+    offset = args["offset"]
+
+    f = Footprint(footprint_name)
+    f.setDescription("PTC Resettable Fuse, Ihold = " + ihold +
+                     ", Itrip=" + itrip + ", " + datasheet)
+    f.setTags("ptc resettable fuse polyfuse THT")
+    f.append(Model(filename="${KISYS3DMOD}/Fuse.3dshapes/" +
+                   footprint_name + ".wrl",
+                   at=[0.0, 0.0, 0.0],
+                   scale=[1.0, 1.0, 1.0],
+                   rotate=[0.0, 0.0, 0.0]))
+
+    d = [drill, drill]
+    p = [drill + 1.0, drill + 1.0]
+
+    s = [1.0, 1.0]
+    t = 0.15
+
+    wCrtYd = 0.05
+    wFab = 0.1
+    wSilkS = 0.12
+
+    silk = 0.1
+    crtYd = 0.25
+
+    clearance = 0.3
+
+    xPin1 = 0.0
+    xPin2 = pitch
+    xCenter = pitch / 2
+    xLeft = xCenter - w / 2
+    xRight = xCenter + w / 2
+    xLeftSilk = xLeft - silk
+    xRightSilk = xRight + silk
+    xLeftCrtYd = xLeft - crtYd
+    xRightCrtYd = xRight + crtYd
+
+    yPin1 = 0.0
+    yPin2 = offset
+    yCenter = offset / 2
+    yTop = yCenter - h / 2
+    yBottom = yCenter + h / 2
+    yRef = yTop - 1.0
+    yValue = yBottom + 1.0
+    yTopSilk = yTop - silk
+    yBottomSilk = yBottom + silk
+    yTopCrtYd = yTop - crtYd
+    yBottomCrtYd = yBottom + crtYd
+
+    keepout = []
+    ko_diameter = p[0] + 2 * clearance
+
+    # Pads
+    pin = 1
+    for coord in [[xPin1, yPin1], [xPin2, yPin2]]:
+        f.append(Pad(number=str(pin), type=Pad.TYPE_THT, shape=Pad.SHAPE_CIRCLE,
+                 at=coord, size=p, layers=Pad.LAYERS_THT, drill=d))
+        keepout = keepout + addKeepoutRound(coord[0], coord[1],
+                                            ko_diameter, ko_diameter)
+        pin = pin + 1
+
+    # Text
+    f.append(Text(type="reference", text="REF**", at=[xCenter, yRef],
+                  layer="F.SilkS", size=s, thickness=t))
+    f.append(Text(type="value", text=footprint_name, at=[xCenter, yValue],
+                  layer="F.Fab", size=s, thickness=t))
+    f.append(Text(type="user", text="%R", at=[xCenter, yCenter],
+                  layer="F.Fab", size=s, thickness=t))
+
+    # Fab outline
+    f.append(RectLine(start=[xLeft, yTop],
+                      end=[xRight, yBottom],
+                      layer="F.Fab", width=wFab))
+
+    # Silk outline
+    addRectWithKeepout(f, xLeftSilk, yTopSilk,
+                       xRightSilk - xLeftSilk, yBottomSilk - yTopSilk,
+                       "F.SilkS", wSilkS, keepout)
+
+    # Courtyard
+    f.append(RectLine(start=[xLeftCrtYd, yTopCrtYd],
+                      end=[xRightCrtYd, yBottomCrtYd],
+                      layer="F.CrtYd", width=wCrtYd))
+
+    file_handler = KicadFileHandler(f)
+    file_handler.writeFile(footprint_name + ".kicad_mod")
+
+
+if __name__ == '__main__':
+    parser = ModArgparser(ptc_fuse_tht)
+    # the root node of .yml files is parsed as name
+    parser.add_parameter("name", type=str, required=True)
+    parser.add_parameter("datasheet", type=str, required=False,
+                         default="http://www.bourns.com/docs/Product-Datasheets/mfrg.pdf")
+    parser.add_parameter("ihold", type=str, required=True)
+    parser.add_parameter("itrip", type=str, required=True)
+    parser.add_parameter("drill", type=float, required=False, default=1.01)
+    parser.add_parameter("pitch", type=float, required=False, default=5.1)
+    parser.add_parameter("height", type=float, required=False, default=3.0)
+    parser.add_parameter("width", type=float, required=True)
+    parser.add_parameter("offset", type=float, required=False, default=1.2)
+
+    # now run our script which handles the whole part of parsing the files
+    parser.run()

--- a/scripts/Fuse/ptc-fuse-tht.yaml
+++ b/scripts/Fuse/ptc-fuse-tht.yaml
@@ -1,0 +1,134 @@
+Fuse_Bourns_MF-RG300:
+  ihold: 3.0A
+  itrip: 5.1A
+  width: 7.1
+Fuse_Bourns_MF-RG400:
+  ihold: 4.0A
+  itrip: 6.8A
+  width: 9.9
+Fuse_Bourns_MF-RG500:
+  ihold: 5.0A
+  itrip: 8.5A
+  width: 10.4
+Fuse_Bourns_MF-RG600:
+  ihold: 6.0A
+  itrip: 10.2A
+  width: 10.7
+Fuse_Bourns_MF-RG650:
+  ihold: 6.5A
+  itrip: 11.1A
+  width: 11.2
+Fuse_Bourns_MF-RG700:
+  ihold: 7.0A
+  itrip: 11.9A
+  width: 11.2
+Fuse_Bourns_MF-RG800:
+  ihold: 8.0A
+  itrip: 13.6A
+  width: 12.7
+Fuse_Bourns_MF-RG900:
+  ihold: 9.0A
+  itrip: 15.3A
+  width: 14.0
+Fuse_Bourns_MF-RG1000:
+  ihold: 10.0A
+  itrip: 17.0A
+  width: 16.5
+Fuse_Bourns_MF-RG1100:
+  ihold: 11.0A
+  itrip: 18.7A
+  width: 17.5
+Fuse_Bourns_MF-RHT050:
+  ihold: 0.5A
+  itrip: 0.92A
+  width: 7.4
+  drill: 0.71
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT070:
+  ihold: 0.7A
+  itrip: 1.4A
+  width: 6.86
+  drill: 0.71
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT100:
+  ihold: 1.0A
+  itrip: 1.8A
+  width: 9.7
+  drill: 0.71
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT200:
+  ihold: 2.0A
+  itrip: 3.8A
+  width: 9.4
+  drill: 0.71
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT300:
+  ihold: 3.0A
+  itrip: 6.0A
+  width: 8.8
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT400:
+  ihold: 4.0A
+  itrip: 7.5A
+  width: 10.0
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT500:
+  ihold: 5.0A
+  itrip: 9.0A
+  width: 11.2
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT550:
+  ihold: 5.5A
+  itrip: 10.0A
+  width: 11.2
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT600:
+  ihold: 6.0A
+  itrip: 10.8A
+  width: 11.2
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT650:
+  ihold: 6.5A
+  itrip: 12.0A
+  width: 12.7
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT700:
+  ihold: 7.0A
+  itrip: 13.0A
+  width: 14.0
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT750:
+  ihold: 7.5A
+  itrip: 13.1A
+  width: 14.0
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT800:
+  ihold: 8.0A
+  itrip: 15.0A
+  width: 16.5
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT900:
+  ihold: 9.0A
+  itrip: 16.5A
+  width: 16.5
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT1000:
+  ihold: 10.0A
+  itrip: 18.5A
+  width: 17.5
+  pitch: 10.2
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT1100:
+  ihold: 11.0A
+  itrip: 20.0A
+  width: 21.0
+  pitch: 10.2
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf
+Fuse_Bourns_MF-RHT1300:
+  ihold: 13.0A
+  itrip: 24.0A
+  width: 23.5
+  height: 3.6
+  pitch: 10.2
+  drill: 1.2
+  datasheet: http://www.bourns.com/docs/product-datasheets/mfrht.pdf


### PR DESCRIPTION
This generates footprints for the Bourns MF-RG and MF-RHT series PTC fuses, which were merged in KiCad/kicad-footprints#579 and KiCad/kicad-footprints#580.