### PR TITLE
Package SO: SO-4_4.4x3.9mm_P2.54mm scripetd version source

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/so.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/so.yaml
@@ -30,8 +30,8 @@ SO-8_4.0x5.0mm_P1.27mm:
 SO-4_4.4x3.9mm_P2.54mm:
   size_source: 'https://toshiba.semicon-storage.com/info/docget.jsp?did=10047&prodName=TLP3123'
   body_size_x:
-    minimum: 4.15
-    maximum: 4.65
+    nominal: 4.4
+    tolerance: 0.25
     # alternatively one can also specify the tolerance instead of minimum and maximum values. 
     # If minimum and maximum values are given then the nominal value is optional. 
     # It should only be included if it is given in the datasheet. 

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/so.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/so.yaml
@@ -37,17 +37,17 @@ SO-4_4.4x3.9mm_P2.54mm:
     # It should only be included if it is given in the datasheet. 
     # (If it is in the datasheet then it must be included.)
   body_size_y:
-    minimum: 3.65
-    maximum: 4.15
+    nominal: 3.9
+    tolerance: 0.25
   overall_size_x:
-    minimum: 6.6
-    maximum: 7.4
+    nominal: 7.0
+    tolerance: 0.4
   lead_width:
-    minimum: 0.3
-    maximum: 0.5
+    nominal: 0.4
+    tolerance: 0.1
   lead_len:
-    minimum: 0.3
-    maximum: 0.9
+    nominal: 0.6
+    tolerance: 0.3
   pitch: 2.54
   num_pins_x: 0
   num_pins_y: 2

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/so.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/so.yaml
@@ -26,3 +26,28 @@ SO-8_4.0x5.0mm_P1.27mm:
   pitch: 1.27
   num_pins_x: 0
   num_pins_y: 4
+
+SO-4_4.4x3.9mm_P2.54mm:
+  size_source: 'https://toshiba.semicon-storage.com/info/docget.jsp?did=10047&prodName=TLP3123'
+  body_size_x:
+    minimum: 4.15
+    maximum: 4.65
+    # alternatively one can also specify the tolerance instead of minimum and maximum values. 
+    # If minimum and maximum values are given then the nominal value is optional. 
+    # It should only be included if it is given in the datasheet. 
+    # (If it is in the datasheet then it must be included.)
+  body_size_y:
+    minimum: 3.65
+    maximum: 4.15
+  overall_size_x:
+    minimum: 6.6
+    maximum: 7.4
+  lead_width:
+    minimum: 0.3
+    maximum: 0.5
+  lead_len:
+    minimum: 0.3
+    maximum: 0.9
+  pitch: 2.54
+  num_pins_x: 0
+  num_pins_y: 2

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/so.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/so.yaml
@@ -32,10 +32,6 @@ SO-4_4.4x3.9mm_P2.54mm:
   body_size_x:
     nominal: 4.4
     tolerance: 0.25
-    # alternatively one can also specify the tolerance instead of minimum and maximum values. 
-    # If minimum and maximum values are given then the nominal value is optional. 
-    # It should only be included if it is given in the datasheet. 
-    # (If it is in the datasheet then it must be included.)
   body_size_y:
     nominal: 3.9
     tolerance: 0.25


### PR DESCRIPTION
Size definition from TLP3123, datasheet at https://toshiba.semicon-storage.com/info/docget.jsp?did=10047&prodName=TLP3123

PR on kicad footprint repo : https://github.com/KiCad/kicad-footprints/pull/1424

Joel