### PR TITLE
Get gullwing generator to feature parity with no lead generator

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/ipc_gullwing_generator.py
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/ipc_gullwing_generator.py
@@ -32,10 +32,12 @@ class Gullwing():
         with open(ipc_doc_file, 'r') as ipc_stream:
             try:
                 self.ipc_defintions = yaml.load(ipc_stream)
+                if 'ipc_generic_rules' in self.ipc_defintions:
+                    self.configuration['min_ep_to_pad_clearance'] = self.ipc_defintions['ipc_generic_rules'].get('min_ep_to_pad_clearance', 0.2)
             except yaml.YAMLError as exc:
                 print(exc)
 
-    def calcPadDetails(self, device_dimensions, ipc_data, ipc_round_base):
+    def calcPadDetails(self, device_dimensions, EP_size, ipc_data, ipc_round_base):
         # Zmax = Lmin + 2JT + √(CL^2 + F^2 + P^2)
         # Gmin = Smax − 2JH − √(CS^2 + F^2 + P^2)
         # Xmax = Wmin + 2JS + √(CW^2 + F^2 + P^2)
@@ -66,6 +68,20 @@ class Gullwing():
                 lead_len=device_dimensions.get('lead_len'),
                 heel_reduction=device_dimensions.get('heel_reduction', 0)
                 )
+
+        min_ep_to_pad_clearance = configuration['min_ep_to_pad_clearance']
+
+        heel_reduction_max = 0
+
+        if Gmin_x - 2*min_ep_to_pad_clearance < EP_size['x']:
+            heel_reduction_max = ((EP_size['x'] + 2*min_ep_to_pad_clearance - Gmin_x)/2)
+            #print('{}, {}, {}'.format(Gmin_x, EP_size['x'], min_ep_to_pad_clearance))
+            Gmin_x = EP_size['x'] + 2*min_ep_to_pad_clearance
+        if Gmin_y - 2*min_ep_to_pad_clearance < EP_size['y']:
+            heel_reduction = ((EP_size['y'] + 2*min_ep_to_pad_clearance - Gmin_y)/2)
+            if heel_reduction>heel_reduction_max:
+                heel_reduction_max = heel_reduction
+            Gmin_y = EP_size['y'] + 2*min_ep_to_pad_clearance
 
         Pad = {}
         Pad['left'] = {'center':[-(Zmax_x+Gmin_x)/4, 0], 'size':[(Zmax_x-Gmin_x)/2,Xmax]}
@@ -135,12 +151,6 @@ class Gullwing():
         ipc_round_base = self.ipc_defintions[ipc_reference]['round_base']
 
         pitch = device_params['pitch']
-        pad_details = self.calcPadDetails(dimensions, ipc_data_set, ipc_round_base)
-
-        suffix = device_params.get('suffix', '').format(pad_x=pad_details['left']['size'][0],
-            pad_y=pad_details['left']['size'][1])
-        suffix_3d = suffix if device_params.get('include_suffix_in_3dpath', 'True') == 'True' else ""
-        model3d_path_prefix = self.configuration.get('3d_model_prefix','${KISYS3DMOD}')
 
         name_format = self.configuration['fp_name_format_string_no_trailing_zero']
         EP_size = {'x':0, 'y':0}
@@ -148,14 +158,30 @@ class Gullwing():
 
         if dimensions['has_EP']:
             name_format = self.configuration['fp_name_EP_format_string_no_trailing_zero']
-            EP_size = {'x':dimensions['EP_size_x'].nominal, 'y':dimensions['EP_size_y'].nominal}
+            if 'EP_size_x_overwrite' in device_params:
+                EP_size = {
+                    'x':device_params['EP_size_x_overwrite'],
+                    'y':device_params['EP_size_y_overwrite']
+                    }
+            else:
+                EP_size = {
+                    'x':device_dimensions['EP_size_x'].nominal,
+                    'y':device_dimensions['EP_size_y'].nominal
+                    }
             if 'EP_mask_x' in dimensions:
                 name_format = self.configuration['fp_name_EP_custom_mask_format_string_no_trailing_zero']
                 EP_mask_size = {'x':dimensions['EP_mask_x'].nominal, 'y':dimensions['EP_mask_y'].nominal}
         EP_size = Vector2D(EP_size)
 
+        pad_details = self.calcPadDetails(dimensions, EP_size, ipc_data_set, ipc_round_base)
+
         if 'custom_name_format' in device_params:
             name_format = device_params['custom_name_format']
+
+        suffix = device_params.get('suffix', '').format(pad_x=pad_details['left']['size'][0],
+            pad_y=pad_details['left']['size'][1])
+        suffix_3d = suffix if device_params.get('include_suffix_in_3dpath', 'True') == 'True' else ""
+        model3d_path_prefix = self.configuration.get('3d_model_prefix','${KISYS3DMOD}')
 
         fp_name = name_format.format(
             man=device_params.get('manufacturer',''),

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/ipc_gullwing_generator.py
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/ipc_gullwing_generator.py
@@ -32,6 +32,8 @@ class Gullwing():
         with open(ipc_doc_file, 'r') as ipc_stream:
             try:
                 self.ipc_defintions = yaml.load(ipc_stream)
+
+                self.configuration['min_ep_to_pad_clearance'] = 0.2
                 if 'ipc_generic_rules' in self.ipc_defintions:
                     self.configuration['min_ep_to_pad_clearance'] = self.ipc_defintions['ipc_generic_rules'].get('min_ep_to_pad_clearance', 0.2)
             except yaml.YAMLError as exc:

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/hsoic.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/hsoic.yaml
@@ -1,0 +1,58 @@
+FileHeader:
+  library_Suffix: 'SO'
+  device_type: 'HSOIC'
+
+HSOP-8-1EP_3.9x4.9mm_P1.27mm_EP2.41x3.1mm_ThermalVias:
+  size_source: 'http://www.ti.com/lit/ds/symlink/lmr14030.pdf#page=28, http://www.ti.com/lit/ml/msoi002j/msoi002j.pdf'
+  custom_name_format: 'Texas_R-PDSO-G{pincount}_EP{ep_size_x:g}x{ep_size_y:g}mm_Mask{mask_size_x:g}x{mask_size_y:g}mm{vias:s}'
+  body_size_x:
+    minimum: 3.8
+    maximum: 4
+  body_size_y:
+    minimum: 4.8
+    maximum: 5
+
+  overall_size_x:
+    minimum: 5.8
+    maximum: 6.2
+  lead_width:
+    minimum: 0.31
+    maximum: 0.51
+  lead_len:
+    minimum: 0.4
+    maximum: 1.27
+  pitch: 1.27
+  num_pins_x: 0
+  num_pins_y: 4
+
+
+  EP_size_x:
+    minimum: 1.65
+    maximum: 2.4
+  EP_size_x_overwrite: 2.95
+  EP_mask_x: 2.4
+
+  EP_size_y:
+    minimum: 2.65
+    maximum: 3.1
+  EP_size_y_overwrite: 4.9
+  EP_mask_y: 3.1
+
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 3]
+  #heel_reduction: 0.1 #for relatively large EP pads (increase clearance)
+  # EP_size_limit_x: 3.6  #for relatively large EP pads (increase clearance)
+  # EP_size_limit_y: 3.6  #for relatively large EP pads (increase clearance)
+
+  thermal_vias:
+    count: [2, 3]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    EP_num_paste_pads: [2, 3]
+    # paste_between_vias: 1
+    # paste_rings_outside: 1
+    EP_paste_coverage: 0.75
+    grid: [1.3, 1.3]
+    # bottom_pad_size:
+    paste_avoid_via: False


### PR DESCRIPTION
Implement features missing from gullwing generator. (Features that have been recently added to the no lead generator)

Inspired by the need for these features for creating the footprint for http://www.ti.com/lit/ds/symlink/lmr14030.pdf#page=28