### PR TITLE
Added foot print QFN-32-1EP_5x5mm_P0.5mm_EP3.7x3.7mm

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-3x.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-3x.yaml
@@ -400,7 +400,7 @@ QFN-32-1EP_5x5mm_P0.5mm_EP3.7x3.7mm:
   EP_num_paste_pads: [2, 2]
 
   thermal_vias:
-    count: [2, 4]
+    count: [3, 3]
     drill: 0.2
     # min_annular_ring: 0.15
     paste_via_clearance: 0.1

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-3x.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-3x.yaml
@@ -358,6 +358,62 @@ QFN-32-1EP_5x5mm_P0.5mm_EP3.65x3.65mm:
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
 
+QFN-32-1EP_5x5mm_P0.5mm_EP3.7x3.7mm:
+  device_type: 'QFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'https://www.espressif.com/sites/default/files/documentation/0a-esp8285_datasheet_en.pdf'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  # custom_name_format:
+  body_size_x:
+    nominal: 5
+    tolerance: 0.05
+  body_size_y:
+    nominal: 5
+    tolerance: 0.05
+  body_height:
+    nominal: 0.85
+    tolerance: 0.05
+
+  lead_width:
+    nominal: 0.25
+    tolerance: 0.05
+  lead_len:
+    nominal: 0.4
+    tolerance: 0.05
+
+  EP_size_x:
+    nominal: 3.7
+    tolerance: 0.05
+  EP_size_y:
+    nominal: 3.7
+    tolerance: 0.05
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 2]
+
+  thermal_vias:
+    count: [2, 4]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    paste_between_vias: 1
+    paste_rings_outside: 1
+    # EP_paste_coverage: 0.75
+    grid: [1, 1]
+    # bottom_pad_size:
+    # paste_avoid_via: False
+
+  pitch: 0.5
+  num_pins_x: 8
+  num_pins_y: 8
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'
+
 QFN-32-1EP_7x7mm_P0.65mm_EP4.65x4.65mm:
   device_type: 'QFN'
   #manufacturer: 'man'

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-3x.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-3x.yaml
@@ -374,7 +374,7 @@ QFN-32-1EP_5x5mm_P0.5mm_EP3.7x3.7mm:
     minimum: 4.95
     nominal: 5.00
     maximum: 5.05
-  body_height:
+  overall_height:
     minimum: 0.80
     nominal: 0.85
     maximum: 0.90

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-3x.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-3x.yaml
@@ -367,28 +367,35 @@ QFN-32-1EP_5x5mm_P0.5mm_EP3.7x3.7mm:
   #ipc_density: 'least' #overwrite global value for this device.
   # custom_name_format:
   body_size_x:
-    nominal: 5
-    tolerance: 0.05
+    minimum: 4.95
+    nominal: 5.00
+    maximum: 5.05
   body_size_y:
-    nominal: 5
-    tolerance: 0.05
+    minimum: 4.95
+    nominal: 5.00
+    maximum: 5.05
   body_height:
+    minimum: 0.80
     nominal: 0.85
-    tolerance: 0.05
-
+    maximum: 0.90
   lead_width:
+    minimum: 0.20
     nominal: 0.25
-    tolerance: 0.05
+    maximum: 0.30
   lead_len:
-    nominal: 0.4
-    tolerance: 0.05
+    minimum: 0.35
+    nominal: 0.40
+    maximum: 0.45
 
   EP_size_x:
-    nominal: 3.7
-    tolerance: 0.05
+    minimum: 3.65
+    nominal: 3.70
+    maximum: 3.75
   EP_size_y:
-    nominal: 3.7
-    tolerance: 0.05
+    minimum: 3.65
+    nominal: 3.70
+    maximum: 3.75
+    
   # EP_paste_coverage: 0.65
   EP_num_paste_pads: [2, 2]
 


### PR DESCRIPTION
Added foot print QFN-32-1EP_5x5mm_P0.5mm_EP3.7x3.7mm

Needed for ESP8285
https://www.espressif.com/sites/default/files/documentation/0a-esp8285_datasheet_en.pdf


Foot print push
https://github.com/KiCad/kicad-footprints/pull/1344

Foot print script push
https://github.com/pointhi/kicad-footprint-generator/pull/279

![bild](https://user-images.githubusercontent.com/25547797/51800272-11dbc900-222d-11e9-905c-6f0e169830e5.png)
