### PR TITLE
Fix wrong pin pitch in VQFN-28-1EP_4x4mm_P0.45mm_EP2.4x2.4mm

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/vqfn.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/vqfn.yaml
@@ -383,7 +383,7 @@ VQFN-28-1EP_4x4mm_P0.45mm_EP2.4x2.4mm:
     EP_paste_coverage: 0.7
 
 
-  pitch: 0.4
+  pitch: 0.45
   num_pins_x: 7
   num_pins_y: 7
 


### PR DESCRIPTION
With #276 I asked to merge two footprints, one of which unfortunately contained a mistake in the pin pitch. I'm really, really sorry for that and fixed it as soon as I recognized my mistake. Please merge the fix to the master, so that the error does not last to long.