### PR TITLE
Added XBGA-121_10x10mm_Layout11x11_P0.8mm

### DIFF
--- a/scripts/Package_BGA/bga.yml
+++ b/scripts/Package_BGA/bga.yml
@@ -149,6 +149,16 @@ UFBGA-100_7x7mm_Layout12x12_P0.5mm:
   layout_x: 12
   layout_y: 12
   row_skips: [[], [], [6, 7], [[4, 10]], [[4, 10]], [[3, 11]], [[3, 11]], [[4, 10]], [[4, 10]], [6, 7], [], []]
+XBGA-121_10x10mm_Layout11x11_P0.8mm:
+  description: "XBGA-121, 11x11 raster, 10x10mm package, pitch 0.6mm; http://ww1.microchip.com/downloads/en/DeviceDoc/39969b.pdf"
+  pkg_width: 10.0
+  pkg_height: 10.0
+  pitch: 0.8
+  pad_diameter: 0.40
+  mask_margin: 0.04
+  paste_margin: 0.000001
+  layout_x: 11
+  layout_y: 11
 UFBGA-132_7x7mm_Layout12x12_P0.5mm:
   description: "UFBGA-132, 12x12 raster, 7x7mm package, pitch 0.5mm; http://www.st.com/resource/en/datasheet/stm32l152zc.pdf#page=123"
   pkg_width: 7.0

--- a/scripts/Package_BGA/bga.yml
+++ b/scripts/Package_BGA/bga.yml
@@ -144,7 +144,7 @@ UFBGA-100_7x7mm_Layout12x12_P0.5mm:
   pkg_height: 7.0
   pitch: 0.5
   pad_diameter: 0.28
-  mask_margin: 0.045
+  mask_margin:  0.045
   paste_margin: 0.000001
   layout_x: 12
   layout_y: 12
@@ -154,9 +154,9 @@ XBGA-121_10x10mm_Layout11x11_P0.8mm:
   pkg_width: 10.0
   pkg_height: 10.0
   pitch: 0.8
-  pad_diameter: 0.40
+  pad_diameter: 0.32
   mask_margin: 0.04
-  paste_margin: 0.000001
+  paste_margin: 0.0001
   layout_x: 11
   layout_y: 11
 UFBGA-132_7x7mm_Layout12x12_P0.5mm:


### PR DESCRIPTION
Added 
```
XBGA-121_10x10mm_Layout11x11_P0.8mm:
  description: "XBGA-121, 11x11 raster, 10x10mm package, pitch 0.6mm; http://ww1.microchip.com/downloads/en/DeviceDoc/39969b.pdf"
  pkg_width: 10.0
  pkg_height: 10.0
  pitch: 0.8
  pad_diameter: 0.32
  mask_margin: 0.032
  paste_margin: 0.00001
  layout_x: 11
  layout_y: 11
```

Used by PIC24FJ256DA210-IBG in push
https://github.com/KiCad/kicad-symbols/pull/1266
http://ww1.microchip.com/downloads/en/DeviceDoc/39969b.pdf


Script push
https://github.com/pointhi/kicad-footprint-generator/pull/241

Foot print push
https://github.com/KiCad/kicad-footprints/pull/1170


