### PR TITLE
add size-definition for SOP-8 Mini-Circuits XX211

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
@@ -2,6 +2,31 @@ FileHeader:
   library_Suffix: 'SO'
   device_type: 'SOP'
 
+
+SOP-8_4.14x5.33mm_P1.27mm:
+  size_source: 'https://ww2.minicircuits.com/case_style/XX211.pdf'
+  body_size_x:
+    nominal: 4.14
+    tolerance: 0.762
+  body_size_y:
+    nominal: 5.33
+    tolerance: 0.762
+  body_height:
+    max: 1.96
+  overall_size_x:
+    nominal: 6.35
+    tolerance: 0.762
+  lead_width:
+    nominal: 0.43
+    tolerance: 0.127
+  lead_len:
+    nominal: 0.76
+    tolerance: 0.127
+  pitch: 1.27
+  num_pins_x: 0
+  num_pins_y: 4
+
+
 SOP-8_6.62x9.15mm_P2.54mm:
   size_source: 'http://www.ti.com/lit/ds/symlink/iso1050.pdf'
   body_size_x:

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
@@ -6,22 +6,22 @@ FileHeader:
 SOP-8_4.14x5.33mm_P1.27mm:
   size_source: 'https://ww2.minicircuits.com/case_style/XX211.pdf'
   body_size_x:
-    nominal: 4.14
-    tolerance: 0.762
+    nominal: 3.759 # max (4.14) - tolerance
+    tolerance: 0.381
   body_size_y:
-    nominal: 5.33
-    tolerance: 0.762
+    nominal: 4.949 # max (5.33) - tolerance
+    tolerance: 0.381
   body_height:
-    max: 1.96
+    maximum: 1.96
   overall_size_x:
-    nominal: 6.35
-    tolerance: 0.762
+    minimum: 5.59
+    maximum: 6.35
   lead_width:
     nominal: 0.43
     tolerance: 0.127
   lead_len:
     nominal: 0.76
-    tolerance: 0.127
+    tolerance: 0.381
   pitch: 1.27
   num_pins_x: 0
   num_pins_y: 4

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
@@ -3,13 +3,13 @@ FileHeader:
   device_type: 'SOP'
 
 
-SOP-8_4.14x5.33mm_P1.27mm:
+SOP-8_3.76x4.96mm_P1.27mm:
   size_source: 'https://ww2.minicircuits.com/case_style/XX211.pdf'
   body_size_x:
-    nominal: 3.759 # max (4.14) - tolerance
+    nominal: 3.76 # max (4.14) - tolerance, rounded to 2 digits (+10um)
     tolerance: 0.381
   body_size_y:
-    nominal: 4.949 # max (5.33) - tolerance
+    nominal: 4.96 # max (5.33) - tolerance, rounded to 2 digits (+10um)
     tolerance: 0.381
   body_height:
     maximum: 1.96


### PR DESCRIPTION
Add a new SOP-8 variant used by Mini-Circuits called XX211 by them. [datasheet](https://ww2.minicircuits.com/case_style/XX211.pdf)