### PR TITLE
Prevent bottom silk dot

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/ipc_gullwing_generator.py
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/ipc_gullwing_generator.py
@@ -386,12 +386,6 @@ class Gullwing():
                 silk_pad_offset=silk_pad_offset,
                 min_lenght=min_lenght)
 
-        '''kicad_mod.append(Line(
-            start=silk_point_bottom_inside,
-            end=silk_point_bottom_inside,
-            width=configuration['silk_line_width'],
-            layer="B.Fab"))'''
-
         poly_bottom_right = []
         if silk_point_bottom_inside is not None:
             poly_bottom_right.append(silk_point_bottom_inside)

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/ipc_gullwing_generator.py
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/ipc_gullwing_generator.py
@@ -386,11 +386,11 @@ class Gullwing():
                 silk_pad_offset=silk_pad_offset,
                 min_lenght=min_lenght)
 
-        kicad_mod.append(Line(
+        '''kicad_mod.append(Line(
             start=silk_point_bottom_inside,
             end=silk_point_bottom_inside,
             width=configuration['silk_line_width'],
-            layer="B.Fab"))
+            layer="B.Fab"))'''
 
         poly_bottom_right = []
         if silk_point_bottom_inside is not None:


### PR DESCRIPTION
@poeschlr 
Please take a look at this. This code draws a bottom silk line with the same start and end points. It ends up placing a silk dot on the X axis under the lower F.SilkS horizontal line. There are no conditionals around this section of code so it runs for every single footprint using this script.

Why? I don't see why any gullwing parts need bottom silk. Am I missing the purpose of this?

I block commented to create the PR, but I can remove these few lines of code if it's not needed.