### PR TITLE
Bga xilinx zynq 7

### DIFF
--- a/scripts/Package_BGA/bga.py
+++ b/scripts/Package_BGA/bga.py
@@ -173,12 +173,7 @@ if __name__ == '__main__':
     parser.add_parameter("layout_y", type=int, required=True)
     parser.add_parameter("row_names", type=list, required=False, default=[
         "A", "B", "C", "D", "E", "F", "G", "H", "J", "K", "L", "M", "N", "P",
-        "R", "T", "U", "V", "W", "Y", "AA", "AB", "AC", "AD", "AE", "AF", "AG",
-        "AH", "AJ", "AK", "AL", "AM", "AN", "AP", "AR", "AT", "AU", "AV", "AW",
-        "AY", "BA", "BB", "BC", "BD", "BE", "BF", "BG", "BH", "BJ", "BK", "BL",
-        "BM", "BN", "BP", "BR", "BT", "BU", "BV", "BW", "BY", "CA", "CB", "CC",
-        "CD", "CE", "CF", "CG", "CH", "CJ", "CK", "CL", "CM", "CN", "CP", "CR",
-        "CT", "CU", "CV", "CW", "CY"])
+        "R", "T", "U", "V", "W", "Y", "AA", "AB", "AC", "AD", "AE"])
     parser.add_parameter("row_skips", type=list, required=False, default=[])
 
     # now run our script which handles the whole part of parsing the files

--- a/scripts/Package_BGA/bga.py
+++ b/scripts/Package_BGA/bga.py
@@ -173,7 +173,12 @@ if __name__ == '__main__':
     parser.add_parameter("layout_y", type=int, required=True)
     parser.add_parameter("row_names", type=list, required=False, default=[
         "A", "B", "C", "D", "E", "F", "G", "H", "J", "K", "L", "M", "N", "P",
-        "R", "T", "U"])
+        "R", "T", "U", "V", "W", "Y", "AA", "AB", "AC", "AD", "AE", "AF", "AG",
+        "AH", "AJ", "AK", "AL", "AM", "AN", "AP", "AR", "AT", "AU", "AV", "AW",
+        "AY", "BA", "BB", "BC", "BD", "BE", "BF", "BG", "BH", "BJ", "BK", "BL",
+        "BM", "BN", "BP", "BR", "BT", "BU", "BV", "BW", "BY", "CA", "CB", "CC",
+        "CD", "CE", "CF", "CG", "CH", "CJ", "CK", "CL", "CM", "CN", "CP", "CR",
+        "CT", "CU", "CV", "CW", "CY"])
     parser.add_parameter("row_skips", type=list, required=False, default=[])
 
     # now run our script which handles the whole part of parsing the files

--- a/scripts/Package_BGA/bga.yml
+++ b/scripts/Package_BGA/bga.yml
@@ -201,12 +201,12 @@ UFBGA-201_10x10mm_Layout15x15_P0.65mm:
   layout_x: 15
   layout_y: 15
   row_skips: [[], [], [], [], [[5, 12]], [5, 11], [5, 11], [5, 11], [5, 11], [5, 11], [[5, 12]], [], [], [], []]
-BGA-225_13x13mm_Layout15x15_P0.8mm_Ball0.4mm_Pad0.4mm_NSMD:
+BGA-225_13x13mm_Layout15x15_P0.8mm_Ball0.4mm_Pad0.3mm_NSMD:
   description: "BGA-225, 15x15 raster, 13x13mm package, pitch 0.8mm, Xilinx CLG225; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=77"
   pkg_width: 13.0
   pkg_height: 13.0
   pitch: 0.8
-  pad_diameter: 0.4
+  pad_diameter: 0.3
   mask_margin: 0.05
   paste_margin: 0.000001
   layout_x: 15
@@ -231,42 +231,42 @@ BGA-484_19x19mm_Layout22x22_P0.8mm_Ball0.5mm_Pad0.4mm_NSMD:
   paste_margin: 0.000001
   layout_x: 22
   layout_y: 22
-BGA-484_23x23mm_Layout22x22_P1.0mm_Ball0.6mm_Pad0.53mm_NSMD:
+BGA-484_23x23mm_Layout22x22_P1.0mm_Ball0.6mm_Pad0.45mm_NSMD:
   description: "BGA-484, 22x22 raster, 23x23 mm package, pitch 1.0 mm, Xilinx FBG484; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=82"
   pkg_width: 23.0
   pkg_height: 23.0
   pitch: 1.0
-  pad_diameter: 0.53
+  pad_diameter: 0.45
   mask_margin: 0.05
   paste_margin: 0.000001
   layout_x: 22
   layout_y: 22
-BGA-676_27x27mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.53mm_NSMD:
+BGA-676_27x27mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.45mm_NSMD:
   description: "BGA-676, 26x26 raster, 27x27 mm package, pitch 1.0 mm, Xilinx FBG676; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=84"
   pkg_width: 27.0
   pkg_height: 27.0
   pitch: 1.0
-  pad_diameter: 0.4
+  pad_diameter: 0.45
   mask_margin: 0.05
   paste_margin: 0.000001
   layout_x: 26
   layout_y: 26
-BGA-900_31x31mm_Layout30x30_P1.0mm_Ball0.6mm_Pad0.53mm_NSMD:
+BGA-900_31x31mm_Layout30x30_P1.0mm_Ball0.6mm_Pad0.45mm_NSMD:
   description: "BGA-900, 30x30 raster, 31x31 mm package, pitch 1.0 mm, Xilinx FFG900; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=89"
   pkg_width: 31.0
   pkg_height: 31.0
   pitch: 1.0
-  pad_diameter: 0.53
+  pad_diameter: 0.45
   mask_margin: 0.05
   paste_margin: 0.000001
   layout_x: 30
   layout_y: 30
-BGA-1156_35x35mm_Layout34x34_P1.0mm_Ball0.6mm_Pad0.53mm_NSMD:
+BGA-1156_35x35mm_Layout34x34_P1.0mm_Ball0.6mm_Pad0.45mm_NSMD:
   description: "BGA-1156, 34x34 raster, 35x35 mm package, pitch 1.0 mm, Xilinx FFG1156; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=91"
   pkg_width: 35.0
   pkg_height: 35.0
   pitch: 1.0
-  pad_diameter: 0.53
+  pad_diameter: 0.45
   mask_margin: 0.05
   paste_margin: 0.000001
   layout_x: 34

--- a/scripts/Package_BGA/bga.yml
+++ b/scripts/Package_BGA/bga.yml
@@ -201,7 +201,7 @@ UFBGA-201_10x10mm_Layout15x15_P0.65mm:
   layout_x: 15
   layout_y: 15
   row_skips: [[], [], [], [], [[5, 12]], [5, 11], [5, 11], [5, 11], [5, 11], [5, 11], [[5, 12]], [], [], [], []]
-BGA-225_13x13mm_Layout15x15_P0.8mm_Ball0.4mm_Pad0.3mm_NSMD:
+BGA-225_13x13mm_Layout15x15_P0.8mm_Ball0.4mm_Pad0.3mm:
   description: "BGA-225, 15x15 raster, 13x13mm package, pitch 0.8mm, Xilinx CLG225; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=77"
   pkg_width: 13.0
   pkg_height: 13.0
@@ -211,7 +211,7 @@ BGA-225_13x13mm_Layout15x15_P0.8mm_Ball0.4mm_Pad0.3mm_NSMD:
   paste_margin: 0.000001
   layout_x: 15
   layout_y: 15
-BGA-400_17x17mm_Layout20x20_P0.8mm_Ball0.5mm_Pad0.4mm_NSMD:
+BGA-400_17x17mm_Layout20x20_P0.8mm_Ball0.5mm_Pad0.4mm:
   description: "BGA-400, 20x20 raster, 17x17mm package, pitch 0.8mm, Xilinx CLG400; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=78"
   pkg_width: 17.0
   pkg_height: 17.0
@@ -221,7 +221,7 @@ BGA-400_17x17mm_Layout20x20_P0.8mm_Ball0.5mm_Pad0.4mm_NSMD:
   paste_margin: 0.000001
   layout_x: 20
   layout_y: 20
-BGA-484_19x19mm_Layout22x22_P0.8mm_Ball0.5mm_Pad0.4mm_NSMD:
+BGA-484_19x19mm_Layout22x22_P0.8mm_Ball0.5mm_Pad0.4mm:
   description: "BGA-484, 22x22 raster, 19x19 mm package, pitch 0.8 mm, Xilinx CLG484; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=79"
   pkg_width: 19.0
   pkg_height: 19.0
@@ -231,7 +231,7 @@ BGA-484_19x19mm_Layout22x22_P0.8mm_Ball0.5mm_Pad0.4mm_NSMD:
   paste_margin: 0.000001
   layout_x: 22
   layout_y: 22
-BGA-484_23x23mm_Layout22x22_P1.0mm_Ball0.6mm_Pad0.45mm_NSMD:
+BGA-484_23x23mm_Layout22x22_P1.0mm_Ball0.6mm_Pad0.45mm:
   description: "BGA-484, 22x22 raster, 23x23 mm package, pitch 1.0 mm, Xilinx FBG484; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=82"
   pkg_width: 23.0
   pkg_height: 23.0
@@ -241,7 +241,7 @@ BGA-484_23x23mm_Layout22x22_P1.0mm_Ball0.6mm_Pad0.45mm_NSMD:
   paste_margin: 0.000001
   layout_x: 22
   layout_y: 22
-BGA-676_27x27mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.45mm_NSMD:
+BGA-676_27x27mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.45mm:
   description: "BGA-676, 26x26 raster, 27x27 mm package, pitch 1.0 mm, Xilinx FBG676; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=84"
   pkg_width: 27.0
   pkg_height: 27.0
@@ -251,7 +251,7 @@ BGA-676_27x27mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.45mm_NSMD:
   paste_margin: 0.000001
   layout_x: 26
   layout_y: 26
-BGA-900_31x31mm_Layout30x30_P1.0mm_Ball0.6mm_Pad0.45mm_NSMD:
+BGA-900_31x31mm_Layout30x30_P1.0mm_Ball0.6mm_Pad0.45mm:
   description: "BGA-900, 30x30 raster, 31x31 mm package, pitch 1.0 mm, Xilinx FFG900; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=89"
   pkg_width: 31.0
   pkg_height: 31.0
@@ -261,7 +261,7 @@ BGA-900_31x31mm_Layout30x30_P1.0mm_Ball0.6mm_Pad0.45mm_NSMD:
   paste_margin: 0.000001
   layout_x: 30
   layout_y: 30
-BGA-1156_35x35mm_Layout34x34_P1.0mm_Ball0.6mm_Pad0.45mm_NSMD:
+BGA-1156_35x35mm_Layout34x34_P1.0mm_Ball0.6mm_Pad0.45mm:
   description: "BGA-1156, 34x34 raster, 35x35 mm package, pitch 1.0 mm, Xilinx FFG1156; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=91"
   pkg_width: 35.0
   pkg_height: 35.0

--- a/scripts/Package_BGA/bga.yml
+++ b/scripts/Package_BGA/bga.yml
@@ -201,3 +201,73 @@ UFBGA-201_10x10mm_Layout15x15_P0.65mm:
   layout_x: 15
   layout_y: 15
   row_skips: [[], [], [], [], [[5, 12]], [5, 11], [5, 11], [5, 11], [5, 11], [5, 11], [[5, 12]], [], [], [], []]
+BGA-225_13x13mm_Layout15x15_P0.8mm_Ball0.4mm_Pad0.4mm_NSMD:
+  description: "BGA-225, 15x15 raster, 13x13mm package, pitch 0.8mm, Xilinx CLG225; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=77"
+  pkg_width: 13.0
+  pkg_height: 13.0
+  pitch: 0.8
+  pad_diameter: 0.4
+  mask_margin: 0.05
+  paste_margin: 0.000001
+  layout_x: 15
+  layout_y: 15
+BGA-400_17x17mm_Layout20x20_P0.8mm_Ball0.5mm_Pad0.4mm_NSMD:
+  description: "BGA-400, 20x20 raster, 17x17mm package, pitch 0.8mm, Xilinx CLG400; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=78"
+  pkg_width: 17.0
+  pkg_height: 17.0
+  pitch: 0.8
+  pad_diameter: 0.4
+  mask_margin: 0.05
+  paste_margin: 0.000001
+  layout_x: 20
+  layout_y: 20
+BGA-484_19x19mm_Layout22x22_P0.8mm_Ball0.5mm_Pad0.4mm_NSMD:
+  description: "BGA-484, 22x22 raster, 19x19 mm package, pitch 0.8 mm, Xilinx CLG484; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=79"
+  pkg_width: 19.0
+  pkg_height: 19.0
+  pitch: 0.8
+  pad_diameter: 0.4
+  mask_margin: 0.05
+  paste_margin: 0.000001
+  layout_x: 22
+  layout_y: 22
+BGA-484_23x23mm_Layout22x22_P1.0mm_Ball0.6mm_Pad0.53mm_NSMD:
+  description: "BGA-484, 22x22 raster, 23x23 mm package, pitch 1.0 mm, Xilinx FBG484; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=82"
+  pkg_width: 23.0
+  pkg_height: 23.0
+  pitch: 1.0
+  pad_diameter: 0.53
+  mask_margin: 0.05
+  paste_margin: 0.000001
+  layout_x: 22
+  layout_y: 22
+BGA-676_27x27mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.53mm_NSMD:
+  description: "BGA-676, 26x26 raster, 27x27 mm package, pitch 1.0 mm, Xilinx FBG676; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=84"
+  pkg_width: 27.0
+  pkg_height: 27.0
+  pitch: 1.0
+  pad_diameter: 0.4
+  mask_margin: 0.05
+  paste_margin: 0.000001
+  layout_x: 26
+  layout_y: 26
+BGA-900_31x31mm_Layout30x30_P1.0mm_Ball0.6mm_Pad0.53mm_NSMD:
+  description: "BGA-900, 30x30 raster, 31x31 mm package, pitch 1.0 mm, Xilinx FFG900; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=89"
+  pkg_width: 31.0
+  pkg_height: 31.0
+  pitch: 1.0
+  pad_diameter: 0.53
+  mask_margin: 0.05
+  paste_margin: 0.000001
+  layout_x: 30
+  layout_y: 30
+BGA-1156_35x35mm_Layout34x34_P1.0mm_Ball0.6mm_Pad0.53mm_NSMD:
+  description: "BGA-1156, 34x34 raster, 35x35 mm package, pitch 1.0 mm, Xilinx FFG1156; https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf#page=91"
+  pkg_width: 35.0
+  pkg_height: 35.0
+  pitch: 1.0
+  pad_diameter: 0.53
+  mask_margin: 0.05
+  paste_margin: 0.000001
+  layout_x: 34
+  layout_y: 34


### PR DESCRIPTION
PR #238 should be merged first. It expands the number of rows supported from 20 to 60 and is required for the packages over 400 balls.

## [Package docs from Xilinx](https://www.xilinx.com/support/documentation/user_guides/ug865-Zynq-7000-Pkg-Pinout.pdf)
## [Additional doc from Xilinx](https://www.xilinx.com/support/documentation/user_guides/ug1099-bga-device-design-rules.pdf)
## [kicad-footprints PR](https://github.com/KiCad/kicad-footprints/pull/1167)

## CLG225 image
Other parts are similar.
![screenshot from 2018-12-14 09-29-40](https://user-images.githubusercontent.com/6054322/50015053-d342c580-ff82-11e8-9c2f-f391b05e1783.png)

# Concerns

## Duplication of existing parts
Some of these are close to existing parts in the library and should probably be removed from the branch before merging.
 - CLG225/BGA-225_13x13mm_Layout15x15_P0.8mm_Ball0.4mm_Pad0.4mm_NSMD is unique
 - CLG400/BGA-400_17x17mm_Layout20x20_P0.8mm_Ball0.5mm_Pad0.4mm_NSMD is unique
 - CLG484/BGA-484_19x19mm_Layout22x22_P0.8mm_Ball0.5mm_Pad0.4mm_NSMD is unique
 - FBG484/BGA-484_23x23mm_Layout22x22_P1.0mm_Ball0.6mm_Pad0.53mm_NSMD is similar to the existing BGA-484_23.0x23.0mm_Layout22x22_P1.0mm and FB-BGA-484_23.0x23.0mm_Layout22x22_P1.0mm
 - FBG676/BGA-676_27.0x27.0mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.5mm_NSMD is similar to the existing BGA-676_27.0x27.0mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.5mm_NSMD
- FFG900/BGA-900_31x31mm_Layout30x30_P1.0mm_Ball0.6mm_Pad0.53mm_NSMD is unique
- FFG1156/BGA-1156_35x35mm_Layout34x34_P1.0mm_Ball0.6mm_Pad0.53mm_NSMD is similrar to BGA-1156_35.0x35.0mm_Layout34x34_P1.0mm

## Naming
 - should these include the Xilinx designator (CLG225, CLG400, etc) in the name?
 - FBG676, FFG676 and RF676 all have the same dimensions on the bottom side. They differ on the top side with a heat spreader vs exposed die. Should these be separate footprints for the sake of attaching 3D models later. The same is true of CLG484 and SBG485. 
 - 17x17mm vs 17.0x17.0mm - which is correct? The library has a mix and I wasn't even consistent within this PR. I'll fix this before the merge.
## Pad size
 - UG865 gives a maximum pad size only (0.4 mm for 0.8 mm pitch and 0.53 mm for 1.0 mm pitch) and that's what I have for now.
 - UG1099 gives a pad size of 0.4 mm for FB and FT devices (1.0 mm pitch), 0.51 mm for FF, FG, other 1.0 mm pitch devices. On 0.8 mm pitch, it is consistent with UG865, calling for an 0.4 mm pad. There is no difference in ball size for these packages (all have 0.6 mm balls).
 - UG1099 also calls for a solder mask expansion of 0.015 mm which is outside of most design rules. I've used the UG865 value of 0.05 mm which is possible at most fabs.

## should there be a more explicit pin 1 marker like others in the Kicad libs?
Example:
![screenshot from 2018-12-14 09-52-17](https://user-images.githubusercontent.com/6054322/50016278-f622a900-ff85-11e8-9fe6-7c377b1ba105.png)
