### PR TITLE
Add Microchip QFN entries

### DIFF
--- a/scripts/Packages/Package_DFN_QFN/size_definitions/uqfn.yaml
+++ b/scripts/Packages/Package_DFN_QFN/size_definitions/uqfn.yaml
@@ -1,0 +1,44 @@
+UQFN-16-1EP_4x4mm_P0.65mm_EP2.6x2.6mm:
+  device_type: 'UQFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'http://ww1.microchip.com/downloads/en/DeviceDoc/16L_UQFN_4x4x0_5mm_JQ_C04257A.pdf'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  # custom_name_format:
+  body_size_x: 4
+  body_size_y: 4
+  lead_width_min: 0.25
+  lead_width_max: 0.35
+  lead_len_min: 0.3
+  lead_len_max: 0.5
+
+  EP_size_x_min: 2.5
+  EP_size_x_max: 2.7
+  EP_size_y_min: 2.5
+  EP_size_y_max: 2.7
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 2]
+  #heel_reduction: 0.05 #for relatively large EP pads (increase clearance)
+
+  thermal_vias:
+    count: [3, 3]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    EP_num_paste_pads: [2, 2]
+    #paste_between_vias: 1
+    #paste_rings_outside: 1
+    EP_paste_coverage: 0.75
+    #grid: [1, 1]
+    # bottom_pad_size:
+    paste_avoid_via: False
+
+  pitch: 0.65
+  num_pins_x: 4
+  num_pins_y: 4
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'

--- a/scripts/Packages/Package_DFN_QFN/size_definitions/vqfn.yaml
+++ b/scripts/Packages/Package_DFN_QFN/size_definitions/vqfn.yaml
@@ -1,3 +1,46 @@
+VQFN-20-1EP_3x3mm_P0.4mm_EP1.7x1.7mm:
+  device_type: 'VQFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'http://ww1.microchip.com/downloads/en/DeviceDoc/20%20Lead%20VQFN%203x3x0_9mm_1_7EP%20U2B%20C04-21496a.pdf'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  # custom_name_format:
+  body_size_x: 3
+  body_size_y: 3
+  lead_width_min: 0.15
+  lead_width_max: 0.25
+  lead_len_min: 0.35
+  lead_len_max: 0.45
+
+  EP_size_x: 1.7
+  EP_size_y: 1.7
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 2]
+  # heel_reduction: 0.05 #for relatively large EP pads (increase clearance)
+
+  thermal_vias:
+    count: [2, 2]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    #EP_num_paste_pads: [2, 2]
+    paste_between_vias: 2
+    #paste_rings_outside: 1
+    EP_paste_coverage: 0.75
+    #grid: [1, 1]
+    # bottom_pad_size:
+    paste_avoid_via: False
+
+  pitch: 0.4
+  num_pins_x: 5
+  num_pins_y: 5
+  chamfer_edge_pins: 0.08
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'
+
 VQFN-20-1EP_3x3mm_P0.45mm_EP1.55x1.55mm:
   device_type: 'VQFN'
   #manufacturer: 'man'


### PR DESCRIPTION
Footprints submitted at .https://github.com/KiCad/kicad-footprints/pull/1097.

I started a UQFN YAML file since there was already a VQFN one.

Datasheets:
- http://ww1.microchip.com/downloads/en/DeviceDoc/16L_UQFN_4x4x0_5mm_JQ_C04257A.pdf
- http://ww1.microchip.com/downloads/en/DeviceDoc/20%20Lead%20VQFN%203x3x0_9mm_1_7EP%20U2B%20C04-21496a.pdf