### PR TITLE
Added VQFN-28-1EP_4x4mm and VQFN32-1EP_5x5mm

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/vqfn.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/vqfn.yaml
@@ -337,6 +337,48 @@ VQFN-24-1EP_4x4mm_P0.5mm:
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
 
+VQFN-28-1EP_4x4mm_P0.45mm_EP2.4x2.4mm:
+  device_type: 'VQFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-9505-AT42-QTouch-BSW-AT42QT1060_Datasheet.pdf'
+  ipc_class: 'qfn'
+  #ipc_density: 'least'
+  body_size_x:
+    minimum: 3.95
+    maximum: 4.05
+  body_size_y:
+    minimum: 3.95
+    maximum: 4.05
+  body_height:
+    minimum: 0.8
+    maximum: 1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    minimum: 0.35
+    maximum: 0.45
+
+  EP_size_x:
+    nominal: 2.4
+    tolerance: 0.05
+  EP_size_y:
+    nominal: 2.4
+    tolerance: 0.05
+  EP_num_paste_pads: [2, 3]
+
+  thermal_vias:
+    count: [3,3]
+    drill: 0.3
+    paste_via_clearance: 0.1
+    paste_avoid_via: False
+
+
+  pitch: 0.4
+  num_pins_x: 7
+  num_pins_y: 7
+
 VQFN-28-1EP_4x5mm_P0.5mm_EP2.55x3.55mm:
   device_type: 'VQFN'
   #manufacturer: 'man'
@@ -385,6 +427,62 @@ VQFN-28-1EP_4x5mm_P0.5mm_EP2.55x3.55mm:
 
   pitch: 0.5
   num_pins_x: 6
+  num_pins_y: 8
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'
+
+
+VQFN-32-1EP_5x5mm_P0.5mm_EP3.1x3.1mm:
+  device_type: 'VQFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'http://ww1.microchip.com/downloads/en/DeviceDoc/32L_VQFN_5x5x0_9mm_3_1EP_RXB_C04-21395a.pdf'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  # custom_name_format:
+  body_size_x:
+    minimum: 4.9
+    maximum: 5.1
+  body_size_y:
+    minimum: 4.9
+    maximum: 5.1
+  body_height:
+    maximum: 1
+  lead_width:
+    minimum: 0.18
+    maximum: 0.3
+  lead_len:
+    minimum: 0.3
+    maximum: 0.5
+
+  EP_size_x:
+    nominal: 3.1
+    tolerance: 0.15
+  EP_size_y:
+    nominal: 3.1
+    tolerance: 0.15
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 3]
+  # heel_reduction: 0.05 #for relatively large EP pads (increase clearance)
+
+  thermal_vias:
+    count: [3, 3]
+    drill: 0.33
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    # paste_between_vias: 1
+    # paste_rings_outside: 1
+    # EP_paste_coverage: 0.75
+    grid: [1.2, 1.2]
+    # bottom_pad_size:
+    paste_avoid_via: False
+
+  pitch: 0.5
+  num_pins_x: 8
   num_pins_y: 8
   #chamfer_edge_pins: 0.25
   #pin_count_grid:


### PR DESCRIPTION
With this commits I added the VQFN-28-1EP_4x4mm and VQFN32-1EP_5x5mm footprints. The according pull request for the footprints is: [KiCad/kicad-footprints/pull/1337](https://github.com/KiCad/kicad-footprints/pull/1337)