### PR TITLE
added sizedefinitions for Texas_PWP_R-PDSO-G20

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/htssop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/htssop.yaml
@@ -46,3 +46,51 @@ HTSSOP-16-1EP_4.4x5mm_P0.65mm_EP3.4x5mm_Mask2.46x2.31mm_ThermalVias:
     grid: [1.5, 1.5]
     # bottom_pad_size:
     paste_avoid_via: False
+
+Texas_PWP_R-PDSO-G20:
+# HTSSOP-20-1EP_4.4x6.5mm_P0.65mm_EP3.4x6.5mm_Mask2.75x3.43mm:
+  size_source: 'http://www.ti.com/lit/ds/symlink/tlc5971.pdf#page=37&zoom=160,-90,3'
+  #                    HTSSOP-20-        1EP_4.4x6.5                        mm_P0.65   mm_EP3.4x6.5                    mm_Mask2.75x3.43mm:
+  custom_name_format: 'HTSSOP-{pincount}-1EP_{size_x:g}x{size_y:g}mm_P{pitch}mm_EP{ep_size_x:g}x{ep_size_y:g}mm_Mask{mask_size_x:g}x{mask_size_y:g}mm{vias:s}'
+  body_size_x:
+    minimum: 4.3
+    maximum: 4.5
+  body_size_y:
+    minimum: 6.4
+    maximum: 6.6
+  overall_size_x:
+    minimum: 6.2
+    maximum: 6.6
+  lead_width:
+    minimum: 0.19
+    maximum: 0.30
+  lead_len:
+    minimum: 0.5
+    maximum: 0.75
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 10
+
+
+  EP_size_x: 3.4
+  EP_size_y: 6.5
+  EP_mask_x: 2.75
+  EP_mask_y: 3.43
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 2]
+  #heel_reduction: 0.1 #for relatively large EP pads (increase clearance)
+  # EP_size_limit_x: 3.6  #for relatively large EP pads (increase clearance)
+  # EP_size_limit_y: 3.6  #for relatively large EP pads (increase clearance)
+
+  thermal_vias:
+    count: [3, 5]
+    drill: 0.3
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    EP_num_paste_pads: [2, 2]
+    paste_between_vias: 1
+    paste_rings_outside: 1
+    EP_paste_coverage: 0.65
+    grid: [1.3, 1.3]
+    # bottom_pad_size:
+    paste_avoid_via: False


### PR DESCRIPTION
added HTSSOP-20-1EP_4.4x6.5mm_P0.65mm_EP3.4x6.5mm_Mask2.75x3.43mm (Texas_PWP_R-PDSO-G20)

please let me know if the size addition is fine this way.
i have used the `custom_name_format` to make sure that the sizes in the name correspond to the actual sizes used in the definition.

for this footprint i would like to have a *hand-soldering* variant - means i would add a mask on the bottom side - this way you can *reflow* the part with a normal soldering iron from the other side. (i tried this out several times with this chip and it works really nice)
should i add this variant myself in form of manually copieng the thermal-via variant - or is this concept fair enough to be incorporated in the script itself?