### PR TITLE
Add ATtiny DFN entry

### DIFF
--- a/scripts/Packages/Package_DFN_QFN/size_definitions/dfn.yaml
+++ b/scripts/Packages/Package_DFN_QFN/size_definitions/dfn.yaml
@@ -148,6 +148,42 @@ MLF-6-1EP_1.6x1.6mm_P0.5mm_EP0.5x1.26mm:
   #suffix: '_PullBack'
   #include_suffix_in_3dpath: 'False'
   #include_pad_size: 'fp_name_only' # 'both' | 'none' (default)
+  
+DFN-8-1EP_2x2mm_P0.5mm_EP0.9x1.5mm:
+  device_type: 'DFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8127-AVR-8-bit-Microcontroller-ATtiny4-ATtiny5-ATtiny9-ATtiny10_Datasheet.pdf'
+  # ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  body_size_x:
+    nominal: 2
+    tolerance: 0.05
+  body_size_y:
+    nominal: 2
+    tolerance: 0.05
+  lead_width:
+    minimum: 0.2
+    maximum: 0.3
+  lead_len:
+    nominal: 0.3
+    tolerance: 0.1
+
+  EP_size_x: 0.9
+  EP_size_y: 1.5
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 2]
+  # heel_reduction: 0.1 #for relatively large EP pads (increase clearance)
+
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 4
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_PullBack'
+  #include_suffix_in_3dpath: 'False'
+  #include_pad_size: 'fp_name_only' # 'both' | 'none' (default)
 
 DFN-8-1EP_3x3mm_P0.65mm_EP1.7x2.05mm:
   device_type: 'DFN'

--- a/scripts/Packages/Package_DFN_QFN/size_definitions/dfn.yaml
+++ b/scripts/Packages/Package_DFN_QFN/size_definitions/dfn.yaml
@@ -173,7 +173,7 @@ DFN-8-1EP_2x2mm_P0.5mm_EP0.9x1.5mm:
   EP_size_y: 1.5
   # EP_paste_coverage: 0.65
   EP_num_paste_pads: [2, 2]
-  # heel_reduction: 0.1 #for relatively large EP pads (increase clearance)
+  heel_reduction: 0.025 #for relatively large EP pads (increase clearance)
 
   pitch: 0.5
   num_pins_x: 0


### PR DESCRIPTION
Footprint suggested at https://github.com/KiCad/kicad-footprints/pull/994 from http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-8127-AVR-8-bit-Microcontroller-ATtiny4-ATtiny5-ATtiny9-ATtiny10_Datasheet.pdf page 200.