### PR TITLE
Update/add SMD capacitor footprints

### DIFF
--- a/scripts/Capacitors_SMD/CP_Elec_round.yaml
+++ b/scripts/Capacitors_SMD/CP_Elec_round.yaml
@@ -1,5 +1,4 @@
 #CP_Elec_6.3x5.8:
-#    description: "SMT capacitor, aluminium electrolytic, 6.6x5.8"
 #    length: 6.6
 #    width: 6.6
 #    height: 5.8
@@ -23,7 +22,7 @@
 # 3x5.3
 
 CP_Elec_3x5.4:
-    description: "SMT capacitor, aluminium electrolytic, 3x5.4, Nichicon"
+    extra_description: "Nichicon"
     length: 3.3
     width: 3.3
     height: 5.3
@@ -34,7 +33,7 @@ CP_Elec_3x5.4:
     pad_spacing: 0.8
 
 CP_Elec_4x3:
-    description: "SMT capacitor, aluminium electrolytic, 4x3, Nichicon"
+    extra_description: "Nichicon"
     length: 4.3
     width: 4.3
     height: 3
@@ -45,7 +44,7 @@ CP_Elec_4x3:
     pad_spacing: 1
 
 CP_Elec_4x3.9:
-    description: "SMT capacitor, aluminium electrolytic, 4x3.9, Nichicon"
+    extra_description: "Nichicon"
     length: 4.3
     width: 4.3
     height: 3.9
@@ -56,7 +55,7 @@ CP_Elec_4x3.9:
     pad_spacing: 1
 
 CP_Elec_4x4.5:
-    description: "SMT capacitor, aluminium electrolytic, 4x4.5, Nichicon"
+    extra_description: "Nichicon"
     length: 4.3
     width: 4.3
     height: 4.5
@@ -67,7 +66,7 @@ CP_Elec_4x4.5:
     pad_spacing: 1
 
 CP_Elec_4x5.3:
-    description: "SMT capacitor, aluminium electrolytic, 4x5.3, Vishay"
+    extra_description: "Vishay"
     length: 4.3
     width: 4.3
     height: 5.3
@@ -78,7 +77,7 @@ CP_Elec_4x5.3:
     pad_spacing: 1
 
 CP_Elec_4x5.4:
-    description: "SMT capacitor, aluminium electrolytic, 4x5.4, Panasonic A5, Nichicon"
+    extra_description: "Panasonic A5 / Nichicon"
     length: 4.3
     width: 4.3
     height: 5.4
@@ -89,7 +88,7 @@ CP_Elec_4x5.4:
     pad_spacing: 1
 
 CP_Elec_4x5.7:
-    description: "SMT capacitor, aluminium electrolytic, 4x5.7, United Chemi-Con"
+    extra_description: "United Chemi-Con"
     length: 4.3
     width: 4.3
     height: 5.7
@@ -100,7 +99,7 @@ CP_Elec_4x5.7:
     pad_spacing: 1
 
 CP_Elec_4x5.8:
-    description: "SMT capacitor, aluminium electrolytic, 4x5.8, Panasonic"
+    extra_description: "Panasonic"
     length: 4.3
     width: 4.3
     height: 5.8
@@ -111,7 +110,7 @@ CP_Elec_4x5.8:
     pad_spacing: 1
 
 CP_Elec_5x3:
-    description: "SMT capacitor, aluminium electrolytic, 5x3, Nichicon"
+    extra_description: "Nichicon"
     length: 5.3
     width: 5.3
     height: 3
@@ -122,7 +121,7 @@ CP_Elec_5x3:
     pad_spacing: 1.4
 
 CP_Elec_5x3.9:
-    description: "SMT capacitor, aluminium electrolytic, 5x3.9, Nichicon"
+    extra_description: "Nichicon"
     length: 5.3
     width: 5.3
     height: 3.9
@@ -133,7 +132,7 @@ CP_Elec_5x3.9:
     pad_spacing: 1.4
 
 CP_Elec_5x4.4:
-    description: "SMT capacitor, aluminium electrolytic, 5x4.4, Panasonic B45"
+    extra_description: "Panasonic B45"
     length: 5.3
     width: 5.3
     height: 4.4
@@ -144,7 +143,7 @@ CP_Elec_5x4.4:
     pad_spacing: 1.4
 
 CP_Elec_5x4.5:
-    description: "SMT capacitor, aluminium electrolytic, 5x4.5, Nichicon"
+    extra_description: "Nichicon"
     length: 5.3
     width: 5.3
     height: 4.5
@@ -155,7 +154,7 @@ CP_Elec_5x4.5:
     pad_spacing: 1.4
 
 CP_Elec_5x5.3:
-    description: "SMT capacitor, aluminium electrolytic, 5x5.3, Nichicon"
+    extra_description: "Nichicon"
     length: 5.3
     width: 5.3
     height: 5.3
@@ -166,7 +165,7 @@ CP_Elec_5x5.3:
     pad_spacing: 1.4
 
 CP_Elec_5x5.4:
-    description: "SMT capacitor, aluminium electrolytic, 5x5.4, Nichicon"
+    extra_description: "Nichicon"
     length: 5.3
     width: 5.3
     height: 5.4
@@ -177,7 +176,7 @@ CP_Elec_5x5.4:
     pad_spacing: 1.4
 
 CP_Elec_5x5.7:
-    description: "SMT capacitor, aluminium electrolytic, 5x5.7, United Chemi-Con"
+    extra_description: "United Chemi-Con"
     length: 5.3
     width: 5.3
     height: 5.7
@@ -188,7 +187,7 @@ CP_Elec_5x5.7:
     pad_spacing: 1.4
 
 CP_Elec_5x5.8:
-    description: "SMT capacitor, aluminium electrolytic, 5x5.8, Panasonic"
+    extra_description: "Panasonic"
     length: 5.3
     width: 5.3
     height: 5.8
@@ -199,7 +198,7 @@ CP_Elec_5x5.8:
     pad_spacing: 1.4
 
 CP_Elec_5x5.9:
-    description: "SMT capacitor, aluminium electrolytic, 5x5.9, Panasonic B6"
+    extra_description: "Panasonic B6"
     length: 5.3
     width: 5.3
     height: 5.9
@@ -210,7 +209,7 @@ CP_Elec_5x5.9:
     pad_spacing: 1.4
 
 CP_Elec_6.3x3:
-    description: "SMT capacitor, aluminium electrolytic, 6.3x3, Nichicon"
+    extra_description: "Nichicon"
     length: 6.6
     width: 6.6
     height: 3
@@ -221,7 +220,7 @@ CP_Elec_6.3x3:
     pad_spacing: 1.9
 
 CP_Elec_6.3x3.9:
-    description: "SMT capacitor, aluminium electrolytic, 6.3x3.9, Nichicon"
+    extra_description: "Nichicon"
     length: 6.6
     width: 6.6
     height: 3.9
@@ -232,7 +231,7 @@ CP_Elec_6.3x3.9:
     pad_spacing: 1.9
 
 CP_Elec_6.3x4.5:
-    description: "SMT capacitor, aluminium electrolytic, 6.3x4.5, Nichicon"
+    extra_description: "Nichicon"
     length: 6.6
     width: 6.6
     height: 4.5
@@ -243,7 +242,7 @@ CP_Elec_6.3x4.5:
     pad_spacing: 1.9
 
 CP_Elec_6.3x4.9:
-    description: "SMT capacitor, aluminium electrolytic, 6.3x4.9, Panasonic C5"
+    extra_description: "Panasonic C5"
     length: 6.6
     width: 6.6
     height: 4.9
@@ -254,7 +253,7 @@ CP_Elec_6.3x4.9:
     pad_spacing: 2.1
 
 CP_Elec_6.3x5.2:
-    description: "SMT capacitor, aluminium electrolytic, 6.3x5.2, United Chemi-Con"
+    extra_description: "United Chemi-Con"
     length: 6.6
     width: 6.6
     height: 5.2
@@ -265,7 +264,7 @@ CP_Elec_6.3x5.2:
     pad_spacing: 2.1
 
 CP_Elec_6.3x5.3:
-    description: "SMT capacitor, aluminium electrolytic, 6.3x5.3, Cornell Dubilier Electronics"
+    extra_description: "Cornell Dubilier"
     length: 6.6
     width: 6.6
     height: 5.3
@@ -276,7 +275,7 @@ CP_Elec_6.3x5.3:
     pad_spacing: 2.1
 
 CP_Elec_6.3x5.4:
-    description: "SMT capacitor, aluminium electrolytic, 6.3x5.4, Panasonic C55"
+    extra_description: "Panasonic C55"
     length: 6.6
     width: 6.6
     height: 5.4
@@ -287,7 +286,7 @@ CP_Elec_6.3x5.4:
     pad_spacing: 2.1
 
 CP_Elec_6.3x5.4_Nichicon:
-    description: "SMT capacitor, aluminium electrolytic, 6.3x5.4, Nichicon"
+    extra_description: "Nichicon"
     length: 6.6
     width: 6.6
     height: 5.4
@@ -298,7 +297,7 @@ CP_Elec_6.3x5.4_Nichicon:
     pad_spacing: 1.9
 
 CP_Elec_6.3x5.7:
-    description: "SMT capacitor, aluminium electrolytic, 6.3x5.7, United Chemi-Con"
+    extra_description: "United Chemi-Con"
     length: 6.6
     width: 6.6
     height: 5.7
@@ -309,7 +308,7 @@ CP_Elec_6.3x5.7:
     pad_spacing: 1.9
 
 CP_Elec_6.3x5.8:
-    description: "SMT capacitor, aluminium electrolytic, 6.3x5.8, Nichicon"
+    extra_description: "Nichicon"
     length: 6.6
     width: 6.6
     height: 5.8
@@ -320,7 +319,7 @@ CP_Elec_6.3x5.8:
     pad_spacing: 1.9
 
 CP_Elec_6.3x5.9:
-    description: "SMT capacitor, aluminium electrolytic, 6.3x5.9, Panasonic C6"
+    extra_description: "Panasonic C6"
     length: 6.6
     width: 6.6
     height: 5.9
@@ -331,7 +330,7 @@ CP_Elec_6.3x5.9:
     pad_spacing: 2.1
 
 CP_Elec_6.3x7.7:
-    description: "SMT capacitor, aluminium electrolytic, 6.3x7.7, Nichicon"
+    extra_description: "Nichicon"
     length: 6.6
     width: 6.6
     height: 7.7
@@ -342,7 +341,7 @@ CP_Elec_6.3x7.7:
     pad_spacing: 1.9
 
 CP_Elec_6.3x9.9:
-    description: "SMT capacitor, aluminium electrolytic, 6.3x9.9, Panasonic C10"
+    extra_description: "Panasonic C10"
     length: 6.6
     width: 6.6
     height: 9.9
@@ -353,7 +352,7 @@ CP_Elec_6.3x9.9:
     pad_spacing: 2.1
 
 CP_Elec_8x5.4:
-    description: "SMT capacitor, aluminium electrolytic, 8x5.4, Nichicon"
+    extra_description: "Nichicon"
     length: 8.3
     width: 8.3
     height: 5.4
@@ -364,7 +363,7 @@ CP_Elec_8x5.4:
     pad_spacing: 2.1
 
 CP_Elec_8x6.2:
-    description: "SMT capacitor, aluminium electrolytic, 8x6.2, Nichicon"
+    extra_description: "Nichicon"
     length: 8.3
     width: 8.3
     height: 6.2
@@ -375,7 +374,7 @@ CP_Elec_8x6.2:
     pad_spacing: 2.1
 
 CP_Elec_8x6.5:
-    description: "SMT capacitor, aluminium electrolytic, 8x6.5, Rubycon"
+    extra_description: "Rubycon"
     length: 8.3
     width: 8.3
     height: 6.5
@@ -386,7 +385,7 @@ CP_Elec_8x6.5:
     pad_spacing: 2.1
 
 CP_Elec_8x6.7:
-    description: "SMT capacitor, aluminium electrolytic, 8x6.7, United Chemi-Con"
+    extra_description: "United Chemi-Con"
     length: 8.3
     width: 8.3
     height: 6.7
@@ -397,7 +396,7 @@ CP_Elec_8x6.7:
     pad_spacing: 2.1
 
 CP_Elec_8x6.9:
-    description: "SMT capacitor, aluminium electrolytic, 8x6.9, Panasonic E7"
+    extra_description: "Panasonic E7"
     length: 8.3
     width: 8.3
     height: 6.9
@@ -408,7 +407,7 @@ CP_Elec_8x6.9:
     pad_spacing: 2.8
 
 CP_Elec_8x10:
-    description: "SMT capacitor, aluminium electrolytic, 8x10, Nichicon"
+    extra_description: "Nichicon"
     length: 8.3
     width: 8.3
     height: 10
@@ -419,7 +418,7 @@ CP_Elec_8x10:
     pad_spacing: 3
 
 CP_Elec_8x10.5:
-    description: "SMT capacitor, aluminium electrolytic, 8x10.5, Vishay 0810"
+    extra_description: "Vishay 0810"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
     length: 8.5
     width: 8.5
@@ -431,7 +430,7 @@ CP_Elec_8x10.5:
     pad_spacing: 3.0
 
 CP_Elec_8x11.9:
-    description: "SMT capacitor, aluminium electrolytic, 8x11.9, Panasonic E12"
+    extra_description: "Panasonic E12"
     length: 8.3
     width: 8.3
     height: 11.9
@@ -442,7 +441,7 @@ CP_Elec_8x11.9:
     pad_spacing: 2.8
 
 CP_Elec_10x7.7:
-    description: "SMT capacitor, aluminium electrolytic, 10x7.7, Nichicon"
+    extra_description: "Nichicon"
     length: 10.3
     width: 10.3
     height: 7.7
@@ -453,7 +452,7 @@ CP_Elec_10x7.7:
     pad_spacing: 4.3
 
 CP_Elec_10x7.9:
-    description: "SMT capacitor, aluminium electrolytic, 10x7.9, Panasonic F8"
+    extra_description: "Panasonic F8"
     length: 10.3
     width: 10.3
     height: 7.9
@@ -464,7 +463,7 @@ CP_Elec_10x7.9:
     pad_spacing: 4.3
 
 CP_Elec_10x10:
-    description: "SMT capacitor, aluminium electrolytic, 10x10, Nichicon"
+    extra_description: "Nichicon"
     length: 10.3
     width: 10.3
     height: 10
@@ -475,7 +474,7 @@ CP_Elec_10x10:
     pad_spacing: 4
 
 CP_Elec_10x10.5:
-    description: "SMT capacitor, aluminium electrolytic, 10x10, Vishay 1010"
+    extra_description: "Vishay 1010"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
     length: 10.5
     width: 10.5
@@ -487,7 +486,7 @@ CP_Elec_10x10.5:
     pad_spacing: 4.0
 
 CP_Elec_10x12.5:
-    description: "SMT capacitor, aluminium electrolytic, 10x12.5, Vishay 1012"
+    extra_description: "Vishay 1012"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
     length: 10.5
     width: 10.5
@@ -499,7 +498,7 @@ CP_Elec_10x12.5:
     pad_spacing: 4.0
 
 CP_Elec_10x12.6:
-    description: "SMT capacitor, aluminium electrolytic, 10x12.6, Panasonic F12"
+    extra_description: "Panasonic F12"
     length: 10.3
     width: 10.3
     height: 12.6
@@ -510,7 +509,7 @@ CP_Elec_10x12.6:
     pad_spacing: 4.3
 
 CP_Elec_10x14.3:
-    description: "SMT capacitor, aluminium electrolytic, 10x14.3, Vishay 1014"
+    extra_description: "Vishay 1014"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
     length: 10.5
     width: 10.5
@@ -525,7 +524,7 @@ CP_Elec_10x14.3:
 # TODO: Vishay 12.5x16.5
 
 CP_Elec_16x17.5:
-    description: "SMT capacitor, aluminium electrolytic, 16x17.5, Vishay 1616"
+    extra_description: "Vishay 1616"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
     length: 16.6
     width: 16.6
@@ -537,7 +536,7 @@ CP_Elec_16x17.5:
     pad_spacing: 4.7
 
 CP_Elec_16x22:
-    description: "SMT capacitor, aluminium electrolytic, 16x22, Vishay 1621"
+    extra_description: "Vishay 1621"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
     length: 16.6
     width: 16.6
@@ -549,7 +548,7 @@ CP_Elec_16x22:
     pad_spacing: 4.7
 
 CP_Elec_18x17.5:
-    description: "SMT capacitor, aluminium electrolytic, 18x17.5, Vishay 1816"
+    extra_description: "Vishay 1816"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
     length: 19
     width: 19
@@ -561,7 +560,7 @@ CP_Elec_18x17.5:
     pad_spacing: 4.7
 
 CP_Elec_18x22:
-    description: "SMT capacitor, aluminium electrolytic, 18x22, Vishay 1821"
+    extra_description: "Vishay 1821"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
     length: 19
     width: 19
@@ -575,7 +574,7 @@ CP_Elec_18x22:
 ######################Panasonic
 #
 #CP_Panasonic_Standard_B:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 4.0mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 4.3
 #    width: 4.3
@@ -587,7 +586,7 @@ CP_Elec_18x22:
 #    pad_spacing: 1.0
 #
 #CP_Panasonic_Standard_B_HandSoldering:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 4.0mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 4.3
 #    width: 4.3
@@ -599,7 +598,7 @@ CP_Elec_18x22:
 #    pad_spacing: 1.0
 #
 #CP_Panasonic_Standard_C:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 5.0mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 5.3
 #    width: 5.3
@@ -611,7 +610,7 @@ CP_Elec_18x22:
 #    pad_spacing: 1.5
 #
 #CP_Panasonic_Standard_C_HandSoldering:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 5.0mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 5.3
 #    width: 5.3
@@ -623,7 +622,7 @@ CP_Elec_18x22:
 #    pad_spacing: 1.5
 #
 #CP_Panasonic_Standard_D:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 6.3mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 6.6
 #    width: 6.6
@@ -635,7 +634,7 @@ CP_Elec_18x22:
 #    pad_spacing: 1.8
 #
 #CP_Panasonic_Standard_D_HandSoldering:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 6.3mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 6.6
 #    width: 6.6
@@ -647,7 +646,7 @@ CP_Elec_18x22:
 #    pad_spacing: 1.8
 #
 #CP_Panasonic_Standard_E:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 8.0mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 8.3
 #    width: 8.3
@@ -659,7 +658,7 @@ CP_Elec_18x22:
 #    pad_spacing: 2.2
 #
 #CP_Panasonic_Standard_E_HandSoldering:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 8.0mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 8.3
 #    width: 8.3
@@ -671,7 +670,7 @@ CP_Elec_18x22:
 #    pad_spacing: 2.2
 #
 #CP_Panasonic_Standard_F:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 8.0mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 8.3
 #    width: 8.3
@@ -683,7 +682,7 @@ CP_Elec_18x22:
 #    pad_spacing: 3.1
 #
 #CP_Panasonic_Standard_F_HandSoldering:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 8.0mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 8.3
 #    width: 8.3
@@ -695,7 +694,7 @@ CP_Elec_18x22:
 #    pad_spacing: 3.1
 #
 #CP_Panasonic_Standard_G:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 10.0mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 10.3
 #    width: 10.3
@@ -707,7 +706,7 @@ CP_Elec_18x22:
 #    pad_spacing: 4.6
 #
 #CP_Panasonic_Standard_G_HandSoldering:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 10.0mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 10.3
 #    width: 10.3
@@ -719,7 +718,7 @@ CP_Elec_18x22:
 #    pad_spacing: 4.6
 #
 #CP_Panasonic_Standard_H:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 12.5mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 13.5
 #    width: 13.5
@@ -731,7 +730,7 @@ CP_Elec_18x22:
 #    pad_spacing: 4.0
 #
 #CP_Panasonic_Standard_H_HandSoldering:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 12.5mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 13.5
 #    width: 13.5
@@ -743,7 +742,7 @@ CP_Elec_18x22:
 #    pad_spacing: 4.0
 #
 #CP_Panasonic_Standard_J:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 16.0mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 17.0
 #    width: 17.0
@@ -755,7 +754,7 @@ CP_Elec_18x22:
 #    pad_spacing: 6.0
 #
 #CP_Panasonic_Standard_J_HandSoldering:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 16.0mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 17.0
 #    width: 17.0
@@ -767,7 +766,7 @@ CP_Elec_18x22:
 #    pad_spacing: 6.0
 #
 #CP_Panasonic_Standard_K:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 18.0mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 19.0
 #    width: 19.0
@@ -779,7 +778,7 @@ CP_Elec_18x22:
 #    pad_spacing: 6.0
 #
 #CP_Panasonic_Standard_K_HandSoldering:
-#    description: "SMT capacitor, standard, aluminium electrolytic, 18.0mm, Panasonic"
+#    extra_description: "Panasonic"
 #    datasheet: "https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/DME0000COL48.pdf"
 #    length: 19.0
 #    width: 19.0

--- a/scripts/Capacitors_SMD/CP_Elec_round.yaml
+++ b/scripts/Capacitors_SMD/CP_Elec_round.yaml
@@ -1,32 +1,42 @@
 #CP_Elec_6.3x5.8:
-#    length: 6.6
-#    width: 6.6
-#    height: 5.8
-#    diameter: 6.3
+#    body_length:
+#      nominal: 6.6
+#    body_width:
+#      nominal: 6.6
+#    body_height:
+#      nominal: 5.8
+#    body_diameter:
+#      nominal: 6.3
 #    pad_width: 1.9
 #    pin1_chamfer: 'auto'
 #    pad_length: 3.5
 #    pad_spacing: 1.6
 
-# https://industrial.panasonic.com/cdbs/www-data/pdf/AAB8000/AAB8000COL60.pdf
-# https://industrial.panasonic.com/cdbs/www-data/pdf/AAB8000/AAB8000COL10.pdf
+# https://industrial.panasonic.com/cdbs/www-data/pdf/AAB8000/AAB8000COL60.pdf # broken link
+# https://industrial.panasonic.com/cdbs/www-data/pdf/AAB8000/AAB8000COL10.pdf # pad sizes
 
-# http://www.vishay.com/docs/28395/150crz.pdf
+# https://www.vishay.com/docs/28395/150crz.pdf
 
+# http://www.nichicon.co.jp/english/products/pdfs/e-ch_ref.pdf # pad sizes
 # https://media.digikey.com/pdf/Data%20Sheets/Nichicon%20PDFs/ZD_Series.pdf
-# http://www.nichicon.co.jp/english/products/pdfs/e-ch_ref.pdf
 # http://nichicon-us.com/english/products/pdfs/e-uzr.pdf
 # http://nichicon-us.com/english/products/pdfs/e-uzs.pdf
 # http://nichicon-us.com/english/products/pdfs/e-uwx.pdf
+
+# UCC, CDE, nor Rubycon datasheets are given above
 
 # 3x5.3
 
 CP_Elec_3x5.4:
     extra_description: "Nichicon"
-    length: 3.3
-    width: 3.3
-    height: 5.3
-    diameter: 3
+    body_length:
+      nominal: 3.3
+    body_width:
+      nominal: 3.3
+    body_height:
+      nominal: 5.4
+    body_diameter:
+      nominal: 3.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 2.2
@@ -34,10 +44,14 @@ CP_Elec_3x5.4:
 
 CP_Elec_4x3:
     extra_description: "Nichicon"
-    length: 4.3
-    width: 4.3
-    height: 3
-    diameter: 4
+    body_length:
+      nominal: 4.3
+    body_width:
+      nominal: 4.3
+    body_height:
+      nominal: 3
+    body_diameter:
+      nominal: 4.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 2.6
@@ -45,10 +59,14 @@ CP_Elec_4x3:
 
 CP_Elec_4x3.9:
     extra_description: "Nichicon"
-    length: 4.3
-    width: 4.3
-    height: 3.9
-    diameter: 4
+    body_length:
+      nominal: 4.3
+    body_width:
+      nominal: 4.3
+    body_height:
+      nominal: 3.9
+    body_diameter:
+      nominal: 4.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 2.6
@@ -56,10 +74,14 @@ CP_Elec_4x3.9:
 
 CP_Elec_4x4.5:
     extra_description: "Nichicon"
-    length: 4.3
-    width: 4.3
-    height: 4.5
-    diameter: 4
+    body_length:
+      nominal: 4.3
+    body_width:
+      nominal: 4.3
+    body_height:
+      nominal: 4.5
+    body_diameter:
+      nominal: 4.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 2.6
@@ -67,10 +89,14 @@ CP_Elec_4x4.5:
 
 CP_Elec_4x5.3:
     extra_description: "Vishay"
-    length: 4.3
-    width: 4.3
-    height: 5.3
-    diameter: 4
+    body_length:
+      nominal: 4.3
+    body_width:
+      nominal: 4.3
+    body_height:
+      nominal: 5.3
+    body_diameter:
+      nominal: 4.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 2.6
@@ -78,10 +104,14 @@ CP_Elec_4x5.3:
 
 CP_Elec_4x5.4:
     extra_description: "Panasonic A5 / Nichicon"
-    length: 4.3
-    width: 4.3
-    height: 5.4
-    diameter: 4
+    body_length:
+      nominal: 4.3
+    body_width:
+      nominal: 4.3
+    body_height:
+      nominal: 5.4
+    body_diameter:
+      nominal: 4.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 2.6
@@ -89,10 +119,14 @@ CP_Elec_4x5.4:
 
 CP_Elec_4x5.7:
     extra_description: "United Chemi-Con"
-    length: 4.3
-    width: 4.3
-    height: 5.7
-    diameter: 4
+    body_length:
+      nominal: 4.3
+    body_width:
+      nominal: 4.3
+    body_height:
+      nominal: 5.7
+    body_diameter:
+      nominal: 4.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 2.6
@@ -100,10 +134,14 @@ CP_Elec_4x5.7:
 
 CP_Elec_4x5.8:
     extra_description: "Panasonic"
-    length: 4.3
-    width: 4.3
-    height: 5.8
-    diameter: 4
+    body_length:
+      nominal: 4.3
+    body_width:
+      nominal: 4.3
+    body_height:
+      nominal: 5.8
+    body_diameter:
+      nominal: 4.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 2.6
@@ -111,10 +149,14 @@ CP_Elec_4x5.8:
 
 CP_Elec_5x3:
     extra_description: "Nichicon"
-    length: 5.3
-    width: 5.3
-    height: 3
-    diameter: 5
+    body_length:
+      nominal: 5.3
+    body_width:
+      nominal: 5.3
+    body_height:
+      nominal: 3.0
+    body_diameter:
+      nominal: 5.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3
@@ -122,10 +164,14 @@ CP_Elec_5x3:
 
 CP_Elec_5x3.9:
     extra_description: "Nichicon"
-    length: 5.3
-    width: 5.3
-    height: 3.9
-    diameter: 5
+    body_length:
+      nominal: 5.3
+    body_width:
+      nominal: 5.3
+    body_height:
+      nominal: 3.9
+    body_diameter:
+      nominal: 5.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3
@@ -133,10 +179,14 @@ CP_Elec_5x3.9:
 
 CP_Elec_5x4.4:
     extra_description: "Panasonic B45"
-    length: 5.3
-    width: 5.3
-    height: 4.4
-    diameter: 5
+    body_length:
+      nominal: 5.3
+    body_width:
+      nominal: 5.3
+    body_height:
+      nominal: 4.4
+    body_diameter:
+      nominal: 5.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3
@@ -144,10 +194,14 @@ CP_Elec_5x4.4:
 
 CP_Elec_5x4.5:
     extra_description: "Nichicon"
-    length: 5.3
-    width: 5.3
-    height: 4.5
-    diameter: 5
+    body_length:
+      nominal: 5.3
+    body_width:
+      nominal: 5.3
+    body_height:
+      nominal: 4.5
+    body_diameter:
+      nominal: 5.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3
@@ -155,10 +209,14 @@ CP_Elec_5x4.5:
 
 CP_Elec_5x5.3:
     extra_description: "Nichicon"
-    length: 5.3
-    width: 5.3
-    height: 5.3
-    diameter: 5
+    body_length:
+      nominal: 5.3
+    body_width:
+      nominal: 5.3
+    body_height:
+      nominal: 5.3
+    body_diameter:
+      nominal: 5.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3
@@ -166,10 +224,14 @@ CP_Elec_5x5.3:
 
 CP_Elec_5x5.4:
     extra_description: "Nichicon"
-    length: 5.3
-    width: 5.3
-    height: 5.4
-    diameter: 5
+    body_length:
+      nominal: 5.3
+    body_width:
+      nominal: 5.3
+    body_height:
+      nominal: 5.4
+    body_diameter:
+      nominal: 5.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3
@@ -177,10 +239,14 @@ CP_Elec_5x5.4:
 
 CP_Elec_5x5.7:
     extra_description: "United Chemi-Con"
-    length: 5.3
-    width: 5.3
-    height: 5.7
-    diameter: 5
+    body_length:
+      nominal: 5.3
+    body_width:
+      nominal: 5.3
+    body_height:
+      nominal: 5.7
+    body_diameter:
+      nominal: 5.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3
@@ -188,10 +254,14 @@ CP_Elec_5x5.7:
 
 CP_Elec_5x5.8:
     extra_description: "Panasonic"
-    length: 5.3
-    width: 5.3
-    height: 5.8
-    diameter: 5
+    body_length:
+      nominal: 5.3
+    body_width:
+      nominal: 5.3
+    body_height:
+      nominal: 5.8
+    body_diameter:
+      nominal: 5.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3
@@ -199,10 +269,14 @@ CP_Elec_5x5.8:
 
 CP_Elec_5x5.9:
     extra_description: "Panasonic B6"
-    length: 5.3
-    width: 5.3
-    height: 5.9
-    diameter: 5
+    body_length:
+      nominal: 5.3
+    body_width:
+      nominal: 5.3
+    body_height:
+      nominal: 5.9
+    body_diameter:
+      nominal: 5.0
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3
@@ -210,10 +284,14 @@ CP_Elec_5x5.9:
 
 CP_Elec_6.3x3:
     extra_description: "Nichicon"
-    length: 6.6
-    width: 6.6
-    height: 3
-    diameter: 6.3
+    body_length:
+      nominal: 6.6
+    body_width:
+      nominal: 6.6
+    body_height:
+      nominal: 3.0
+    body_diameter:
+      nominal: 6.3
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3.5
@@ -221,10 +299,14 @@ CP_Elec_6.3x3:
 
 CP_Elec_6.3x3.9:
     extra_description: "Nichicon"
-    length: 6.6
-    width: 6.6
-    height: 3.9
-    diameter: 6.3
+    body_length:
+      nominal: 6.6
+    body_width:
+      nominal: 6.6
+    body_height:
+      nominal: 3.9
+    body_diameter:
+      nominal: 6.3
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3.5
@@ -232,10 +314,14 @@ CP_Elec_6.3x3.9:
 
 CP_Elec_6.3x4.5:
     extra_description: "Nichicon"
-    length: 6.6
-    width: 6.6
-    height: 4.5
-    diameter: 6.3
+    body_length:
+      nominal: 6.6
+    body_width:
+      nominal: 6.6
+    body_height:
+      nominal: 4.5
+    body_diameter:
+      nominal: 6.3
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3.5
@@ -243,10 +329,14 @@ CP_Elec_6.3x4.5:
 
 CP_Elec_6.3x4.9:
     extra_description: "Panasonic C5"
-    length: 6.6
-    width: 6.6
-    height: 4.9
-    diameter: 6.3
+    body_length:
+      nominal: 6.6
+    body_width:
+      nominal: 6.6
+    body_height:
+      nominal: 4.9
+    body_diameter:
+      nominal: 6.3
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3.5
@@ -254,10 +344,14 @@ CP_Elec_6.3x4.9:
 
 CP_Elec_6.3x5.2:
     extra_description: "United Chemi-Con"
-    length: 6.6
-    width: 6.6
-    height: 5.2
-    diameter: 6.3
+    body_length:
+      nominal: 6.6
+    body_width:
+      nominal: 6.6
+    body_height:
+      nominal: 5.2
+    body_diameter:
+      nominal: 6.3
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3.5
@@ -265,10 +359,14 @@ CP_Elec_6.3x5.2:
 
 CP_Elec_6.3x5.3:
     extra_description: "Cornell Dubilier"
-    length: 6.6
-    width: 6.6
-    height: 5.3
-    diameter: 6.3
+    body_length:
+      nominal: 6.6
+    body_width:
+      nominal: 6.6
+    body_height:
+      nominal: 5.3
+    body_diameter:
+      nominal: 6.3
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3.5
@@ -276,10 +374,14 @@ CP_Elec_6.3x5.3:
 
 CP_Elec_6.3x5.4:
     extra_description: "Panasonic C55"
-    length: 6.6
-    width: 6.6
-    height: 5.4
-    diameter: 6.3
+    body_length:
+      nominal: 6.6
+    body_width:
+      nominal: 6.6
+    body_height:
+      nominal: 5.4
+    body_diameter:
+      nominal: 6.3
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3.5
@@ -287,10 +389,14 @@ CP_Elec_6.3x5.4:
 
 CP_Elec_6.3x5.4_Nichicon:
     extra_description: "Nichicon"
-    length: 6.6
-    width: 6.6
-    height: 5.4
-    diameter: 6.3
+    body_length:
+      nominal: 6.6
+    body_width:
+      nominal: 6.6
+    body_height:
+      nominal: 5.4
+    body_diameter:
+      nominal: 6.3
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3.5
@@ -298,10 +404,14 @@ CP_Elec_6.3x5.4_Nichicon:
 
 CP_Elec_6.3x5.7:
     extra_description: "United Chemi-Con"
-    length: 6.6
-    width: 6.6
-    height: 5.7
-    diameter: 6.3
+    body_length:
+      nominal: 6.6
+    body_width:
+      nominal: 6.6
+    body_height:
+      nominal: 5.7
+    body_diameter:
+      nominal: 6.3
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3.5
@@ -309,10 +419,14 @@ CP_Elec_6.3x5.7:
 
 CP_Elec_6.3x5.8:
     extra_description: "Nichicon"
-    length: 6.6
-    width: 6.6
-    height: 5.8
-    diameter: 6.3
+    body_length:
+      nominal: 6.6
+    body_width:
+      nominal: 6.6
+    body_height:
+      nominal: 5.8
+    body_diameter:
+      nominal: 6.3
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3.5
@@ -320,10 +434,14 @@ CP_Elec_6.3x5.8:
 
 CP_Elec_6.3x5.9:
     extra_description: "Panasonic C6"
-    length: 6.6
-    width: 6.6
-    height: 5.9
-    diameter: 6.3
+    body_length:
+      nominal: 6.6
+    body_width:
+      nominal: 6.6
+    body_height:
+      nominal: 5.9
+    body_diameter:
+      nominal: 6.3
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3.5
@@ -331,10 +449,14 @@ CP_Elec_6.3x5.9:
 
 CP_Elec_6.3x7.7:
     extra_description: "Nichicon"
-    length: 6.6
-    width: 6.6
-    height: 7.7
-    diameter: 6.3
+    body_length:
+      nominal: 6.6
+    body_width:
+      nominal: 6.6
+    body_height:
+      nominal: 7.7
+    body_diameter:
+      nominal: 6.3
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3.5
@@ -342,10 +464,14 @@ CP_Elec_6.3x7.7:
 
 CP_Elec_6.3x9.9:
     extra_description: "Panasonic C10"
-    length: 6.6
-    width: 6.6
-    height: 9.9
-    diameter: 6.3
+    body_length:
+      nominal: 6.6
+    body_width:
+      nominal: 6.6
+    body_height:
+      nominal: 9.9
+    body_diameter:
+      nominal: 6.3
     pad_width: 1.6
     pin1_chamfer: 'auto'
     pad_length: 3.5
@@ -353,10 +479,14 @@ CP_Elec_6.3x9.9:
 
 CP_Elec_8x5.4:
     extra_description: "Nichicon"
-    length: 8.3
-    width: 8.3
-    height: 5.4
-    diameter: 8
+    body_length:
+      nominal: 8.3
+    body_width:
+      nominal: 8.3
+    body_height:
+      nominal: 5.4
+    body_diameter:
+      nominal: 8.0
     pad_width: 2.5
     pin1_chamfer: 'auto'
     pad_length: 4
@@ -364,10 +494,14 @@ CP_Elec_8x5.4:
 
 CP_Elec_8x6.2:
     extra_description: "Nichicon"
-    length: 8.3
-    width: 8.3
-    height: 6.2
-    diameter: 8
+    body_length:
+      nominal: 8.3
+    body_width:
+      nominal: 8.3
+    body_height:
+      nominal: 6.2
+    body_diameter:
+      nominal: 8.0
     pad_width: 2.5
     pin1_chamfer: 'auto'
     pad_length: 4
@@ -375,10 +509,14 @@ CP_Elec_8x6.2:
 
 CP_Elec_8x6.5:
     extra_description: "Rubycon"
-    length: 8.3
-    width: 8.3
-    height: 6.5
-    diameter: 8
+    body_length:
+      nominal: 8.3
+    body_width:
+      nominal: 8.3
+    body_height:
+      nominal: 6.5
+    body_diameter:
+      nominal: 8.0
     pad_width: 2.5
     pin1_chamfer: 'auto'
     pad_length: 4
@@ -386,10 +524,14 @@ CP_Elec_8x6.5:
 
 CP_Elec_8x6.7:
     extra_description: "United Chemi-Con"
-    length: 8.3
-    width: 8.3
-    height: 6.7
-    diameter: 8
+    body_length:
+      nominal: 8.3
+    body_width:
+      nominal: 8.3
+    body_height:
+      nominal: 6.7
+    body_diameter:
+      nominal: 8.0
     pad_width: 2.5
     pin1_chamfer: 'auto'
     pad_length: 4
@@ -397,10 +539,14 @@ CP_Elec_8x6.7:
 
 CP_Elec_8x6.9:
     extra_description: "Panasonic E7"
-    length: 8.3
-    width: 8.3
-    height: 6.9
-    diameter: 8
+    body_length:
+      nominal: 8.3
+    body_width:
+      nominal: 8.3
+    body_height:
+      nominal: 6.9
+    body_diameter:
+      nominal: 8.0
     pad_width: 1.9
     pin1_chamfer: 'auto'
     pad_length: 4.15
@@ -408,10 +554,14 @@ CP_Elec_8x6.9:
 
 CP_Elec_8x10:
     extra_description: "Nichicon"
-    length: 8.3
-    width: 8.3
-    height: 10
-    diameter: 8
+    body_length:
+      nominal: 8.3
+    body_width:
+      nominal: 8.3
+    body_height:
+      nominal: 10
+    body_diameter:
+      nominal: 8.0
     pad_width: 2.5
     pin1_chamfer: 'auto'
     pad_length: 3.5
@@ -420,10 +570,14 @@ CP_Elec_8x10:
 CP_Elec_8x10.5:
     extra_description: "Vishay 0810"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
-    length: 8.5
-    width: 8.5
-    height: 10.5
-    diameter: 8
+    body_length:
+      nominal: 8.5
+    body_width:
+      nominal: 8.5
+    body_height:
+      nominal: 10.5
+    body_diameter:
+      nominal: 8.0
     pad_width: 2.5
     pin1_chamfer: 'auto'
     pad_length: 4.4
@@ -431,10 +585,14 @@ CP_Elec_8x10.5:
 
 CP_Elec_8x11.9:
     extra_description: "Panasonic E12"
-    length: 8.3
-    width: 8.3
-    height: 11.9
-    diameter: 8
+    body_length:
+      nominal: 8.3
+    body_width:
+      nominal: 8.3
+    body_height:
+      nominal: 11.9
+    body_diameter:
+      nominal: 8.0
     pad_width: 1.9
     pin1_chamfer: 'auto'
     pad_length: 4.15
@@ -442,10 +600,14 @@ CP_Elec_8x11.9:
 
 CP_Elec_10x7.7:
     extra_description: "Nichicon"
-    length: 10.3
-    width: 10.3
-    height: 7.7
-    diameter: 10
+    body_length:
+      nominal: 10.3
+    body_width:
+      nominal: 10.3
+    body_height:
+      nominal: 7.7
+    body_diameter:
+      nominal: 10.0
     pad_width: 1.9
     pin1_chamfer: 'auto'
     pad_length: 4.4
@@ -453,10 +615,14 @@ CP_Elec_10x7.7:
 
 CP_Elec_10x7.9:
     extra_description: "Panasonic F8"
-    length: 10.3
-    width: 10.3
-    height: 7.9
-    diameter: 10
+    body_length:
+      nominal: 10.3
+    body_width:
+      nominal: 10.3
+    body_height:
+      nominal: 7.9
+    body_diameter:
+      nominal: 10.0
     pad_width: 1.9
     pin1_chamfer: 'auto'
     pad_length: 4.4
@@ -464,10 +630,14 @@ CP_Elec_10x7.9:
 
 CP_Elec_10x10:
     extra_description: "Nichicon"
-    length: 10.3
-    width: 10.3
-    height: 10
-    diameter: 10
+    body_length:
+      nominal: 10.3
+    body_width:
+      nominal: 10.3
+    body_height:
+      nominal: 10.0
+    body_diameter:
+      nominal: 10.0
     pad_width: 2.5
     pin1_chamfer: 'auto'
     pad_length: 4
@@ -476,10 +646,14 @@ CP_Elec_10x10:
 CP_Elec_10x10.5:
     extra_description: "Vishay 1010"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
-    length: 10.5
-    width: 10.5
-    height: 10.5
-    diameter: 10
+    body_length:
+      nominal: 10.5
+    body_width:
+      nominal: 10.5
+    body_height:
+      nominal: 10.5
+    body_diameter:
+      nominal: 10.0
     pad_width: 2.5
     pin1_chamfer: 'auto'
     pad_length: 4.4
@@ -488,10 +662,14 @@ CP_Elec_10x10.5:
 CP_Elec_10x12.5:
     extra_description: "Vishay 1012"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
-    length: 10.5
-    width: 10.5
-    height: 12.5
-    diameter: 10
+    body_length:
+      nominal: 10.5
+    body_width:
+      nominal: 10.5
+    body_height:
+      nominal: 12.5
+    body_diameter:
+      nominal: 10.0
     pad_width: 2.5
     pin1_chamfer: 'auto'
     pad_length: 4.4
@@ -499,10 +677,14 @@ CP_Elec_10x12.5:
 
 CP_Elec_10x12.6:
     extra_description: "Panasonic F12"
-    length: 10.3
-    width: 10.3
-    height: 12.6
-    diameter: 10
+    body_length:
+      nominal: 10.3
+    body_width:
+      nominal: 10.3
+    body_height:
+      nominal: 12.6
+    body_diameter:
+      nominal: 10.0
     pad_width: 1.9
     pin1_chamfer: 'auto'
     pad_length: 4.4
@@ -511,10 +693,14 @@ CP_Elec_10x12.6:
 CP_Elec_10x14.3:
     extra_description: "Vishay 1014"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
-    length: 10.5
-    width: 10.5
-    height: 14.3
-    diameter: 10
+    body_length:
+      nominal: 10.5
+    body_width:
+      nominal: 10.5
+    body_height:
+      nominal: 14.3
+    body_diameter:
+      nominal: 10.0
     pad_width: 2.5
     pin1_chamfer: 'auto'
     pad_length: 4.4
@@ -526,10 +712,14 @@ CP_Elec_10x14.3:
 CP_Elec_16x17.5:
     extra_description: "Vishay 1616"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
-    length: 16.6
-    width: 16.6
-    height: 17.5
-    diameter: 16
+    body_length:
+      nominal: 16.6
+    body_width:
+      nominal: 16.6
+    body_height:
+      nominal: 17.5
+    body_diameter:
+      nominal: 16.0
     pad_width: 9.6
     pin1_chamfer: 'auto'
     pad_length: 7.8
@@ -538,10 +728,14 @@ CP_Elec_16x17.5:
 CP_Elec_16x22:
     extra_description: "Vishay 1621"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
-    length: 16.6
-    width: 16.6
-    height: 22
-    diameter: 16
+    body_length:
+      nominal: 16.6
+    body_width:
+      nominal: 16.6
+    body_height:
+      nominal: 22.0
+    body_diameter:
+      nominal: 16.0
     pad_width: 9.6
     pin1_chamfer: 'auto'
     pad_length: 7.8
@@ -550,10 +744,14 @@ CP_Elec_16x22:
 CP_Elec_18x17.5:
     extra_description: "Vishay 1816"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
-    length: 19
-    width: 19
-    height: 17.5
-    diameter: 18
+    body_length:
+      nominal: 19.0
+    body_width:
+      nominal: 19.0
+    body_height:
+      nominal: 17.5
+    body_diameter:
+      nominal: 18.0
     pad_width: 9.6
     pin1_chamfer: 'auto'
     pad_length: 8.8
@@ -562,10 +760,14 @@ CP_Elec_18x17.5:
 CP_Elec_18x22:
     extra_description: "Vishay 1821"
     datasheet: "http://www.vishay.com/docs/28395/150crz.pdf"
-    length: 19
-    width: 19
-    height: 22
-    diameter: 18
+    body_length:
+      nominal: 19.0
+    body_width:
+      nominal: 19.0
+    body_height:
+      nominal: 22.0
+    body_diameter:
+      nominal: 18.0
     pad_width: 9.6
     pin1_chamfer: 'auto'
     pad_length: 8.8

--- a/scripts/Capacitors_SMD/C_Elec_round.py
+++ b/scripts/Capacitors_SMD/C_Elec_round.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import argparse
+import yaml
+import math
+
+sys.path.append(os.path.join(sys.path[0], "..", ".."))  # load parent path of KicadModTree
+from KicadModTree import *  # NOQA
+from KicadModTree.nodes.base.Pad import Pad  # NOQA
+
+sys.path.append(os.path.join(sys.path[0], "..", "tools"))  # load parent path of tools
+from ipc_pad_size_calculators import *
+
+def create_footprint(name, configuration, **kwargs):
+    kicad_mod = Footprint(name)
+
+    # init kicad footprint
+    datasheet = "" if 'datasheet' in kwargs else ""
+    description = "SMD capacitor, aluminum electrolytic"
+    if name[:2] == "C_":
+        description += " nonpolar"
+    if 'extra_description' in kwargs:
+        description += ", " + kwargs['extra_description']
+
+    # ensure all provided dimensions are fully toleranced
+    device_dimensions = {
+        'body_length': TolerancedSize.fromYaml(kwargs, base_name='body_length'),
+        'body_width': TolerancedSize.fromYaml(kwargs, base_name='body_width'),
+        'body_height': TolerancedSize.fromYaml(kwargs, base_name='body_height'),
+        'body_diameter': TolerancedSize.fromYaml(kwargs, base_name='body_diameter'),
+        'lead_width': TolerancedSize.fromYaml(kwargs, base_name='lead_width'),
+        'lead_spacing': TolerancedSize.fromYaml(kwargs, base_name='lead_spacing'),
+        'lead_length': TolerancedSize.fromYaml(kwargs, base_name='lead_length')
+    }
+    
+    # for ease of use, capture nominal body and pad sizes
+    body_size = {
+        'length': device_dimensions['body_length'].nominal,
+        'width': device_dimensions['body_width'].nominal,
+        'height': device_dimensions['body_height'].nominal,
+        'diameter': device_dimensions['body_diameter'].nominal
+    }
+    pad_size = {
+        'length': device_dimensions['lead_length'].nominal,
+        'width': device_dimensions['body_width'].nominal,
+        'height': device_dimensions['body_height'].nominal
+    }
+
+    description += ", " + str(body_size['diameter']) + "x" + str(body_size['height']) + "mm"
+    kicad_mod.setDescription(description + datasheet)
+    kicad_mod.setTags('capacitor electrolytic' if name[:2] is "CP" else 'capacitor electrolyic nonpolar')
+    kicad_mod.setAttribute('smd')
+
+    # set general values
+    text_offset_y = body_size['width'] / 2.0 + configuration['courtyard_offset']['default'] + 0.8
+
+    #silkscreen REF**
+    silk_text_size = configuration['references'][0]['size']
+    silk_text_thickness = silk_text_size[0]*configuration['references'][0]['fontwidth']
+    kicad_mod.append(Text(type='reference', text='REF**', at=[0, -text_offset_y], layer='F.SilkS', size=[silk_text_size[0], silk_text_size[1]], thickness= silk_text_thickness))
+    #fab value
+    fab_text_size = configuration['values'][0]['size']
+    fab_text_thickness = fab_text_size[0]*configuration['values'][0]['fontwidth']
+    kicad_mod.append(Text(type='value', text=name, at=[0, text_offset_y], layer='F.Fab', size=[fab_text_size[0], fab_text_size[1]], thickness= fab_text_thickness))
+    #fab REF**
+    fab_text_size = body_size['diameter']/5.0
+    fab_text_size = min(fab_text_size, configuration['references'][1]['size_max'][0])
+    fab_text_size = max(fab_text_size, configuration['references'][1]['size_min'][0])
+    fab_text_thickness = fab_text_size*configuration['references'][1]['thickness_factor']
+    kicad_mod.append(Text(type='user', text='%R', at=[0, 0], layer='F.Fab', size=[fab_text_size, fab_text_size], thickness= fab_text_thickness))
+
+    # create pads
+    # all pads have these properties
+    pad_params = {'type': Pad.TYPE_SMT, 'layers': Pad.LAYERS_SMT, 'shape': Pad.SHAPE_RECT}
+    
+    # prefer IPC-7351C compliant rounded rectangle pads
+    if not configuration['force_rectangle_pads']:
+        pad_params['shape'] = Pad.SHAPE_ROUNDRECT
+        pad_params['radius_ratio'] = 0.25
+        pad_params['maximum_radius'] = 0.25
+
+    # prefer calculating pads from lead dimensions per IPC
+    # fall back to using pad sizes directly if necessary
+    if ('lead_length' in kwargs) and ('lead_width' in kwargs) and ('lead_spacing' in kwargs):
+        # gather IPC data (unique parameters for >= 10mm tall caps)
+        ipc_density_suffix = '' if body_size['height'] < 10 else '_10mm'
+        ipc_density = configuration['ipc_density']
+        ipc_data = ipc_defintions['ipc_spec_capae_crystal'][ipc_density + ipc_density_suffix]
+        ipc_round_base = ipc_defintions['ipc_spec_capae_crystal']['round_base']
+        
+        manf_tol = {
+            'F': configuration.get('manufacturing_tolerance', 0.1),
+            'P': configuration.get('placement_tolerance', 0.05)
+        }
+        
+        # leads are dimensioned like SOIC so use gullwing calculator
+        device_dimensions['lead_outside'] = TolerancedSize(maximum =
+            device_dimensions['lead_spacing'].maximum +
+            device_dimensions.get('lead_length').maximum * 2,
+            minimum = device_dimensions['lead_spacing'].minimum +
+            device_dimensions.get('lead_length').minimum * 2)
+        
+        Gmin, Zmax, Xmax = ipc_gull_wing(ipc_data, ipc_round_base, manf_tol,
+                device_dimensions['lead_width'], device_dimensions['lead_outside'],
+                lead_len=device_dimensions.get('lead_length'))
+        
+        pad_params['size'] = [(Zmax - Gmin) / 2.0, Xmax]
+
+        x_pad_spacing = (Zmax + Gmin) / 4.0
+    elif ('pad_length' in kwargs) and ('pad_width' in kwargs) and ('pad_spacing' in kwargs):
+        x_pad_spacing = kwargs['pad_spacing'] / 2.0 + kwargs['pad_length'] / 2.0
+        pad_params['size'] = [kwargs['pad_length'], kwargs['pad_width']]
+    else:
+        raise KeyError("Provide all three 'pad' or 'lead' properties ('_spacing', '_length', and '_width')")
+
+    kicad_mod.append(Pad(number=1, at=[-x_pad_spacing, 0], **pad_params))
+    kicad_mod.append(Pad(number=2, at=[x_pad_spacing, 0], **pad_params))
+    
+    # create fabrication layer
+    fab_x = body_size['length'] / 2.0
+    fab_y = body_size['width'] / 2.0
+
+    if kwargs['pin1_chamfer'] == 'auto':
+        fab_edge = min(fab_x/2.0, fab_y/2.0, configuration['fab_pin1_marker_length'])
+    else:
+        fab_edge = kwargs['pin1_chamfer']
+    fab_x_edge = fab_x - fab_edge
+    fab_y_edge = fab_y - fab_edge
+    kicad_mod.append(Line(start=[fab_x, -fab_y], end=[fab_x, fab_y], layer='F.Fab', width=configuration['fab_line_width']))
+    kicad_mod.append(Line(start=[-fab_x_edge, -fab_y], end=[fab_x, -fab_y], layer='F.Fab', width=configuration['fab_line_width']))
+    kicad_mod.append(Line(start=[-fab_x_edge, fab_y], end=[fab_x, fab_y], layer='F.Fab', width=configuration['fab_line_width']))
+    if fab_edge > 0:
+        kicad_mod.append(Line(start=[-fab_x, -fab_y_edge], end=[-fab_x, fab_y_edge], layer='F.Fab', width=configuration['fab_line_width']))
+        kicad_mod.append(Line(start=[-fab_x, -fab_y_edge], end=[-fab_x_edge, -fab_y], layer='F.Fab', width=configuration['fab_line_width']))
+    kicad_mod.append(Line(start=[-fab_x, fab_y_edge], end=[-fab_x_edge, fab_y], layer='F.Fab', width=configuration['fab_line_width']))
+    kicad_mod.append(Circle(center=[0, 0], radius=body_size['diameter']/2.0, layer='F.Fab', width=configuration['fab_line_width']))
+
+
+    #fab polarity marker for polarized caps
+    if name[:2].upper() == "CP":
+        fab_pol_size = body_size['diameter']/10.0
+        fab_pol_wing = fab_pol_size/2.0
+        fab_pol_distance = body_size['diameter']/2.0 - fab_pol_wing - configuration['fab_line_width']
+        fab_pol_pos_y = fab_text_size/2.0 + configuration['silk_pad_clearance'] + fab_pol_size
+        fab_pol_pos_x = math.sqrt(fab_pol_distance*fab_pol_distance-fab_pol_pos_y*fab_pol_pos_y)
+        fab_pol_pos_x = -fab_pol_pos_x
+        fab_pol_pos_y = -fab_pol_pos_y
+        kicad_mod.append(Line(start=[fab_pol_pos_x-fab_pol_wing, fab_pol_pos_y], end=[fab_pol_pos_x+fab_pol_wing, fab_pol_pos_y], 
+            layer='F.Fab', width=configuration['fab_line_width']))
+        kicad_mod.append(Line(start=[fab_pol_pos_x, fab_pol_pos_y-fab_pol_wing], end=[fab_pol_pos_x, fab_pol_pos_y+fab_pol_wing], 
+            layer='F.Fab', width=configuration['fab_line_width']))
+
+
+    # create silkscreen
+    fab_to_silk_offset = configuration['silk_fab_offset']
+    silk_x = body_size['length'] / 2.0 + fab_to_silk_offset
+    silk_y = body_size['width'] / 2.0 + fab_to_silk_offset
+    silk_y_start = pad_params['size'][1] / 2.0 + configuration['silk_pad_clearance'] + configuration['silk_line_width']/2.0
+    silk_45deg_offset = fab_to_silk_offset*math.tan(math.radians(22.5))
+    silk_x_edge = fab_x - fab_edge + silk_45deg_offset
+    silk_y_edge = fab_y - fab_edge + silk_45deg_offset
+
+    kicad_mod.append(Line(start=[silk_x, silk_y], end=[silk_x, silk_y_start], layer='F.SilkS', width=configuration['silk_line_width']))
+    kicad_mod.append(Line(start=[silk_x, -silk_y], end=[silk_x, -silk_y_start], layer='F.SilkS', width=configuration['silk_line_width']))
+    kicad_mod.append(Line(start=[-silk_x_edge, -silk_y], end=[silk_x, -silk_y], layer='F.SilkS', width=configuration['silk_line_width']))
+    kicad_mod.append(Line(start=[-silk_x_edge, silk_y], end=[silk_x, silk_y], layer='F.SilkS', width=configuration['silk_line_width']))
+
+    if silk_y_edge > silk_y_start:
+        kicad_mod.append(Line(start=[-silk_x, silk_y_edge], end=[-silk_x, silk_y_start], layer='F.SilkS', width=configuration['silk_line_width']))
+        kicad_mod.append(Line(start=[-silk_x, -silk_y_edge], end=[-silk_x, -silk_y_start], layer='F.SilkS', width=configuration['silk_line_width']))
+
+        kicad_mod.append(Line(start=[-silk_x, -silk_y_edge], end=[-silk_x_edge, -silk_y], layer='F.SilkS', width=configuration['silk_line_width']))
+        kicad_mod.append(Line(start=[-silk_x, silk_y_edge], end=[-silk_x_edge, silk_y], layer='F.SilkS', width=configuration['silk_line_width']))
+    else:
+        silk_x_cut = silk_x - (silk_y_start - silk_y_edge) # because of the 45 degree edge we can user a simple apporach
+        silk_y_edge_cut = silk_y_start
+
+        kicad_mod.append(Line(start=[-silk_x_cut, -silk_y_edge_cut], end=[-silk_x_edge, -silk_y], layer='F.SilkS', width=configuration['silk_line_width']))
+        kicad_mod.append(Line(start=[-silk_x_cut, silk_y_edge_cut], end=[-silk_x_edge, silk_y], layer='F.SilkS', width=configuration['silk_line_width']))
+
+    #silk polarity marker
+    if name[:2].upper() == "CP":
+        silk_pol_size = body_size['diameter']/8.0
+        silk_pol_wing = silk_pol_size/2.0
+        silk_pol_pos_y = silk_y_start + silk_pol_size
+        silk_pol_pos_x = silk_x + silk_pol_wing + configuration['silk_line_width']*2
+        silk_pol_pos_x = -silk_pol_pos_x
+        silk_pol_pos_y = -silk_pol_pos_y
+        kicad_mod.append(Line(start=[silk_pol_pos_x-silk_pol_wing, silk_pol_pos_y], end=[silk_pol_pos_x+silk_pol_wing, silk_pol_pos_y], 
+            layer='F.SilkS', width=configuration['silk_line_width']))
+        kicad_mod.append(Line(start=[silk_pol_pos_x, silk_pol_pos_y-silk_pol_wing], end=[silk_pol_pos_x, silk_pol_pos_y+silk_pol_wing], 
+            layer='F.SilkS', width=configuration['silk_line_width']))
+
+    # create courtyard
+    courtyard_offset = configuration['courtyard_offset']['default']
+    courtyard_x = body_size['length'] / 2.0 + courtyard_offset
+    courtyard_y = body_size['width'] / 2.0 + courtyard_offset
+    courtyard_pad_x = x_pad_spacing + pad_params['size'][0] / 2.0 + courtyard_offset
+    courtyard_pad_y = pad_params['size'][1] / 2.0 + courtyard_offset
+    courtyard_45deg_offset = courtyard_offset*math.tan(math.radians(22.5))
+    courtyard_x_edge = fab_x - fab_edge + courtyard_45deg_offset
+    courtyard_y_edge = fab_y - fab_edge + courtyard_45deg_offset
+    courtyard_x_lower_edge = courtyard_x
+    if courtyard_y_edge < courtyard_pad_y:
+        courtyard_x_lower_edge = courtyard_x_lower_edge - courtyard_pad_y + courtyard_y_edge
+        courtyard_y_edge = courtyard_pad_y
+    #rounding
+    courtyard_x = float(format(courtyard_x, ".2f"))
+    courtyard_y = float(format(courtyard_y, ".2f"))
+    courtyard_pad_x = float(format(courtyard_pad_x, ".2f"))
+    courtyard_pad_y = float(format(courtyard_pad_y, ".2f"))
+    courtyard_x_edge = float(format(courtyard_x_edge, ".2f"))
+    courtyard_y_edge = float(format(courtyard_y_edge, ".2f"))
+    courtyard_x_lower_edge = float(format(courtyard_x_lower_edge, ".2f"))
+
+    # drawing courtyard
+    kicad_mod.append(Line(start=[courtyard_x, -courtyard_y], end=[courtyard_x, -courtyard_pad_y], layer='F.CrtYd', width=configuration['courtyard_line_width']))
+    kicad_mod.append(Line(start=[courtyard_x, -courtyard_pad_y], end=[courtyard_pad_x, -courtyard_pad_y], layer='F.CrtYd', width=configuration['courtyard_line_width']))
+    kicad_mod.append(Line(start=[courtyard_pad_x, -courtyard_pad_y], end=[courtyard_pad_x, courtyard_pad_y], layer='F.CrtYd', width=configuration['courtyard_line_width']))
+    kicad_mod.append(Line(start=[courtyard_pad_x, courtyard_pad_y], end=[courtyard_x, courtyard_pad_y], layer='F.CrtYd', width=configuration['courtyard_line_width']))
+    kicad_mod.append(Line(start=[courtyard_x, courtyard_pad_y], end=[courtyard_x, courtyard_y], layer='F.CrtYd', width=configuration['courtyard_line_width']))
+
+    kicad_mod.append(Line(start=[-courtyard_x_edge, courtyard_y], end=[courtyard_x, courtyard_y], layer='F.CrtYd', width=configuration['courtyard_line_width']))
+    kicad_mod.append(Line(start=[-courtyard_x_edge, -courtyard_y], end=[courtyard_x, -courtyard_y], layer='F.CrtYd', width=configuration['courtyard_line_width']))
+    if fab_edge > 0:
+        kicad_mod.append(Line(start=[-courtyard_x_lower_edge, courtyard_y_edge], end=[-courtyard_x_edge, courtyard_y], layer='F.CrtYd', width=configuration['courtyard_line_width']))
+        kicad_mod.append(Line(start=[-courtyard_x_lower_edge, -courtyard_y_edge], end=[-courtyard_x_edge, -courtyard_y], layer='F.CrtYd', width=configuration['courtyard_line_width']))
+    if courtyard_y_edge > courtyard_pad_y:
+        kicad_mod.append(Line(start=[-courtyard_x, -courtyard_y_edge], end=[-courtyard_x, -courtyard_pad_y], layer='F.CrtYd', width=configuration['courtyard_line_width']))
+        kicad_mod.append(Line(start=[-courtyard_x, courtyard_pad_y], end=[-courtyard_x, courtyard_y_edge], layer='F.CrtYd', width=configuration['courtyard_line_width']))
+    kicad_mod.append(Line(start=[-courtyard_x_lower_edge, -courtyard_pad_y], end=[-courtyard_pad_x, -courtyard_pad_y], layer='F.CrtYd', width=configuration['courtyard_line_width']))
+    kicad_mod.append(Line(start=[-courtyard_pad_x, -courtyard_pad_y], end=[-courtyard_pad_x, courtyard_pad_y], layer='F.CrtYd', width=configuration['courtyard_line_width']))
+    kicad_mod.append(Line(start=[-courtyard_pad_x, courtyard_pad_y], end=[-courtyard_x_lower_edge, courtyard_pad_y], layer='F.CrtYd', width=configuration['courtyard_line_width']))
+
+    lib_name ='Capacitor_SMD'
+    # add model
+    modelname = name.replace("_HandSoldering", "")
+    kicad_mod.append(Model(filename="{model_prefix:s}{lib_name:s}.3dshapes/{name:s}.wrl".format(model_prefix=configuration['3d_model_prefix'], lib_name=lib_name, name=modelname),
+                            at=[0, 0, 0], scale=[1, 1, 1], rotate=[0, 0, 0]))
+
+    # write file
+    output_dir = '{lib_name:s}.pretty/'.format(lib_name=lib_name)
+    if not os.path.isdir(output_dir): #returns false if path does not yet exist!! (Does not check path validity)
+        os.makedirs(output_dir)
+
+    filename = '{outdir:s}{fp_name:s}.kicad_mod'.format(outdir=output_dir, fp_name=name)
+    file_handler = KicadFileHandler(kicad_mod)
+    file_handler.writeFile(filename)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Parse *.kicad_mod.yml file(s) and create matching footprints')
+    parser.add_argument('files', metavar='file', type=str, nargs='+', help='yml-files to parse')
+    parser.add_argument('--global_config', type=str, nargs='?', help='the config file defining how the footprint will look like. (KLC)', default='../tools/global_config_files/config_KLCv3.0.yaml')
+    parser.add_argument('--series_config', type=str, nargs='?', help='the config file defining series parameters.', default='../SMD_chip_package_rlc-etc/config_KLCv3.0.yaml')
+    parser.add_argument('--ipc_definition', type=str, nargs='?', help='the IPC definition file', default='ipc7351B_capae_crystal.yaml')
+    parser.add_argument('--ipc_density', type=str, nargs='?', help='the IPC desnity', default='nominal')
+    parser.add_argument('--force_rectangle_pads', action='store_true', help='Force the generation of rectangle pads instead of rounded rectangle (KiCad 4.x compatibility.)')
+    #parser.add_argument('-v', '--verbose', help='show more information when creating footprint', action='store_true')
+    # TODO: allow writing into sub file
+    
+    args = parser.parse_args()
+    with open(args.global_config, 'r') as config_stream:
+        try:
+            configuration = yaml.load(config_stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+
+    with open(args.series_config, 'r') as config_stream:
+        try:
+            configuration.update(yaml.load(config_stream))
+        except yaml.YAMLError as exc:
+            print(exc)
+    
+    ipc_doc = args.ipc_definition
+    with open(ipc_doc, 'r') as ipc_stream:
+        try:
+            ipc_defintions = yaml.load(ipc_stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+
+    configuration['ipc_density'] = args.ipc_density
+    configuration['force_rectangle_pads'] = args.force_rectangle_pads
+    
+    for filepath in args.files:
+        with open(filepath, 'r') as stream:
+            try:
+                yaml_parsed = yaml.load(stream)
+                for footprint in yaml_parsed:
+                    print("generate {name}.kicad_mod".format(name=footprint))
+                    create_footprint(footprint, configuration , **yaml_parsed.get(footprint))
+            except yaml.YAMLError as exc:
+                print(exc)

--- a/scripts/Capacitors_SMD/C_Elec_round.py
+++ b/scripts/Capacitors_SMD/C_Elec_round.py
@@ -17,10 +17,12 @@ def create_footprint(name, configuration, **kwargs):
     kicad_mod = Footprint(name)
 
     # init kicad footprint
-    datasheet = "" if 'datasheet' in kwargs else ""
+    datasheet = ", " + kwargs['datasheet'] if 'datasheet' in kwargs else ""
     description = "SMD capacitor, aluminum electrolytic"
+    tags = 'capacitor electrolytic'
     if name[:2] == "C_":
         description += " nonpolar"
+        tags += " nonpolar"
     if 'extra_description' in kwargs:
         description += ", " + kwargs['extra_description']
 
@@ -29,10 +31,7 @@ def create_footprint(name, configuration, **kwargs):
         'body_length': TolerancedSize.fromYaml(kwargs, base_name='body_length'),
         'body_width': TolerancedSize.fromYaml(kwargs, base_name='body_width'),
         'body_height': TolerancedSize.fromYaml(kwargs, base_name='body_height'),
-        'body_diameter': TolerancedSize.fromYaml(kwargs, base_name='body_diameter'),
-        'lead_width': TolerancedSize.fromYaml(kwargs, base_name='lead_width'),
-        'lead_spacing': TolerancedSize.fromYaml(kwargs, base_name='lead_spacing'),
-        'lead_length': TolerancedSize.fromYaml(kwargs, base_name='lead_length')
+        'body_diameter': TolerancedSize.fromYaml(kwargs, base_name='body_diameter')
     }
     
     # for ease of use, capture nominal body and pad sizes
@@ -42,15 +41,10 @@ def create_footprint(name, configuration, **kwargs):
         'height': device_dimensions['body_height'].nominal,
         'diameter': device_dimensions['body_diameter'].nominal
     }
-    pad_size = {
-        'length': device_dimensions['lead_length'].nominal,
-        'width': device_dimensions['body_width'].nominal,
-        'height': device_dimensions['body_height'].nominal
-    }
 
     description += ", " + str(body_size['diameter']) + "x" + str(body_size['height']) + "mm"
     kicad_mod.setDescription(description + datasheet)
-    kicad_mod.setTags('capacitor electrolytic' if name[:2] is "CP" else 'capacitor electrolyic nonpolar')
+    kicad_mod.setTags(tags)
     kicad_mod.setAttribute('smd')
 
     # set general values
@@ -95,7 +89,10 @@ def create_footprint(name, configuration, **kwargs):
             'P': configuration.get('placement_tolerance', 0.05)
         }
         
-        # leads are dimensioned like SOIC so use gullwing calculator
+        # # fully tolerance lead dimensions; leads are dimensioned like SOIC so use gullwing calculator
+        device_dimensions['lead_width'] = TolerancedSize.fromYaml(kwargs, base_name='lead_width')
+        device_dimensions['lead_spacing'] = TolerancedSize.fromYaml(kwargs, base_name='lead_spacing')
+        device_dimensions['lead_length'] = TolerancedSize.fromYaml(kwargs, base_name='lead_length')
         device_dimensions['lead_outside'] = TolerancedSize(maximum =
             device_dimensions['lead_spacing'].maximum +
             device_dimensions.get('lead_length').maximum * 2,

--- a/scripts/Capacitors_SMD/C_Elec_round.yaml
+++ b/scripts/Capacitors_SMD/C_Elec_round.yaml
@@ -1,0 +1,275 @@
+# http://nichicon-us.com/english/products/pdfs/e-uup.pdf
+# http://nichicon-us.com/english/products/pdfs/e-uwp.pdf
+# https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/ABA0000C1145.pdf
+# https://media.digikey.com/pdf/Data%20Sheets/Panasonic%20Electronic%20Components/S_Series_Type_V_.pdf
+# https://industrial.panasonic.com/cdbs/www-data/pdf/RDE0000/ABA0000C1157.pdf
+
+# Note: KLC puts pin 1 to the left so body_length is across the pins (horizontal)
+
+# Note: Due to minor variations in lead dimension for the same body size,
+# given dimensions are the greatest of all common body sizes in the datasheets
+# above. This may result in slightly more paste than if the lead size was
+# specific to one vendor's datasheet dimensions. However, as the lead sizes are
+# already large, lead-to-PCB coplanarity is quite varaible, and the capacitor
+# body does not sit flush with the PCB, the amount of paste is not extremely
+# critical. Pads a few tenths of a millimeter bigger or smaller than ideal
+# won't affect solderability or reliability.
+
+C_Elec_3x5.4:
+    body_length:
+      nominal: 3.3
+      tolerance: 0.2
+    body_width:
+      nominal: 3.3
+      tolerance: 0.2
+    body_height:
+      nominal: 5.4
+    body_diameter:
+      nominal: 3.0
+    lead_width:
+      minimum: 0.45
+      maximum: 0.65
+    lead_length:
+      nominal: 1.5
+      tolerance: 0.2
+    lead_spacing:
+      nominal: 0.6
+    pin1_chamfer: 'auto'
+
+C_Elec_4x5.4:
+    body_length:
+      nominal: 4.3
+      tolerance: 0.2
+    body_width:
+      nominal: 4.3
+      tolerance: 0.2
+    body_height:
+      nominal: 5.4
+    body_diameter:
+      nominal: 4.0
+    lead_width:
+      minimum: 0.5
+      maximum: 0.8
+    lead_length:
+      nominal: 1.8
+      tolerance: 0.2
+    lead_spacing:
+      nominal: 1.0
+    pin1_chamfer: 'auto'
+
+C_Elec_4x5.8:
+    body_length:
+      nominal: 4.3
+      tolerance: 0.2
+    body_width:
+      nominal: 4.3
+      tolerance: 0.2
+    body_height:
+      nominal: 5.8
+    body_diameter:
+      nominal: 4.0
+    lead_width:
+      minimum: 0.5
+      maximum: 0.8
+    lead_length:
+      nominal: 1.8
+      tolerance: 0.2
+    lead_spacing:
+      nominal: 1.0
+    pin1_chamfer: 'auto'
+
+C_Elec_5x5.4:
+    body_length:
+      nominal: 5.3
+      tolerance: 0.2
+    body_width:
+      nominal: 5.3
+      tolerance: 0.2
+    body_height:
+      nominal: 5.4
+    body_diameter:
+      nominal: 5.0
+    lead_width:
+      minimum: 0.5
+      maximum: 0.8
+    lead_length:
+      minimum: 2.1
+      maximum: 2.2
+    lead_spacing:
+      minimum: 1.3
+      maximum: 1.5
+    pin1_chamfer: 'auto'
+
+C_Elec_5x5.8:
+    body_length:
+      nominal: 5.3
+      tolerance: 0.2
+    body_width:
+      nominal: 5.3
+      tolerance: 0.2
+    body_height:
+      nominal: 5.8
+    body_diameter:
+      nominal: 5.0
+    lead_width:
+      minimum: 0.5
+      maximum: 0.8
+    lead_length:
+      minimum: 2.1
+      maximum: 2.2
+    lead_spacing:
+      minimum: 1.3
+      maximum: 1.5
+    pin1_chamfer: 'auto'
+    
+C_Elec_6.3x5.4:
+    body_length:
+      nominal: 6.6
+      tolerance: 0.2
+    body_width:
+      nominal: 6.6
+      tolerance: 0.2
+    body_height:
+      nominal: 5.4
+    body_diameter:
+      nominal: 6.3
+    lead_width:
+      minimum: 0.5
+      maximum: 0.8
+    lead_length:
+      minimum: 2.4
+      maximum: 2.6
+    lead_spacing:
+      minimum: 1.8
+      maximum: 2.2
+    pin1_chamfer: 'auto'
+
+C_Elec_6.3x5.8:
+    body_length:
+      nominal: 6.6
+      tolerance: 0.2
+    body_width:
+      nominal: 6.6
+      tolerance: 0.2
+    body_height:
+      nominal: 5.8
+    body_diameter:
+      nominal: 6.3
+    lead_width:
+      minimum: 0.5
+      maximum: 0.8
+    lead_length:
+      minimum: 2.4
+      maximum: 2.6
+    lead_spacing:
+      minimum: 1.8
+      maximum: 2.2
+    pin1_chamfer: 'auto'
+
+C_Elec_6.3x7.7:
+    body_length:
+      nominal: 6.6
+      tolerance: 0.2
+    body_width:
+      nominal: 6.6
+      tolerance: 0.2
+    body_height:
+      nominal: 7.7
+    body_diameter:
+      nominal: 6.3
+    lead_width:
+      minimum: 0.5
+      maximum: 0.8
+    lead_length:
+      minimum: 2.4
+      maximum: 2.6
+    lead_spacing:
+      minimum: 1.8
+      maximum: 2.2
+    pin1_chamfer: 'auto'
+
+C_Elec_8x5.4:
+    body_length:
+      nominal: 8.3
+      tolerance: 0.2
+    body_width:
+      nominal: 8.3
+      tolerance: 0.2
+    body_height:
+      nominal: 5.4
+    body_diameter:
+      nominal: 8.0
+    lead_width:
+      minimum: 0.5
+      maximum: 0.8
+    lead_length:
+      minimum: 3.3
+      maximum: 3.4
+    lead_spacing:
+      minimum: 2.2
+      maximum: 2.3
+    pin1_chamfer: 'auto'
+
+C_Elec_8x6.2:
+    body_length:
+      nominal: 8.3
+      tolerance: 0.2
+    body_width:
+      nominal: 8.3
+      tolerance: 0.2
+    body_height:
+      nominal: 6.2
+    body_diameter:
+      nominal: 8.0
+    lead_width:
+      minimum: 0.5
+      maximum: 0.8
+    lead_length:
+      minimum: 3.3
+      maximum: 3.4
+    lead_spacing:
+      minimum: 2.2
+      maximum: 2.3
+    pin1_chamfer: 'auto'
+
+C_Elec_8x10.2:
+    body_length:
+      nominal: 8.3
+      tolerance: 0.2
+    body_width:
+      nominal: 8.3
+      tolerance: 0.2
+    body_height:
+      nominal: 10.2
+    body_diameter:
+      nominal: 8.0
+    lead_width:
+      minimum: 0.7
+      maximum: 1.1
+    lead_length:
+      nominal: 3.4
+      tolerance: 0.2
+    lead_spacing:
+      nominal: 3.1
+    pin1_chamfer: 'auto'
+
+C_Elec_10x10.2:
+    body_length:
+      nominal: 10.3
+      tolerance: 0.2
+    body_width:
+      nominal: 10.3
+      tolerance: 0.2
+    body_height:
+      nominal: 10.2
+    body_diameter:
+      nominal: 10.0
+    lead_width:
+      minimum: 0.7
+      maximum: 1.1
+    lead_length:
+      nominal: 3.5
+      tolerance: 0.2
+    lead_spacing:
+      nominal: 4.6
+    pin1_chamfer: 'auto'

--- a/scripts/Capacitors_SMD/ipc7351B_capae_crystal.yaml
+++ b/scripts/Capacitors_SMD/ipc7351B_capae_crystal.yaml
@@ -1,0 +1,51 @@
+# Dimensions taken from ipc7351b table 3-20
+
+# Aluminum Electrolytic Capacitor and 2-Pin Crystal
+#           | Minimum | Median    | Maximum |
+#           | (Most)  | (Nominal) | (Least) |
+#           | Density | Density   | Density | round
+# Lead Part | Level A | Level B   | Level C |  to
+# ----------+---------+-----------+---------+-
+# Toe (JT)  |  0.7    |  0.5      |  0.3    | 0.05
+# >=10mm    |  1.0    |  0.7      |  0.4
+# Heel (JH) |  0.0    |  -0.1     |  -0.2   | 0.05
+# >=10mm    |  0.0    |  -0.05    |  -0.1
+# Side (JS) |  0.5    |  0.4      |  0.03   | 0.05
+# >=10mm    |  0.6    |  0.5      |  0.4
+# Courtyard |  1.0    |  0.5      |  0.25   |
+
+ipc_spec_capae_crystal:
+    most:
+        toe: 0.7
+        heel: 0
+        side: 0.5
+        courtyard: 1.0
+    most_10mm:
+        toe: 1.0
+        heel: 0.0
+        side: 0.6
+        courtyard: 1.0
+    nominal:
+        toe: 0.5
+        heel: -0.1
+        side: 0.4
+        courtyard: 0.5
+    nominal_10mm:
+        toe: 0.7
+        heel: -0.05
+        side: 0.5
+        courtyard: 0.5
+    least:
+        toe: 0.3
+        heel: -0.2
+        side: 0.03
+        courtyard: 0.25
+    least_10mm:
+        toe: 0.4
+        heel: -0.1
+        side: 0.4
+        courtyard: 0.25
+    round_base:
+        toe: 0.05
+        heel: 0.05
+        side: 0.05

--- a/scripts/Packages/ipc_definitions.yaml
+++ b/scripts/Packages/ipc_definitions.yaml
@@ -1,6 +1,6 @@
 # IPC IPC-7351 http://pcbget.ru/Files/Standarts/IPC_7351.pdf
 # Page 23
-# Updated with IPC-7351 B values (sadly no openly accessable document available)
+# Updated with IPC-7351 B values (sadly no openly accessible document available)
 
 # Gull-Wing (L-Lead) pitch > 0.625
 #           | Minimum | Median    | Maximum |


### PR DESCRIPTION
SMD complement to https://github.com/pointhi/kicad-footprint-generator/pull/200.

This adds non-polar electrolytic SMD caps using IPC-calculated pads. It also updates all the existing SMD electrolytic polar caps to use rounded rect pads (while retaining the original pad sizes and placements for compatibility) and cleans up the script and YAML file a bit.

Also fixed one typo that doesn't affect anything else.

Footprints submitted at https://github.com/KiCad/kicad-footprints/pull/1030 and https://github.com/KiCad/kicad-footprints/pull/1032.