### PR TITLE
add definition for Analog CP-16-22 LFCSP-16

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
@@ -8,22 +8,26 @@ LFCSP-16-1EP_3x3mm_P0.5mm_EP1.6x1.6mm:
   #ipc_density: 'least' #overwrite global value for this device.
   # custom_name_format:
   body_size_x:
+    minimum: 2.9
     nominal: 3
-    tolerance: 0.1
+    minimum: 3.1
   body_size_y:
+    minimum: 2.9
     nominal: 3
-    tolerance: 0.1
+    minimum: 3.1
   body_height:
+    minimum: 0.7
     nominal: 0.75
-    tolerance: 0.05
+    maximum: 0.8
 
   lead_width:
     maximum: 0.30
     nominal: 0.23
     minimum: 0.18
   lead_len:
+    minimum: 0.3
     nominal: 0.4
-    tolerance: 0.1
+    maximum: 0.5
 
   EP_size_x:
     maximum: 1.75

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
@@ -1,0 +1,60 @@
+LFCSP-16-1EP_3x3mm_P0.5mm_EP1.6x1.6mm:
+  device_type: 'LFCSP'
+  library: Package_CSP
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'https://www.analog.com/media/en/package-pcb-resources/package/pkg_pdf/lfcspcp/cp-16/CP_16_22.pdf'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  # custom_name_format:
+  body_size_x:
+    nominal: 3
+    tolerance: 0.1
+  body_size_y:
+    nominal: 3
+    tolerance: 0.1
+  body_height:
+    nominal: 0.75
+    tolerance: 0.05
+
+  lead_width:
+    maximum: 0.30
+    nominal: 0.23
+    minimum: 0.18
+  lead_len:
+    nominal: 0.4
+    tolerance: 0.1
+
+  EP_size_x:
+    maximum: 1.75
+    nominal: 1.60
+    minimum: 1.45
+  EP_size_y:
+    maximum: 1.75
+    nominal: 1.60
+    minimum: 1.45
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 2]
+  #heel_reduction: 0.05 #for relatively large EP pads (increase clearance)
+
+  thermal_vias:
+    count: [2, 2]
+    drill: 0.3
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    EP_num_paste_pads: [2, 2]
+    #paste_between_vias: 1
+    #paste_rings_outside: 1
+    EP_paste_coverage: 0.75
+    #grid: [1, 1]
+    # bottom_pad_size:
+    paste_avoid_via: False
+
+  pitch: 0.5
+  num_pins_x: 4
+  num_pins_y: 4
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'


### PR DESCRIPTION
Add the size definitions for Analogs CP-16-22 LFCSP-16-1EP footprint.
[datasheet](https://www.analog.com/media/en/package-pcb-resources/package/pkg_pdf/lfcspcp/cp-16/CP_16_22.pdf)