### PR TITLE
Added battery holder BatteryHolder_TruPower_BH-331P_3xAA

### DIFF
--- a/scripts/Battery/BatteryHolder.py
+++ b/scripts/Battery/BatteryHolder.py
@@ -27,7 +27,7 @@ def qfn(args):
     pins = args["pins"]
     extratexts = args["extratexts"]
 
-    dir3D = 'Sensor_Current.3dshapes'
+    dir3D = 'Battery.3dshapes'
     f = Footprint(footprint_name)
 
     file3Dname = "${KISYS3DMOD}/" + dir3D + "/" + footprint_name + ".wrl"

--- a/scripts/Battery/BatteryHolder.yml
+++ b/scripts/Battery/BatteryHolder.yml
@@ -131,7 +131,7 @@ BatteryHolder_TruPower_BH-331P_3xAA:
   tags: "Battery Holder, BH-331P, Battery Type 3xAA"
   extratexts: [[-4.5, 0.0, "+", "F.SilkS", 3.0, 3.0]]
   at: [-2.3, 9.15]
-  size: [58.3, 48.0]
+  size: [58.0, 48.3]
   pins: [["tht", "1", 0, 0, 3.0, 3.0, 1.2], ["tht", "2", 0, -12.8, 3.0, 3.0, 1.2], ["npth", "", 26.7, 0.0, 3.5, 0, 3.5], ["npth", "", 26.7, -30.0, 3.5, 0, 3.5]]
 
 

--- a/scripts/Battery/BatteryHolder.yml
+++ b/scripts/Battery/BatteryHolder.yml
@@ -125,4 +125,13 @@ BatteryHolder_MPD_BK-18650-PC2:
   size: [76.96, 20.98]
   pins: [["tht", "1", 0, 0, 3.0, 3.0, 1.57], ["tht", "2", 72.90, 0, 3.0, 3.0, 1.57], ["npth", "", 8.445, 0.0, 3.2, 0, 3.2], ["npth", "", 64.055, 0.0, 3.2, 0, 3.2]]
 
+BatteryHolder_TruPower_BH-331P_3xAA:
+  description: "Keystone Battery Holder, BH-331P, Battery Type 3xAA"
+  datasheet: "https://static.rapidonline.com/pdf/18-2967_v1.pdf"
+  tags: "Battery Holder, BH-331P, Battery Type 3xAA"
+  extratexts: [[-4.5, 0.0, "+", "F.SilkS", 3.0, 3.0]]
+  at: [-2.3, 9.15]
+  size: [58.3, 48.0]
+  pins: [["tht", "1", 0, 0, 3.0, 3.0, 1.2], ["tht", "2", 0, -12.8, 3.0, 3.0, 1.2], ["npth", "", 26.7, 0.0, 3.5, 0, 3.5], ["npth", "", 26.7, -30.0, 3.5, 0, 3.5]]
+
 

--- a/scripts/Battery/BatteryHolder.yml
+++ b/scripts/Battery/BatteryHolder.yml
@@ -126,9 +126,9 @@ BatteryHolder_MPD_BK-18650-PC2:
   pins: [["tht", "1", 0, 0, 3.0, 3.0, 1.57], ["tht", "2", 72.90, 0, 3.0, 3.0, 1.57], ["npth", "", 8.445, 0.0, 3.2, 0, 3.2], ["npth", "", 64.055, 0.0, 3.2, 0, 3.2]]
 
 BatteryHolder_TruPower_BH-331P_3xAA:
-  description: "Keystone Battery Holder, BH-331P, Battery Type 3xAA"
+  description: "Keystone Battery Holder BH-331P Battery Type 3xAA"
   datasheet: "https://static.rapidonline.com/pdf/18-2967_v1.pdf"
-  tags: "Battery Holder, BH-331P, Battery Type 3xAA"
+  tags: "Battery Holder BH-331P Battery Type 3xAA"
   extratexts: [[-4.5, 0.0, "+", "F.SilkS", 3.0, 3.0]]
   at: [-2.3, 9.15]
   size: [58.0, 48.3]


### PR DESCRIPTION
Adding BatteryHolder from TruPower serie BH-331P for 3xAA
https://static.rapidonline.com/pdf/18-2967_v1.pdf

The foot print is scripted

Foot print push
https://github.com/KiCad/kicad-footprints/pull/1359

Foot print script push
https://github.com/pointhi/kicad-footprint-generator/pull/286

![bild](https://user-images.githubusercontent.com/25547797/52167615-1bc66600-271e-11e9-9321-af04dc1d3f0d.png)

![bild](https://user-images.githubusercontent.com/25547797/52167619-2680fb00-271e-11e9-8e04-ae66f044887a.png)

![bild](https://user-images.githubusercontent.com/25547797/52167622-33055380-271e-11e9-8593-00ea41e19f23.png)

![bild](https://user-images.githubusercontent.com/25547797/52167625-3f89ac00-271e-11e9-90ee-c93b6c74edd3.png)


