### PR TITLE
New foot prints for Valves

### DIFF
--- a/KicadModTree/KicadFileHandler.py
+++ b/KicadModTree/KicadFileHandler.py
@@ -250,15 +250,26 @@ class KicadFileHandler(FileHandler):
         return sexpr
 
     def _serialize_Model(self, node):
-        sexpr = ['model', node.filename,
-                 SexprSerializer.NEW_LINE,
-                 ['at', ['xyz', node.at.x, node.at.y, node.at.z]],
-                 SexprSerializer.NEW_LINE,
-                 ['scale', ['xyz', node.scale.x, node.scale.y, node.scale.z]],
-                 SexprSerializer.NEW_LINE,
-                 ['rotate', ['xyz', node.rotate.x, node.rotate.y, node.rotate.z]],
-                 SexprSerializer.NEW_LINE
-                ]  # NOQA
+        if node._useAt():
+            sexpr = ['model', node.filename,
+                     SexprSerializer.NEW_LINE,
+                     ['at', ['xyz', node.at.x, node.at.y, node.at.z]],
+                     SexprSerializer.NEW_LINE,
+                     ['scale', ['xyz', node.scale.x, node.scale.y, node.scale.z]],
+                     SexprSerializer.NEW_LINE,
+                     ['rotate', ['xyz', node.rotate.x, node.rotate.y, node.rotate.z]],
+                     SexprSerializer.NEW_LINE
+                    ]  # NOQA
+        else:
+            sexpr = ['model', node.filename,
+                     SexprSerializer.NEW_LINE,
+                     ['offset', ['xyz', node.offset.x, node.offset.y, node.offset.z]],
+                     SexprSerializer.NEW_LINE,
+                     ['scale', ['xyz', node.scale.x, node.scale.y, node.scale.z]],
+                     SexprSerializer.NEW_LINE,
+                     ['rotate', ['xyz', node.rotate.x, node.rotate.y, node.rotate.z]],
+                     SexprSerializer.NEW_LINE
+                    ]  # NOQA
 
         return sexpr
 

--- a/KicadModTree/nodes/base/Model.py
+++ b/KicadModTree/nodes/base/Model.py
@@ -28,6 +28,8 @@ class Model(Node):
           name of the 3d-model file
         * *at* (``Vector3D``) --
           position of the model (default: [0, 0, 0])
+        * *offset* (``Vector3D``) --
+          offset position of the model (default: [0, 0, 0]), if at and offset is both present, at will superseed offset
         * *scale* (``Vector3D``) --
           scale of the model (default: [1, 1, 1])
         * *rotate* (``Vector3D``) --
@@ -44,16 +46,30 @@ class Model(Node):
         Node.__init__(self)
         self.filename = kwargs['filename']
         self.at = Vector3D(kwargs.get('at', [0, 0, 0]))
+        self.offset = Vector3D(kwargs.get('offset', [0, 0, 0]))
         self.scale = Vector3D(kwargs.get('scale', [1, 1, 1]))
         self.rotate = Vector3D(kwargs.get('rotate', [0, 0, 0]))
+        
+        self.useAt = False
+        if kwargs.get('at'):
+            self.useAt = True
+
+    def _useAt(self):
+        return self.useAt
 
     def _getRenderTreeText(self):
         render_text = Node._getRenderTreeText(self)
 
-        render_string = ['filename: {filename}'.format(filename=self.filename),
-                         'at: {at}'.format(at=self.at.render('(xyz {x} {y} {z})')),
-                         'scale: {scale}'.format(scale=self.scale.render('(xyz {x} {y} {z})')),
-                         'rotate: {rotate}'.format(rotate=self.rotate.render('(xyz {x} {y} {z})'))]
+        if self.useAt:
+            render_string = ['filename: {filename}'.format(filename=self.filename),
+                             'at: {at}'.format(at=self.at.render('(xyz {x} {y} {z})')),
+                             'scale: {scale}'.format(scale=self.scale.render('(xyz {x} {y} {z})')),
+                             'rotate: {rotate}'.format(rotate=self.rotate.render('(xyz {x} {y} {z})'))]
+        else:
+            render_string = ['filename: {filename}'.format(filename=self.filename),
+                             'offset: {offset}'.format(offset=self.offset.render('(xyz {x} {y} {z})')),
+                             'scale: {scale}'.format(scale=self.scale.render('(xyz {x} {y} {z})')),
+                             'rotate: {rotate}'.format(rotate=self.rotate.render('(xyz {x} {y} {z})'))]
 
         render_text += " [{}]".format(", ".join(render_string))
 

--- a/scripts/Valves/valve.py
+++ b/scripts/Valves/valve.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+import math
+import os
+import sys
+
+# load parent path of KicadModTree
+sys.path.append(os.path.join(sys.path[0], "..", ".."))
+
+from KicadModTree import *
+
+def bga(args):
+    footprint_name = args["name"]
+    description = args["pkg_description"]
+    datasheet = args["pkg_datasheet"]
+    D = args["pkg_D"]
+    pkg_valve_offset = args["pkg_valve_offset"]
+    pkg_socket_offset = args["pkg_socket_offset"]
+    npth_pin = args["pkg_npth_pin"]
+    center_pin = args["pkg_center_pin"]
+    pin_type = args["pkg_pin_type"]
+    pin_number = args["pkg_pin_number"]
+    pin_arc = args["pkg_pin_arc"]
+    pin_diameter = args["pkg_pin_diameter"]
+    npth_pin = args["pkg_npth_pin"]
+    socket = args["pkg_socket"]
+    tube = args["pkg_tube"]
+
+    socket
+    
+    alpha_delta = 0 - ((pin_arc * math.pi) / 180.0)
+    h = pin_diameter / 2.0
+    origo_dx = (h * math.sin(alpha_delta))
+    origo_dy = (h * math.cos(alpha_delta))
+    
+    origo_x = 0 - origo_dx
+    origo_y = origo_dy
+    
+    s1 = [1.0, 1.0]
+    s2 = [1.0, 1.0]
+    
+    t1 = 0.15 * s1[0]
+    t2 = 0.15 * s2[0]
+
+    yRef = origo_y - (D / 2.0) - (s1[1] * 1.2)
+    yValue = origo_y + (D / 2.0) + (s1[1] * 1.2)
+
+    wFab = 0.10
+    wCrtYd = 0.05
+    wSilkS = 0.12
+    
+    description_tot = description + ', Made by script https://github.com/pointhi/kicad-footprint-generator/scripts/Valves, ' + datasheet
+    
+    #
+    f = Footprint(footprint_name)
+    f.setDescription(description_tot)
+    f.setTags("{}".format(footprint_name))
+    #
+    s = socket
+    f.append(Model(filename="${{KISYS3DMOD}}/Valve.3dshapes/{}.wrl".format(s), offset=(pkg_socket_offset[0], pkg_socket_offset[1], pkg_socket_offset[2])))
+    #
+    s = tube
+    f.append(Model(filename="${{KISYS3DMOD}}/Valve.3dshapes/{}.wrl".format(s), offset=(pkg_valve_offset[0], pkg_valve_offset[1], pkg_valve_offset[2])))
+    # Text
+    f.append(Text(type="reference", text="REF**",       at=[round(origo_x, 2), round(yRef, 2)],     layer="F.SilkS",    size=s1, thickness=t1))
+    f.append(Text(type="value", text=footprint_name,    at=[round(origo_x, 2), round(yValue, 2)],   layer="F.Fab",      size=s1, thickness=t1))
+    f.append(Text(type="user", text="%R",               at=[round(origo_x, 2), round(origo_y, 2)],  layer="F.Fab",      size=s2, thickness=t2))
+
+    # Fab
+    f.append(Circle(center=(round(origo_x, 2), round(origo_y, 2)), radius=round((D / 2.0), 2), layer="F.Fab", width=wFab))
+
+    # Courtyard
+    f.append(Circle(center=(round(origo_x, 2), round(origo_y, 2)), radius=round((D / 2.0) + 0.12, 2), layer="F.CrtYd", width=wCrtYd))
+
+    # Silk
+    f.append(Circle(center=(round(origo_x, 2), round(origo_y, 2)), radius=round((D / 2.0) + 0.25, 2), layer="F.SilkS", width=wSilkS))
+
+    pad_size = round(pin_type[1] * 1.7, 1)
+    pad_drill = round(pin_type[1] * 1.1, 1)
+    alpha = alpha_delta
+    pad_shape = Pad.SHAPE_RECT
+    if pin_type[0] == 'tap':
+        pad_size = [round(pin_type[1] * 1.7, 1), round(pin_type[2] * 1.7, 1)]
+        pad_drill = [round(pin_type[1] * 1.1, 1), round(pin_type[2] * 1.1, 1)]
+        pad_shape = Pad.SHAPE_OVAL
+    #
+    pad_type = Pad.TYPE_THT
+    pad_layers = Pad.LAYERS_THT
+    for i in range(0, pin_number):
+        x1 = (h * math.sin(alpha)) + origo_x
+        y1 = (h * math.cos(alpha)) - origo_y
+
+        rotation = 0.0
+        if pin_type[0] == 'tap':
+            rotation = 360.0 - (alpha * (360.0 / (2.0 * math.pi)))
+        #
+        f.append(Pad(number="{}".format(i+1), 
+                    type=pad_type,
+                    shape=pad_shape,
+                    at=[round(x1, 2), round((0 - y1), 2)],
+                    size=pad_size,
+                    layers=pad_layers, 
+                    rotation=rotation,
+                    drill=pad_drill,
+                    radius_ratio=0.25))
+        #
+        pad_shape = Pad.SHAPE_ROUNDRECT
+        if pin_type[0] == 'tap':
+            pad_shape = Pad.SHAPE_OVAL
+        alpha = alpha + alpha_delta
+
+    if len(center_pin) > 0:
+        if center_pin[0] == "metal":
+            f.append(Pad(number="{}".format(pin_number + 1), 
+                    type=pad_type,
+                    shape=pad_shape,
+                    at=[round(origo_x, 2), round(origo_y, 2)],
+                    size=pad_size,
+                    layers=pad_layers, 
+                    drill=pad_drill,
+                    radius_ratio=0.25))
+                         
+    file_handler = KicadFileHandler(f)
+    file_handler.writeFile(footprint_name + ".kicad_mod")
+
+if __name__ == '__main__':
+    parser = ModArgparser(bga)
+    # the root node of .yml files is parsed as name
+    parser.add_parameter("name",                type=str,   required=True)
+    parser.add_parameter("pkg_description",     type=str,   required=True)
+    parser.add_parameter("pkg_datasheet",       type=str,   required=True)
+    parser.add_parameter("pkg_D",               type=float, required=True)
+    parser.add_parameter("pkg_valve_offset",    type=list, required=True)
+    parser.add_parameter("pkg_socket_offset",   type=list, required=True)
+    parser.add_parameter("pkg_npth_pin",        type=list,  required=True)
+    parser.add_parameter("pkg_center_pin",      type=list,  required=True)
+    parser.add_parameter("pkg_pin_type",        type=list,  required=True)
+    parser.add_parameter("pkg_pin_number",      type=int,   required=True)
+    parser.add_parameter("pkg_pin_arc",         type=float, required=True)
+    parser.add_parameter("pkg_pin_diameter",    type=float, required=True)
+    parser.add_parameter("pkg_socket",          type=str,   required=True)
+    parser.add_parameter("pkg_tube",            type=str,   required=True)
+    
+    # now run our script which handles the whole part of parsing the files
+    parser.run()

--- a/scripts/Valves/valve.yml
+++ b/scripts/Valves/valve.yml
@@ -1,0 +1,119 @@
+Valve_Magnoval-B9D-Pin:
+  pkg_description: "Magnoval B9D pin hole"
+  pkg_datasheet: "https://en.wikipedia.org/wiki/Tube_socket"
+  pkg_D: 30.00                  # Body width/diameter
+  pkg_npth_pin: []              # NPTH hole [(x, y, length)]
+  pkg_center_pin: []            # Center pin ('type', diameter, length)
+  pkg_pin_type: ['round', 1.27, 3.0]  # Pin type, diameter, length
+  pkg_pin_number: 9             # Number of pins
+  pkg_pin_arc: 36.0             # Arch between pins
+  pkg_pin_diameter: 17.45       # Diameter of the circle where pins are located
+  pkg_socket_offset: [0.00, 0.00, 0.00]    # Socket 3D model placement 
+  pkg_valve_offset: [0.00, 0.00, 12.00]    # Valve 3D model placement 
+  pkg_socket: 'Valve_Socket_Magnoval-B9D-D17.45mm_Pin'       # 3D model of socket
+  pkg_tube: 'Valve_Tube_Magnoval-B9D-D17.45mm_Pin'       # 3D model of tube
+
+Valve_Noval-B9A-Pin:
+  pkg_description: "Noval B9A pin hole"
+  pkg_datasheet: "https://en.wikipedia.org/wiki/Tube_socket"
+  pkg_D: 25.50                  # Body width/diameter
+  pkg_npth_pin: []              # NPTH hole [(x, y, length)]
+  pkg_center_pin: []            # Center pin ('type', diameter, length)
+  pkg_pin_type: ['round', 1.016, 3.0]  # Pin type, diameter, length
+  pkg_pin_number: 9             # Number of pins
+  pkg_pin_arc: 36.0             # Arch between pins
+  pkg_pin_diameter: 11.89       # Diameter of the circle where pins are located
+  pkg_socket_offset: [0.00, 0.00, 0.00]    # Socket 3D model placement 
+  pkg_valve_offset: [0.00, 0.00, 11.00]    # Valve 3D model placement 
+  pkg_socket: 'Valve_Socket_Noval-B9A-D11.89mm_Pin'       # 3D model of socket
+  pkg_tube: 'Valve_Tube_Noval-B9A-D11.89mm_Pin'       # 3D model of tube
+
+Valve_Belton_VT9_PT-B9A-Tap:
+  pkg_description: "Belton VT9-PT-B9A Tap"
+  pkg_datasheet: "http://www.belton.co.kr/inc/downfile.php?seq=58&file=pdf"
+  pkg_D: 27.00                  # Body width/diameter
+  pkg_npth_pin: []              # NPTH hole [(x, y, length)]
+  pkg_center_pin: []            # Center pin ('type', diameter, length)
+  pkg_pin_type: ['round', 1.8, 3.0]  # Pin type, diameter, length
+  pkg_pin_number: 9             # Number of pins
+  pkg_pin_arc: 36.0             # Arch between pins
+  pkg_pin_diameter: 21.00       # Diameter of the circle where pins are located
+  pkg_socket_offset: [0.00, 0.00, 0.00]    # Socket 3D model placement 
+  pkg_valve_offset: [2.68, -3.69, 12.00]    # Valve 3D model placement 
+  pkg_socket: 'Valve_Socket_Belton_VT9_PT-B9A-D21.00mm_Tap'       # 3D model of socket
+  pkg_tube: 'Valve_Tube_Noval-B9A-D11.89mm_Pin'       # 3D model of tube
+
+Valve_Miniature-B7G-Pin:
+  pkg_description: "Miniature B7G pin hole"
+  pkg_datasheet: "https://en.wikipedia.org/wiki/Tube_socket"
+  pkg_D: 15.00                  # Body width/diameter
+  pkg_npth_pin: []              # NPTH hole [(x, y, length)]
+  pkg_center_pin: []            # Center pin ('type', diameter, length)
+  pkg_pin_type: ['round', 1.016, 3.0]  # Pin type, diameter, length
+  pkg_pin_number: 7             # Number of pins
+  pkg_pin_arc: 45.0             # Arch between pins
+  pkg_pin_diameter: 09.53       # Diameter of the circle where pins are located
+  pkg_socket_offset: [0.00, 0.00, 0.00]    # Socket 3D model placement 
+  pkg_valve_offset: [0.00, 0.00,  8.00]    # Valve 3D model placement 
+  pkg_socket: 'Valve_Socket_Miniature-B7G-D09.53mm_Pin'       # 3D model of socket
+  pkg_tube: 'Valve_Tube_Miniature-B7G-D09.53mm_Pin'       # 3D model of tube
+
+Valve_Loctal-B9G-Pin:
+  pkg_description: "Loctal B9G pin hole"
+  pkg_datasheet: "https://en.wikipedia.org/wiki/Tube_socket"
+  pkg_D: 27.00                  # Body width/diameter
+  pkg_npth_pin: []              # NPTH hole [(x, y, length)]
+  pkg_center_pin: []            # Center pin ('type', diameter, length)
+  pkg_pin_type: ['round', 1.3, 3.0]  # Pin type, diameter, length
+  pkg_pin_number: 9             # Number of pins
+  pkg_pin_arc: 40.0             # Arch between pins
+  pkg_pin_diameter: 21.00       # Diameter of the circle where pins are located
+  pkg_socket_offset: [0.00, 0.00, 0.00]    # Socket 3D model placement 
+  pkg_valve_offset: [0.00, 0.00, 12.00]    # Valve 3D model placement 
+  pkg_socket: 'Valve_Socket_Loctal-B9G-D21.00mm_Pin'       # 3D model of socket
+  pkg_tube: 'Valve_Tube_Loctal-B9G-D21.00mm_Pin'       # 3D model of tube
+
+Valve_Loctal-B8G-Pin:
+  pkg_description: "Loctal B8G pin hole"
+  pkg_datasheet: "https://en.wikipedia.org/wiki/Tube_socket"
+  pkg_D: 29.00                  # Body width/diameter
+  pkg_npth_pin: []              # NPTH pin [(x, y, length)]
+  pkg_center_pin: []            # Center pin ('type', diameter, length)
+  pkg_pin_type: ['round', 1.30, 3.0]   # Pin type, diameter, length
+  pkg_pin_number: 8             # Number of pins
+  pkg_pin_arc: 45.0             # Arch between pins
+  pkg_pin_diameter: 17.45       # Diameter of the circle where pins are located
+  pkg_socket_offset: [0.00, 0.00, 0.00]    # Socket 3D model placement 
+  pkg_valve_offset: [0.00, 0.00, 14.00]    # Valve 3D model placement 
+  pkg_socket: 'Valve_Socket_Loctal-B8G-D17.45mm-Pin'       # 3D model of socket
+  pkg_tube: 'Valve_Tube_Loctal-B8G-D17.45mm-Pin'       # 3D model of tube
+
+Valve_Decar-B10G-Pin:
+  pkg_description: "Decar B10G pin hole"
+  pkg_datasheet: "https://en.wikipedia.org/wiki/Tube_socket"
+  pkg_D: 17.00                  # Body width/diameter
+  pkg_npth_pin: []              # NPTH pin [(x, y, length)]
+  pkg_center_pin: []            # Center pin ('type', diameter, length)
+  pkg_pin_type: ['round', 1.016, 3.0]   # Pin type, diameter, length
+  pkg_pin_number: 9             # Number of pins
+  pkg_pin_arc: 36.0             # Arch between pins
+  pkg_pin_diameter: 11.89       # Diameter of the circle where pins are located
+  pkg_socket_offset: [0.00, 0.00, 0.00]    # Socket 3D model placement 
+  pkg_valve_offset: [0.00, 0.00,  8.00]    # Valve 3D model placement 
+  pkg_socket: 'Valve_Socket_Decar-B10G-D11.89mm_Pin'  # 3D model of socket
+  pkg_tube: 'Valve_Tube_Decar-B10G-D11.89mm_Pin'      # 3D model of tube
+
+Valve_Octal-K8A-Pin:
+  pkg_description: "Octal K8A pin hole"
+  pkg_datasheet: "https://en.wikipedia.org/wiki/Tube_socket"
+  pkg_D: 29.00                  # Body width/diameter
+  pkg_npth_pin: []              # NPTH pin [(x, y, length)]
+  pkg_center_pin: []            # Center pin ('type', diameter, length)
+  pkg_pin_type: ['round', 2.36, 3.0]   # Pin type, diameter, length
+  pkg_pin_number: 8             # Number of pins
+  pkg_pin_arc: 45.0             # Arch between pins
+  pkg_pin_diameter: 17.45       # Diameter of the circle where pins are located
+  pkg_socket_offset: [0.00, 0.00, 0.00]    # Socket 3D model placement 
+  pkg_valve_offset: [0.00, 0.00, 14.50]    # Valve 3D model placement 
+  pkg_socket: 'Valve_Socket_Octal-K8A-D17.45mm_Pin' # 3D model of socket
+  pkg_tube: 'Valve_Tube_Octal-K8A-D17.45mm_Pin'     # 3D model of tube


### PR DESCRIPTION
Overhaul of the valve foot prints

All foot prints are script made (except CK6418)
All 3D models are script made

The models and foot print does not replace existing valve foot prints.
Removal of old foot prints will be done with a later push of thesymbols

`NOTE: this push include a fix in KicadModTree/nodes/base/Model.py and KicadModTree/KicadFileHandler.py which make it possible to use offset and at when setting the 3D  model cordinate`

Foot print push

Foot print script push


3D model push
https://github.com/KiCad/kicad-packages3D/pull/466

3D model scripts



![bild](https://user-images.githubusercontent.com/25547797/48979894-df451100-f0c1-11e8-8a8c-af6710009e27.png)

![bild](https://user-images.githubusercontent.com/25547797/48979895-e409c500-f0c1-11e8-9882-8b10b3925682.png)

![bild](https://user-images.githubusercontent.com/25547797/48979899-e9ffa600-f0c1-11e8-8e2f-3f8a95b203d2.png)

![bild](https://user-images.githubusercontent.com/25547797/48979902-f2f07780-f0c1-11e8-947a-1cd4ffb3608e.png)

![bild](https://user-images.githubusercontent.com/25547797/48979904-f84dc200-f0c1-11e8-89a9-72702dfeb209.png)
