### PR TITLE
Added new foot for MPL115A1

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lga.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lga.yaml
@@ -160,12 +160,12 @@ NXP-8_3x5mm_P1.25mm_LayoutBorder2x4y:
   body_size_y: 5.0
   body_size_y_max: 5.0
   lead_width_min: 0.45
-  lead_width_max: 0.55
+  lead_width_max: 0.45
   lead_to_edge:
-    minimum: 0.095
-    maximum: 0.15
-  lead_len_min: 0.75
-  lead_len_max: 0.85
+    minimum: -0.1
+    maximum: -0.1
+  lead_len_min: 0.95
+  lead_len_max: 0.95
   pitch: 1.25
   num_pins_x: 0
   num_pins_y: 4

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lga.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lga.yaml
@@ -152,20 +152,21 @@ NXP-8_3x5mm_P1.25mm_LayoutBorder2x4y:
   manufacturer: 'NXP'
   part_number: 'MPL115A1'
   size_source: 'https://www.nxp.com/docs/en/data-sheet/MPL115A1.pdf'
-  ipc_class: 'qfn_pull_back'
-  body_size_x_min: 3.0
-  body_size_x: 3.0
-  body_size_x_max: 3.0
-  body_size_y_min: 5.0
-  body_size_y: 5.0
-  body_size_y_max: 5.0
-  lead_width_min: 0.45
-  lead_width_max: 0.45
-  lead_to_edge:
-    minimum: -0.1
-    maximum: -0.1
-  lead_len_min: 0.95
-  lead_len_max: 0.95
+  body_size_x:
+    nominal: 3
+    tolerance: 0
+  body_size_y:
+    nominal: 5
+    tolerance: 0
+  lead_width:
+    nominal: 0.5
+    tolerance: 0.05
+  lead_center_pos_x: 
+    nominal: 1
+    tolerance: 0
+  lead_len:
+    nominal: 0.8
+    tolerance: 0.05
   pitch: 1.25
   num_pins_x: 0
   num_pins_y: 4

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lga.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lga.yaml
@@ -158,6 +158,8 @@ NXP-8_3x5mm_P1.25mm_LayoutBorder2x4y:
   body_size_y:
     nominal: 5
     tolerance: 0
+  body_height:
+    maximum: 1.2    
   lead_width:
     nominal: 0.5
     tolerance: 0.05

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lga.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lga.yaml
@@ -145,6 +145,36 @@ LGA-16_4x4mm_P0.65mm_LayoutBorder4x4y:
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
 
+NXP-8_3x5mm_P1.25mm_LayoutBorder2x4y:
+  device_type: 'LGA'
+  library: Package_LGA
+  use_name_format: 'LGA'
+  manufacturer: 'NXP'
+  part_number: 'MPL115A1'
+  size_source: 'https://www.nxp.com/docs/en/data-sheet/MPL115A1.pdf'
+  ipc_class: 'qfn_pull_back'
+  body_size_x_min: 3.0
+  body_size_x: 3.0
+  body_size_x_max: 3.0
+  body_size_y_min: 5.0
+  body_size_y: 5.0
+  body_size_y_max: 5.0
+  lead_width_min: 0.45
+  lead_width_max: 0.55
+  lead_to_edge:
+    minimum: 0.095
+    maximum: 0.15
+  lead_len_min: 0.75
+  lead_len_max: 0.85
+  pitch: 1.25
+  num_pins_x: 0
+  num_pins_y: 4
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'
+
 Bosch_LGA-8_3x3mm_P0.8mm:
   device_type: 'LGA'
   library: Package_LGA


### PR DESCRIPTION
To save the 3D model of the MPL115A1
https://github.com/KiCad/kicad-packages3D/pull/515

A new foot print need to be created
NXP_MPL115A1_LGA-8_3x5mm_P1.25mm.kicad_mod

Data sheet
https://www.nxp.com/docs/en/data-sheet/MPL115A1.pdf

foot print push
https://github.com/KiCad/kicad-footprints/pull/1342

Symbol push
https://github.com/KiCad/kicad-symbols/pull/1467

foot print script push
https://github.com/pointhi/kicad-footprint-generator/pull/277

![bild](https://user-images.githubusercontent.com/25547797/51798932-c3253380-221a-11e9-982b-7f88ea45e119.png)

![bild](https://user-images.githubusercontent.com/25547797/51798936-c8827e00-221a-11e9-9c29-dfbfdef1b455.png)

![bild](https://user-images.githubusercontent.com/25547797/51793265-f1c0f100-21bd-11e9-94e6-1823c838a815.png)

![bild](https://user-images.githubusercontent.com/25547797/51793268-fbe2ef80-21bd-11e9-9857-8f6030b70ee8.png)

