### PR TITLE
added sizedefinitions for QFN-56 EP5.6 (=Texas RTQ)

### DIFF
--- a/scripts/Packages/Package_DFN_QFN/size_definitions/qfn-other.yaml
+++ b/scripts/Packages/Package_DFN_QFN/size_definitions/qfn-other.yaml
@@ -48,6 +48,60 @@ QFN-56-1EP_8x8mm_P0.5mm_EP4.8x5.5mm:
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
 
+QFN-56-1EP_8x8mm_P0.5mm_EP5.6x5.6mm:
+  # also known as Texas RTQ (S-PVQFN-N56)
+  device_type: 'QFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'http://www.ti.com/lit/ds/symlink/tlc5957.pdf#page=23 (page 23f)'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  # custom_name_format:
+  body_size_x:
+    nominal: 8
+    tolerance: 0.15
+  body_size_y:
+    nominal: 8
+    tolerance: 0.15
+  lead_width:
+    minimum: 0.18
+    maximum: 0.30
+  lead_len:
+    minimum: 0.3
+    maximum: 0.5
+
+  EP_size_x:
+    nominal: 5.6
+    tolerance: 0.1
+  EP_size_y:
+    nominal: 5.6
+    tolerance: 0.1
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [4, 4]
+  #heel_reduction: 0.1 #for relatively large EP pads (increase clearance)
+
+  thermal_vias:
+    count: [5, 5]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    #paste_between_vias: 1
+    #paste_rings_outside: 1
+    EP_paste_coverage: 0.6
+    #grid: [1, 1]
+    # bottom_pad_size:
+    # paste_avoid_via: False
+
+  pitch: 0.5
+  num_pins_x: 14
+  num_pins_y: 14
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'
+
 QFN-68-1EP_8x8mm_P0.4mm_EP5.2x5.2mm:
   device_type: 'QFN'
   #manufacturer: 'man'


### PR DESCRIPTION
QFN-56-1EP_8x8mm_P0.5mm_EP5.6x5.6mm
Texas RTQ (S-PVQFN-N56)
based on http://www.ti.com/lit/ds/symlink/tlc5957.pdf#page=23&zoom=140,-151,778

optional TODO: change Pads to D-Shape (first needs script modification to create this custom Pad-Type)