### PR TITLE
Size definition for TQFP-100 with 5x5mm EP

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tqfp.yaml
@@ -93,6 +93,52 @@ TQFP_100:
   num_pins_x: 25
   num_pins_y: 25
 
+TQFP-100-1EP_14x14mm_P0.5mm_EP5.0x5.0mm:
+  size_source: 'https://www.analog.com/media/en/package-pcb-resources/package/pkg_pdf/tqfp_edsv/sv_100_4.pdf'
+  body_size_x:
+    nominal: 14
+  body_size_y:
+    nominal: 14
+  overall_size_x:
+    nominal: 16
+  overall_size_y:
+    nominal: 16
+  lead_width:
+    minimum: 0.17
+    nominal: 0.22
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    nominal: 0.60
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 25
+  num_pins_y: 25
+
+  EP_size_x:
+    nominal: 5.0
+  EP_size_y:
+    nominal: 5.0
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [4, 4]
+  #heel_reduction: 0.1 #for relatively large EP pads (increase clearance)
+  # EP_size_limit_x: 3.6  #for relatively large EP pads (increase clearance)
+  # EP_size_limit_y: 3.6  #for relatively large EP pads (increase clearance)
+
+  thermal_vias:
+    count: [5, 5]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    #paste_between_vias: 1
+    #paste_rings_outside: 1
+    #EP_paste_coverage: 0.65
+    #grid: [1, 1]
+    # bottom_pad_size:
+    # paste_avoid_via: True
+
+
 TQFP_144:
   size_source: 'http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=131095'
   body_size_x:

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tqfp.yaml
@@ -103,6 +103,9 @@ TQFP-100-1EP_14x14mm_P0.5mm_EP5.0x5.0mm:
     nominal: 16
   overall_size_y:
     nominal: 16
+  overall_height:
+    minimum: 1
+    maximum: 1.2
   lead_width:
     minimum: 0.17
     nominal: 0.22


### PR DESCRIPTION
[Mechanical drawing](https://www.analog.com/media/en/package-pcb-resources/package/pkg_pdf/tqfp_edsv/sv_100_4.pdf). It exists already in the library, but still with square pads and without thermal vias.