### PR TITLE
Added qfn-24 with 2.8mm^2 ep.

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-24.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-24.yaml
@@ -410,28 +410,27 @@ QFN-24-1EP_4x4mm_P0.5mm_EP2.8x2.8mm:
   #ipc_density: 'least' #overwrite global value for this device.
   # custom_name_format:
   body_size_x:
-    nominal: 4
-    tolerance: 0.1
+    minimum: 3.9
+    maximum: 4.1
   body_size_y:
-    nominal: 4
-    tolerance: 0.1
+    minimum: 3.9
+    maximum: 4.1
   body_height:
-    nominal: 0.9
-    tolerance: 0.1
+    minimum: 0.8
+    maximum: 1.0
 
   lead_width:
-    nominal: 0.24
-    tolerance: 0.06
+    minimum: 0.18
+    maximum: 0.3
   lead_len:
-    nominal: 0.3
-    tolerance: 0.1
+    nominal: 0.4
 
   EP_size_x:
-    nominal: 2.8
-    tolerance: 0.15
+    minimum: 2.65
+    maximum: 2.95
   EP_size_y:
-    nominal: 2.8
-    tolerance: 0.15
+    minimum: 2.65
+    maximum: 2.95
   # EP_paste_coverage: 0.65
   EP_num_paste_pads: [2, 2]
 
@@ -448,6 +447,8 @@ QFN-24-1EP_4x4mm_P0.5mm_EP2.8x2.8mm:
     # bottom_pad_size:
     paste_avoid_via: False
 
+  # The datasheet does not give the pitch as a reference dimension. Instead, it only specifies
+  # the range.
   pitch: 0.5
   num_pins_x: 6
   num_pins_y: 6


### PR DESCRIPTION
[HMC431LP4E](https://www.analog.com/media/en/technical-documentation/data-sheets/hmc431.pdf) has a 2.8x2.8mm ep.