### PR TITLE
Adding size definitions for qfp footprints

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/ipc_gullwing_generator.py
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/ipc_gullwing_generator.py
@@ -130,6 +130,8 @@ class Gullwing():
         pincount = device_params['num_pins_x']*2 + device_params['num_pins_y']*2
 
         ipc_reference = 'ipc_spec_gw_large_pitch' if device_params['pitch'] >= 0.625 else 'ipc_spec_gw_small_pitch'
+        if device_params.get('force_small_pitch_ipc_definition', False):
+            ipc_reference = 'ipc_spec_gw_small_pitch'
 
         used_density = device_params.get('ipc_density', ipc_density)
         ipc_data_set = self.ipc_defintions[ipc_reference][used_density]

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/ipc_gullwing_generator.py
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/ipc_gullwing_generator.py
@@ -131,7 +131,8 @@ class Gullwing():
 
         ipc_reference = 'ipc_spec_gw_large_pitch' if device_params['pitch'] >= 0.625 else 'ipc_spec_gw_small_pitch'
 
-        ipc_data_set = self.ipc_defintions[ipc_reference][ipc_density]
+        used_density = device_params.get('ipc_density', ipc_density)
+        ipc_data_set = self.ipc_defintions[ipc_reference][used_density]
         ipc_round_base = self.ipc_defintions[ipc_reference]['round_base']
 
         pitch = device_params['pitch']

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/eqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/eqfp.yaml
@@ -1,0 +1,203 @@
+FileHeader:
+  library_Suffix: 'QFP'
+  device_type: 'EQFP'
+
+EQFP-144-1EP_20x20mm_P0.5mm_EP4x4mm:
+  size_source: 'https://www.intel.com/content/dam/www/programmable/us/en/pdfs/literature/packaging/04r00482-02.pdf'
+  body_size_x:
+    nominal: 20
+  body_size_y:
+    nominal: 20
+  overall_size_x:
+    nominal: 22
+  overall_size_y:
+    nominal: 22
+  lead_width:
+    minimum: 0.17
+    nominal: 0.22
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    nominal: 0.6
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 36
+  num_pins_y: 36
+
+  EP_size_x: 4
+  EP_size_y: 4
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [3, 3]
+
+  thermal_vias:
+    count: [3, 3]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    paste_between_vias: 1
+    paste_rings_outside: 1
+    EP_paste_coverage: 0.65
+    grid: [1.2, 1.2]
+    # bottom_pad_size:
+    # paste_avoid_via: True
+
+EQFP-144-1EP_20x20mm_P0.5mm_EP5x5mm:
+  size_source: 'https://www.intel.com/content/dam/www/programmable/us/en/pdfs/literature/packaging/04r00476-02.pdf'
+  body_size_x:
+    nominal: 20
+  body_size_y:
+    nominal: 20
+  overall_size_x:
+    nominal: 22
+  overall_size_y:
+    nominal: 22
+  lead_width:
+    minimum: 0.17
+    nominal: 0.22
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    nominal: 0.6
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 36
+  num_pins_y: 36
+
+  EP_size_x: 5
+  EP_size_y: 5
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [4, 4]
+
+  thermal_vias:
+    count: [4, 4]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    paste_between_vias: 1
+    paste_rings_outside: 1
+    EP_paste_coverage: 0.65
+    grid: [1.2, 1.2]
+    # bottom_pad_size:
+    # paste_avoid_via: True
+
+EQFP-144-1EP_20x20mm_P0.5mm_EP6.61x5.615mm:
+  size_source: 'https://www.intel.com/content/dam/www/programmable/us/en/pdfs/literature/packaging/04r00476-02.pdf'
+  body_size_x:
+    nominal: 20
+  body_size_y:
+    nominal: 20
+  overall_size_x:
+    nominal: 22
+  overall_size_y:
+    nominal: 22
+  lead_width:
+    minimum: 0.17
+    nominal: 0.22
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    nominal: 0.6
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 36
+  num_pins_y: 36
+
+  EP_size_x: 6.61
+  EP_size_y: 5.615
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [5, 4]
+
+  thermal_vias:
+    count: [5, 4]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    paste_between_vias: 1
+    paste_rings_outside: 1
+    EP_paste_coverage: 0.65
+    grid: [1.3, 1.4]
+    # bottom_pad_size:
+    # paste_avoid_via: True
+
+EQFP-144-1EP_20x20mm_P0.5mm_EP7.2x6.35mm:
+  size_source: 'https://www.intel.com/content/dam/www/programmable/us/en/pdfs/literature/packaging/04r00487-01.pdf'
+  body_size_x:
+    nominal: 20
+  body_size_y:
+    nominal: 20
+  overall_size_x:
+    nominal: 22
+  overall_size_y:
+    nominal: 22
+  lead_width:
+    minimum: 0.17
+    nominal: 0.22
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    nominal: 0.6
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 36
+  num_pins_y: 36
+
+  EP_size_x: 7.2
+  EP_size_y: 6.35
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [6, 5]
+
+  thermal_vias:
+    count: [6, 5]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    paste_between_vias: 1
+    paste_rings_outside: 1
+    EP_paste_coverage: 0.65
+    grid: [1.2, 1.2]
+    # bottom_pad_size:
+    # paste_avoid_via: True
+
+EQFP-144-1EP_20x20mm_P0.5mm_EP8.93x8.7mm:
+  size_source: 'https://www.intel.com/content/dam/www/programmable/us/en/pdfs/literature/packaging/04r00479-02.pdf'
+  body_size_x:
+    nominal: 20
+  body_size_y:
+    nominal: 20
+  overall_size_x:
+    nominal: 22
+  overall_size_y:
+    nominal: 22
+  lead_width:
+    minimum: 0.17
+    nominal: 0.22
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    nominal: 0.6
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 36
+  num_pins_y: 36
+
+  EP_size_x: 8.93
+  EP_size_y: 8.7
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [7, 7]
+
+  thermal_vias:
+    count: [7, 7]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    paste_between_vias: 1
+    paste_rings_outside: 1
+    EP_paste_coverage: 0.65
+    grid: [1.2, 1.2]
+    # bottom_pad_size:
+    # paste_avoid_via: True

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/eqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/eqfp.yaml
@@ -83,7 +83,7 @@ EQFP-144-1EP_20x20mm_P0.5mm_EP5x5mm:
     # paste_avoid_via: True
 
 EQFP-144-1EP_20x20mm_P0.5mm_EP6.61x5.615mm:
-  size_source: 'https://www.intel.com/content/dam/www/programmable/us/en/pdfs/literature/packaging/04r00476-02.pdf'
+  size_source: 'https://www.intel.com/content/dam/www/programmable/us/en/pdfs/literature/packaging/04r00485-02.pdf'
   body_size_x:
     nominal: 20
   body_size_y:

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
@@ -260,3 +260,124 @@ LQFP-52_14x14mm_P1mm:
   pitch: 1
   num_pins_x: 13
   num_pins_y: 13
+
+LQFP-64-1EP_10x10mm_P0.5mm_EP6.5x6.5mm:
+  size_source: 'https://www.nxp.com/files-static/shared/doc/package_info/98ARH98426A.pdf'
+  # ipc_density: 'least'
+  # force_small_pitch_ipc_definition: True
+  body_size_x:
+    nominal: 10
+  body_size_y:
+    nominal: 10
+  overall_size_x:
+    nominal: 12
+  overall_size_y:
+    nominal: 12
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 16
+  num_pins_y: 16
+
+  EP_size_x: 6.5
+  EP_size_y: 6.5
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [5, 5]
+  #heel_reduction: 0.1 #for relatively large EP pads (increase clearance)
+  # EP_size_limit_x: 3.6  #for relatively large EP pads (increase clearance)
+  # EP_size_limit_y: 3.6  #for relatively large EP pads (increase clearance)
+
+  thermal_vias:
+    count: [5, 5]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    paste_between_vias: 1
+    paste_rings_outside: 1
+    EP_paste_coverage: 0.65
+    grid: [1.2, 1.2]
+    # bottom_pad_size:
+    # paste_avoid_via: True
+
+LQFP-64_7x7mm_P0.4mm:
+  size_source: 'https://www.nxp.com/docs/en/package-information/SOT414-1.pdf'
+  body_size_x:
+    minimum: 6.9
+    maximum: 7.1
+  body_size_y:
+    minimum: 6.9
+    maximum: 7.1
+  overall_size_x:
+    minimum: 8.85
+    maximum: 9.15
+  overall_size_y:
+    minimum: 8.85
+    maximum: 9.15
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.4
+  num_pins_x: 16
+  num_pins_y: 16
+
+LQFP-64_10x10mm_P0.5mm:
+  size_source: 'https://www.analog.com/media/en/technical-documentation/data-sheets/ad7606_7606-6_7606-4.pdf'
+  body_size_x:
+    minimum: 9.8
+    nominal: 10
+    maximum: 10.2
+  body_size_y:
+    minimum: 9.8
+    nominal: 10
+    maximum: 10.2
+  overall_size_x:
+    minimum: 11.8
+    nominal: 12
+    maximum: 12.2
+  overall_size_y:
+    minimum: 11.8
+    nominal: 12
+    maximum: 12.2
+  lead_width:
+    minimum: 0.17
+    nominal: 0.22
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    nominal: 0.6
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 16
+  num_pins_y: 16
+
+LQFP-64_14x14mm_P0.8mm:
+  size_source: 'https://www.nxp.com/docs/en/package-information/SOT791-1.pdf'
+  body_size_x:
+    minimum: 13.9
+    maximum: 14.1
+  body_size_y:
+    minimum: 13.9
+    maximum: 14.1
+  overall_size_x:
+    minimum: 15.85
+    maximum: 16.15
+  overall_size_y:
+    minimum: 15.85
+    maximum: 16.15
+  lead_width:
+    minimum: 0.3
+    maximum: 0.45
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.8
+  num_pins_x: 16
+  num_pins_y: 16

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
@@ -75,7 +75,47 @@ LQFP-36_7x7mm_P0.65mm:
   num_pins_x: 9
   num_pins_y: 9
 
-LQFP-48:
+LQFP-44_10x10mm_P0.8mm:
+  size_source: 'https://www.nxp.com/files-static/shared/doc/package_info/98ASS23225W.pdf?&fsrch=1'
+  body_size_x:
+    nominal: 10
+  body_size_y:
+    nominal: 10
+  overall_size_x:
+    nominal: 12
+  overall_size_y:
+    nominal: 12
+  lead_width:
+    minimum: 0.3
+    maximum: 0.45
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.8
+  num_pins_x: 11
+  num_pins_y: 11
+
+LQFP-48_7x7mm_P0.5mm:
+  size_source: 'https://www.analog.com/media/en/technical-documentation/data-sheets/ltc2358-16.pdf'
+  body_size_x:
+    nominal: 7
+  body_size_y:
+    nominal: 7
+  overall_size_x:
+    nominal: 9
+  overall_size_y:
+    nominal: 9
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 12
+  num_pins_y: 12
+
+LQFP-48-1ep:
   size_source: 'http://www.analog.com/media/en/technical-documentation/data-sheets/LTC7810.pdf'
   body_size_x:
     nominal: 7

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
@@ -190,6 +190,7 @@ LQFP-52_10x10mm_P0.65mm:
 
 LQFP-52-1EP_10x10mm_P0.65mm_EP4.8x4.8mm:
   size_source: 'https://www.onsemi.com/pub/Collateral/848H-01.PDF'
+  force_small_pitch_ipc_definition: True
   body_size_x:
     nominal: 10
     tolerance: 0

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
@@ -2,6 +2,78 @@ FileHeader:
   library_Suffix: 'QFP'
   device_type: 'LQFP'
 
+LQFP-32_5x5mm_P0.5mm:
+  size_source: 'https://www.nxp.com/docs/en/package-information/SOT401-1.pdf'
+  body_size_x:
+    minimum: 4.9
+    maximum: 5.1
+  body_size_y:
+    minimum: 4.9
+    maximum: 5.1
+  overall_size_x:
+    minimum: 6.85
+    maximum: 7.15
+  overall_size_y:
+    minimum: 6.85
+    maximum: 7.15
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 8
+  num_pins_y: 8
+
+LQFP-32_7x7mm_P0.8mm:
+  size_source: 'https://www.nxp.com/docs/en/package-information/SOT358-1.pdf'
+  body_size_x:
+    minimum: 6.9
+    maximum: 7.1
+  body_size_y:
+    minimum: 6.9
+    maximum: 7.1
+  overall_size_x:
+    minimum: 8.85
+    maximum: 9.15
+  overall_size_y:
+    minimum: 8.85
+    maximum: 9.15
+  lead_width:
+    minimum: 0.3
+    maximum: 0.4
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.8
+  num_pins_x: 8
+  num_pins_y: 8
+
+LQFP-36_7x7mm_P0.65mm:
+  size_source: 'https://www.onsemi.com/pub/Collateral/561AV.PDF'
+  body_size_x:
+    nominal: 7
+    tolerance: 0.1
+  body_size_y:
+    nominal: 7
+    tolerance: 0.1
+  overall_size_x:
+    nominal: 9
+    tolerance: 0.2
+  overall_size_y:
+    nominal: 9
+    tolerance: 0.2
+  lead_width:
+    nominal: 0.3
+    tolerance: 0.1
+  lead_len:
+    nominal: 0.5
+    tolerance: 0.2
+  pitch: 0.65
+  num_pins_x: 9
+  num_pins_y: 9
+
 LQFP-48:
   size_source: 'http://www.analog.com/media/en/technical-documentation/data-sheets/LTC7810.pdf'
   body_size_x:

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
@@ -482,3 +482,49 @@ LQFP-100_14x14mm_P0.5mm:
   pitch: 0.5
   num_pins_x: 25
   num_pins_y: 25
+
+LQFP-128_14x14mm_P0.4mm:
+  size_source: 'https://www.renesas.com/eu/en/package-image/pdf/outdrawing/q128.14x14.pdf'
+  body_size_x:
+    nominal: 14
+  body_size_y:
+    nominal: 14
+  overall_size_x:
+    nominal: 16
+  overall_size_y:
+    nominal: 16
+  lead_width:
+    minimum: 0.13
+    nominal: 0.16
+    maximum: 0.23
+  lead_len:
+    minimum: 0.45
+    nominal: 0.6
+    maximum: 0.75
+  pitch: 0.4
+  num_pins_x: 32
+  num_pins_y: 32
+
+LQFP-128_14x20mm_P0.5mm:
+  size_source: 'https://www.nxp.com/docs/en/package-information/SOT425-1.pdf'
+  body_size_x:
+    minimum: 13.9
+    maximum: 14.1
+  body_size_y:
+    minimum: 19.9
+    maximum: 20.1
+  overall_size_x:
+    minimum: 15.85
+    maximum: 16.15
+  overall_size_y:
+    minimum: 21.85
+    maximum: 22.15
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 26
+  num_pins_y: 38

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
@@ -622,3 +622,51 @@ LQFP-176_24x24mm_P0.5mm:
   pitch: 0.5
   num_pins_x: 44
   num_pins_y: 44
+
+LQFP-208_28x28mm_P0.5mm:
+  size_source: 'https://www.nxp.com/docs/en/package-information/SOT459-1.pdf'
+  body_size_x:
+    minimum: 27.9
+    maximum: 28.1
+  body_size_y:
+    minimum: 27.9
+    maximum: 28.1
+  overall_size_x:
+    minimum: 29.85
+    maximum: 30.15
+  overall_size_y:
+    minimum: 29.85
+    maximum: 30.15
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 52
+  num_pins_y: 52
+
+LQFP-216_24x24mm_P0.4mm:
+  size_source: 'https://www.onsemi.com/pub/Collateral/566DB.PDF'
+  body_size_x:
+    nominal: 24
+    tolerance: 0
+  body_size_y:
+    nominal: 24
+    tolerance: 0
+  overall_size_x:
+    nominal: 26
+    tolerance: 0
+  overall_size_y:
+    nominal: 26
+    tolerance: 0
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.4
+  num_pins_x: 54
+  num_pins_y: 54

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
@@ -381,3 +381,104 @@ LQFP-64_14x14mm_P0.8mm:
   pitch: 0.8
   num_pins_x: 16
   num_pins_y: 16
+
+LQFP-80_10x10mm_P0.4mm:
+  size_source: 'https://www.renesas.com/eu/en/package-image/pdf/outdrawing/q80.10x10.pdf'
+  body_size_x:
+    nominal: 10
+  body_size_y:
+    nominal: 10
+  overall_size_x:
+    nominal: 12
+  overall_size_y:
+    nominal: 12
+  lead_width:
+    minimum: 0.13
+    nominal: 0.16
+    maximum: 0.23
+  lead_len:
+    minimum: 0.45
+    nominal: 0.6
+    maximum: 0.75
+  pitch: 0.4
+  num_pins_x: 20
+  num_pins_y: 20
+
+LQFP-80_12x12mm_P0.5mm:
+  size_source: 'https://www.nxp.com/docs/en/package-information/SOT315-1.pdf'
+  body_size_x:
+    minimum: 11.9
+    maximum: 12.1
+  body_size_y:
+    minimum: 11.9
+    maximum: 12.1
+  overall_size_x:
+    minimum: 13.85
+    maximum: 14.15
+  overall_size_y:
+    minimum: 13.85
+    maximum: 14.15
+  lead_width:
+    minimum: 0.13
+    maximum: 0.27
+  lead_len:
+    minimum: 0.3
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 20
+  num_pins_y: 20
+
+LQFP-80_14x14mm_P0.65mm:
+  size_source: 'https://www.analog.com/media/en/technical-documentation/data-sheets/AD9852.pdf'
+  force_small_pitch_ipc_definition: True
+  body_size_x:
+    minimum: 13.8
+    nominal: 14
+    maximum: 14.2
+  body_size_y:
+    minimum: 13.8
+    nominal: 14
+    maximum: 14.2
+  overall_size_x:
+    minimum: 15.8
+    nominal: 16
+    maximum: 16.2
+  overall_size_y:
+    minimum: 15.8
+    nominal: 16
+    maximum: 16.2
+  lead_width:
+    minimum: 0.22
+    nominal: 0.32
+    maximum: 0.38
+  lead_len:
+    minimum: 0.45
+    nominal: 0.6
+    maximum: 0.75
+  pitch: 0.65
+  num_pins_x: 20
+  num_pins_y: 20
+
+LQFP-100_14x14mm_P0.5mm:
+  size_source: 'https://www.nxp.com/docs/en/package-information/SOT407-1.pdf'
+  body_size_x:
+    minimum: 13.9
+    maximum: 14.1
+  body_size_y:
+    minimum: 13.9
+    maximum: 14.1
+  overall_size_x:
+    minimum: 15.75
+    maximum: 16.25
+  overall_size_y:
+    minimum: 15.75
+    maximum: 16.25
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 25
+  num_pins_y: 25

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
@@ -531,7 +531,7 @@ LQFP-128_14x20mm_P0.5mm:
   num_pins_y: 38
 
 LQFP-144_20x20mm_P0.5mm:
-  size_source: 'http://ww1.microchip.com/downloads/en/PackagingSpec/00000049BQ.pdf (page 426)'
+  size_source: 'http://ww1.microchip.com/downloads/en/PackagingSpec/00000049BQ.pdf#page=425'
   body_size_x:
     nominal: 20
   body_size_y:
@@ -601,7 +601,7 @@ LQFP-176_20x20mm_P0.4mm:
   num_pins_y: 44
 
 LQFP-176_24x24mm_P0.5mm:
-  size_source: 'https://www.st.com/resource/en/datasheet/stm32f207vg.pdf (page 163)'
+  size_source: 'https://www.st.com/resource/en/datasheet/stm32f207vg.pdf#page=163'
   body_size_x:
     minimum: 23.9
     maximum: 24.1

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
@@ -649,7 +649,7 @@ LQFP-208_28x28mm_P0.5mm:
   num_pins_y: 52
 
 LQFP-216_24x24mm_P0.4mm:
-  size_source: 'https://www.onsemi.com/pub/Collateral/566DB.PDF'
+  size_source: 'https://www.onsemi.com/pub/Collateral/561BE.PDF'
   body_size_x:
     nominal: 24
     tolerance: 0

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
@@ -166,3 +166,69 @@ LQFP-48-1ep:
     grid: [1, 1]
     # bottom_pad_size:
     # paste_avoid_via: True
+
+LQFP-52_10x10mm_P0.65mm:
+  size_source: 'https://www.nxp.com/docs/en/package-information/98ARL10526D.pdf'
+  # ipc_density: 'least'
+  force_small_pitch_ipc_definition: True
+  body_size_x:
+    nominal: 10
+  body_size_y:
+    nominal: 10
+  overall_size_x:
+    nominal: 12
+  overall_size_y:
+    nominal: 12
+  lead_width:
+    nominal: 0.325
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.65
+  num_pins_x: 13
+  num_pins_y: 13
+
+LQFP-52-1EP_10x10mm_P0.65mm_EP4.8x4.8mm:
+  size_source: 'https://www.onsemi.com/pub/Collateral/848H-01.PDF'
+  body_size_x:
+    nominal: 10
+    tolerance: 0
+  body_size_y:
+    nominal: 10
+    tolerance: 0
+  overall_size_x:
+    nominal: 12
+    tolerance: 0
+  overall_size_y:
+    nominal: 12
+    tolerance: 0
+  lead_width:
+    minimum: 0.22
+    maximum: 0.4
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.65
+  num_pins_x: 13
+  num_pins_y: 13
+
+  EP_size_x: 4.8
+  EP_size_y: 4.8
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [3, 3]
+  #heel_reduction: 0.1 #for relatively large EP pads (increase clearance)
+  # EP_size_limit_x: 3.6  #for relatively large EP pads (increase clearance)
+  # EP_size_limit_y: 3.6  #for relatively large EP pads (increase clearance)
+
+  thermal_vias:
+    count: [4, 4]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    paste_between_vias: 1
+    paste_rings_outside: 1
+    EP_paste_coverage: 0.65
+    grid: [1, 1]
+    # bottom_pad_size:
+    # paste_avoid_via: True

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
@@ -52,7 +52,8 @@ LQFP-32_7x7mm_P0.8mm:
 
 LQFP-36_7x7mm_P0.65mm:
   size_source: 'https://www.onsemi.com/pub/Collateral/561AV.PDF'
-  ipc_density: 'least'
+  # ipc_density: 'least'
+  force_small_pitch_ipc_definition: True
   body_size_x:
     nominal: 7
     tolerance: 0.1

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
@@ -52,6 +52,7 @@ LQFP-32_7x7mm_P0.8mm:
 
 LQFP-36_7x7mm_P0.65mm:
   size_source: 'https://www.onsemi.com/pub/Collateral/561AV.PDF'
+  ipc_density: 'least'
   body_size_x:
     nominal: 7
     tolerance: 0.1

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/lqfp.yaml
@@ -528,3 +528,97 @@ LQFP-128_14x20mm_P0.5mm:
   pitch: 0.5
   num_pins_x: 26
   num_pins_y: 38
+
+LQFP-144_20x20mm_P0.5mm:
+  size_source: 'http://ww1.microchip.com/downloads/en/PackagingSpec/00000049BQ.pdf (page 426)'
+  body_size_x:
+    nominal: 20
+  body_size_y:
+    nominal: 20
+  overall_size_x:
+    nominal: 22
+  overall_size_y:
+    nominal: 22
+  lead_width:
+    minimum: 0.17
+    nominal: 0.22
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    nominal: 0.6
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 36
+  num_pins_y: 36
+
+LQFP-160_24x24mm_P0.5mm:
+  size_source: 'https://www.nxp.com/docs/en/package-information/SOT435-1.pdf'
+  body_size_x:
+    minimum: 23.9
+    maximum: 24.1
+  body_size_y:
+    minimum: 23.9
+    maximum: 24.1
+  overall_size_x:
+    minimum: 25.85
+    maximum: 26.15
+  overall_size_y:
+    minimum: 25.85
+    maximum: 26.15
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 40
+  num_pins_y: 40
+
+LQFP-176_20x20mm_P0.4mm:
+  size_source: 'https://www.onsemi.com/pub/Collateral/566DB.PDF'
+  body_size_x:
+    nominal: 20
+    tolerance: 0.1
+  body_size_y:
+    nominal: 20
+    tolerance: 0.1
+  overall_size_x:
+    nominal: 22
+    tolerance: 0.2
+  overall_size_y:
+    nominal: 22
+    tolerance: 0.2
+  lead_width:
+    nominal: 0.15
+    tolerance: [0.04, 0.05]
+  lead_len:
+    nominal: 0.5
+    tolerance: 0.2
+  pitch: 0.4
+  num_pins_x: 44
+  num_pins_y: 44
+
+LQFP-176_24x24mm_P0.5mm:
+  size_source: 'https://www.st.com/resource/en/datasheet/stm32f207vg.pdf (page 163)'
+  body_size_x:
+    minimum: 23.9
+    maximum: 24.1
+  body_size_y:
+    minimum: 23.9
+    maximum: 24.1
+  overall_size_x:
+    minimum: 25.9
+    maximum: 26.1
+  overall_size_y:
+    minimum: 25.9
+    maximum: 26.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 44
+  num_pins_y: 44

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/mqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/mqfp.yaml
@@ -1,0 +1,32 @@
+FileHeader:
+  library_Suffix: 'QFP'
+  device_type: 'MQFP'
+
+MQFP-44_10x10mm_P0.8mm:
+  size_source: 'https://www.analog.com/media/en/technical-documentation/data-sheets/ad7722.pdf'
+  body_size_x:
+    minimum: 9.8
+    nominal: 10
+    maximum: 10.2
+  body_size_y:
+    minimum: 9.8
+    nominal: 10
+    maximum: 10.2
+  overall_size_x:
+    minimum: 13.65
+    nominal: 13.9
+    maximum: 14.15
+  overall_size_y:
+    minimum: 13.65
+    nominal: 13.9
+    maximum: 14.15
+  lead_width:
+    minimum: 0.3
+    maximum: 0.45
+  lead_len:
+    minimum: 0.73
+    nominal: 0.88
+    maximum: 1.03
+  pitch: 0.8
+  num_pins_x: 11
+  num_pins_y: 11

--- a/scripts/tools/global_config_files/config_KLCv3.0.yaml
+++ b/scripts/tools/global_config_files/config_KLCv3.0.yaml
@@ -3,7 +3,7 @@
 silk_line_width: 0.12
 silk_pad_clearance: 0.2
 silk_fab_offset: 0.11
-silk_line_lenght_min: 0.3
+silk_line_lenght_min: 0.2
 allow_silk_below_part: 'tht' # tht | smd | all | none
 
 fab_line_width: 0.1


### PR DESCRIPTION
This PR will be used to add missing qfp size definitions to generate more of the qfp footprints that are already in the lib.
Will be split into multiple sections to make my life and the life of the reviewing librarian easier. (one commit here will mean one pull request on the official repo.)