### PR TITLE
add support for double letter BGA ball names

### DIFF
--- a/scripts/Package_BGA/bga.py
+++ b/scripts/Package_BGA/bga.py
@@ -173,7 +173,12 @@ if __name__ == '__main__':
     parser.add_parameter("layout_y", type=int, required=True)
     parser.add_parameter("row_names", type=list, required=False, default=[
         "A", "B", "C", "D", "E", "F", "G", "H", "J", "K", "L", "M", "N", "P",
-        "R", "T", "U"])
+        "R", "T", "U", "V", "W", "Y", "AA", "AB", "AC", "AD", "AE", "AF", "AG",
+        "AH", "AJ", "AK", "AL", "AM", "AN", "AP", "AR", "AT", "AU", "AV", "AW",
+        "AY", "BA", "BB", "BC", "BD", "BE", "BF", "BG", "BH", "BJ", "BK", "BL",
+        "BM", "BN", "BP", "BR", "BT", "BU", "BV", "BW", "BY", "CA", "CB", "CC",
+        "CD", "CE", "CF", "CG", "CH", "CJ", "CK", "CL", "CM", "CN", "CP", "CR",
+        "CT", "CU", "CV", "CW", "CY"])
     parser.add_parameter("row_skips", type=list, required=False, default=[])
 
     # now run our script which handles the whole part of parsing the files


### PR DESCRIPTION
up to CY, 60x60 array

I'll be submitting a PR shortly for some bigger BGAs that need this.

I'm also happy to redo in a more programmatic way rather than an array of strings, if desired.