### PR TITLE
SMD_chip_package_rlc: Add 1008-scale package

### DIFF
--- a/scripts/SMD_chip_package_rlc-etc/size_definitions/size_default_chip_devices.yaml
+++ b/scripts/SMD_chip_package_rlc-etc/size_definitions/size_default_chip_devices.yaml
@@ -24,15 +24,18 @@ SMD_0805:
     terminator_spacing_max: 1.55
     size_info: '(Body size source: https://docs.google.com/spreadsheets/d/1BsfQQcO9C6DZCsRaXUlFlo91Tg2WpOkGARC1WS5S8t0/edit?usp=sharing)'
 
-# SMD_1008:
-# I did not find any part that uses this package.
-#     code_imperial: "1008"
-#     code_metric: "2520"
-#     body_length: 2.5
-#     body_length_min:
-#     body_width: 2.0
-#     body_width_min:
-#     terminator_spacing_max:
+SMD_1008:
+    code_imperial: "1008"
+    code_metric: "2520"
+    body_length: 2.5
+    body_length_min: 2.31
+    body_length_max: 2.71
+    body_width: 2.0
+    body_width_min: 1.82
+    body_width_max: 2.21
+    terminator_spacing_min: 1.08
+    terminator_spacing_max: 1.87
+    size_info: '(Body size source: https://docs.google.com/spreadsheets/d/1HlOzk286nJIew-0KkiQX-PjRaN0zUAehqjjhlR58QBM/edit?usp=sharing)'
 
 SMD_1206:
     code_imperial: "1206"


### PR DESCRIPTION
Add parameters for EIA 1008 size devices. Based off a sample of
inductors from various manufacturers (using Digikey stock as a rough
metric of popularity).