### PR TITLE
Fix import path for StandardBox

### DIFF
--- a/scripts/Battery/BatteryHolder.py
+++ b/scripts/Battery/BatteryHolder.py
@@ -7,13 +7,16 @@ import re
 # load parent path of KicadModTree
 sys.path.append(os.path.join(sys.path[0], "..", ".."))
 
+# load scripts
+sys.path.append(os.path.join(sys.path[0], ".."))
+
 from KicadModTree import *
-from tree.master.scripts.general.StandardBox import *
+from general.StandardBox import *
 
 def qfn(args):
 
     extraffablines = []
-    
+
     footprint_name = args["name"]
     description = args["description"]
     datasheet = args["description"]
@@ -23,12 +26,12 @@ def qfn(args):
     size = args["size"]
     pins = args["pins"]
     extratexts = args["extratexts"]
-    
+
     dir3D = 'Sensor_Current.3dshapes'
     f = Footprint(footprint_name)
-    
+
     file3Dname = "${KISYS3DMOD}/" + dir3D + "/" + footprint_name + ".wrl"
-    words = footprint_name.split("_")  
+    words = footprint_name.split("_")
     if words[-1].lower().startswith('handsolder'):
         words[-1] = ''
         ff = '_'.join(words)


### PR DESCRIPTION
I tried to run `BatteryHolder.py` and got the error:
```bash
Traceback (most recent call last):
  File "BatteryHolder.py", line 11, in <module>
    from tree.master.scripts.general.StandardBox import *
ModuleNotFoundError: No module named 'tree'
```

I think import paths must have changed elsewhere in the library because `tree` doesn't exist in the project nor as a dependency (as far as I can tell). I looked for other examples where a "general" script is used from another script to see how this is handled there, but I couldn't find any others so I fixed this by appending the "general" scripts directory to the Python path like you do with the `KicadModTree` path.

This fixes the issue for me on Python 3 (not tested Python 2), but I guess given that in #154 you packaged `KicadModTree` on PyPI and added a `setup.py` file, this path hacking should be removed entirely at some point.