### PR TITLE
BMI-S-230-F RF shield frame

### DIFF
--- a/scripts/Shielding/laird_technologies_smd_shielding.kicad_mod.yaml
+++ b/scripts/Shielding/laird_technologies_smd_shielding.kicad_mod.yaml
@@ -211,6 +211,18 @@ Laird_Technologies_BMI-S-210-F_44.00x30.50mm:
     x_pad_mirror: True
     y_pad_mirror: True
 
+Laird_Technologies_BMI-S-230-F_50.8x38.1mm:
+    description: "Laird Technologies BMI-S-230-F Shielding Cabinet Two Piece SMD 50.8x38.1mm"
+    datasheet: "https://media.digikey.com/pdf/Data%20Sheets/Laird%20Technologies/BMI-S-230-F_Dwg.pdf"
+    courtjard: 0.25
+    pads_width: 1
+    x_part_size: 50.8
+    y_part_size: 38.1
+    x_pad_spacer: [1.9, 4.1, 7.9, 10.1, 13.9, 16.1, 19.9, 22.1, 25.95]
+    y_pad_spacer: [1.9, 4.1, 7.9, 10.1, 13.9, 16.1, 19.45]
+    x_pad_mirror: True
+    y_pad_mirror: True
+
 # page 19
 Laird_Technologies_97-2002_25.40x25.40mm:
     description: "Laird Technologies 97-2002 EZ PEEL Shielding Cabinet One Piece SMD 25.40x25.40mm"

--- a/scripts/Shielding/laird_technologies_smd_shielding.kicad_mod.yaml
+++ b/scripts/Shielding/laird_technologies_smd_shielding.kicad_mod.yaml
@@ -218,7 +218,7 @@ Laird_Technologies_BMI-S-230-F_50.8x38.1mm:
     pads_width: 1
     x_part_size: 50.8
     y_part_size: 38.1
-    x_pad_spacer: [1.9, 4.1, 7.9, 10.1, 13.9, 16.1, 19.9, 22.1, 25.95]
+    x_pad_spacer: [1.9, 4.1, 7.9, 10.1, 13.9, 16.1, 19.9, 22.1, 25.8]
     y_pad_spacer: [1.9, 4.1, 7.9, 10.1, 13.9, 16.1, 19.45]
     x_pad_mirror: True
     y_pad_mirror: True

--- a/scripts/Shielding/smd_shielding.py
+++ b/scripts/Shielding/smd_shielding.py
@@ -71,6 +71,16 @@ def create_smd_shielding(name, **kwargs):
                               end=[x_courtjard_max, y_courtjard_max],
                               layer='F.CrtYd'))
 
+    # create inner courtyard
+    pad_width = kwargs['pads_width']
+    x_courtjard_min = round_to(x_pad_min + pad_width + kwargs['courtjard'], 0.05)
+    x_courtjard_max = round_to(x_pad_max - pad_width - kwargs['courtjard'], 0.05)
+    y_courtjard_min = round_to(y_pad_min + pad_width + kwargs['courtjard'], 0.05)
+    y_courtjard_max = round_to(y_pad_max - pad_width - kwargs['courtjard'], 0.05)
+    kicad_mod.append(RectLine(start=[x_courtjard_min, y_courtjard_min],
+                              end=[x_courtjard_max, y_courtjard_max],
+                              layer='F.CrtYd'))
+
     # create Fabriaction Layer
     kicad_mod.append(RectLine(start=[x_part_min, y_part_min],
                               end=[x_part_max, y_part_max],

--- a/scripts/Shielding/smd_shielding.py
+++ b/scripts/Shielding/smd_shielding.py
@@ -51,7 +51,7 @@ def create_smd_shielding(name, **kwargs):
     x_pad_max_center = x_pad_max - kwargs['pads_width']/2.
     y_pad_min_center = y_pad_min + kwargs['pads_width']/2.
     y_pad_max_center = y_pad_max - kwargs['pads_width']/2.
-    
+
     x_part_min = -kwargs['x_part_size'] / 2.
     x_part_max = kwargs['x_part_size'] / 2.
     y_part_min = -kwargs['y_part_size'] / 2.
@@ -80,7 +80,7 @@ def create_smd_shielding(name, **kwargs):
     general_kwargs = {'number': 1,
                       'type': Pad.TYPE_SMT,
                       'shape': Pad.SHAPE_RECT,
-                      'layers': ['F.Cu', 'F.Mask']}
+                      'layers': ['F.Cu', 'F.Mask', 'F.Paste']}
 
     # create edge pads
     kicad_mod.append(Pad(at=[x_pad_min_center, y_pad_min_center],

--- a/scripts/Shielding/smd_shielding.py
+++ b/scripts/Shielding/smd_shielding.py
@@ -36,7 +36,7 @@ def create_smd_shielding(name, **kwargs):
     kicad_mod.setDescription(kwargs['description'])
     kicad_mod.setTags('Shielding Cabinet')
     kicad_mod.setAttribute('smd')
-    kicad_mod.append(Model(filename="RF_Shielding.3dshapes/" + name + ".wrl"))
+    kicad_mod.append(Model(filename="${KISYS3DMOD}/RF_Shielding.3dshapes/" + name + ".wrl"))
 
     # do some pre calculations
     # TODO: when mirror=False, array has to have even number of array elements
@@ -61,7 +61,7 @@ def create_smd_shielding(name, **kwargs):
     # set general values
     kicad_mod.append(Text(type='reference', text='REF**', at=[0, y_pad_min - kwargs['courtjard'] - 0.75], layer='F.SilkS'))
     kicad_mod.append(Text(type='value', text=name, at=[0, y_pad_max + kwargs['courtjard'] + 0.75], layer='F.Fab'))
-    kicad_mod.append(Text(type='%R', text=name, at=[0, 0], layer='F.Fab'))
+    kicad_mod.append(Text(type='user', text='%R', at=[0, 0], layer='F.Fab'))
 
     # create courtyard
     x_courtjard_min = round_to(x_pad_min - kwargs['courtjard'], 0.05)

--- a/scripts/Shielding/smd_shielding.py
+++ b/scripts/Shielding/smd_shielding.py
@@ -36,6 +36,7 @@ def create_smd_shielding(name, **kwargs):
     kicad_mod.setDescription(kwargs['description'])
     kicad_mod.setTags('Shielding Cabinet')
     kicad_mod.setAttribute('smd')
+    kicad_mod.append(Model(filename="RF_Shielding.3dshapes/" + name + ".wrl"))
 
     # do some pre calculations
     # TODO: when mirror=False, array has to have even number of array elements
@@ -60,6 +61,7 @@ def create_smd_shielding(name, **kwargs):
     # set general values
     kicad_mod.append(Text(type='reference', text='REF**', at=[0, y_pad_min - kwargs['courtjard'] - 0.75], layer='F.SilkS'))
     kicad_mod.append(Text(type='value', text=name, at=[0, y_pad_max + kwargs['courtjard'] + 0.75], layer='F.Fab'))
+    kicad_mod.append(Text(type='%R', text=name, at=[0, 0], layer='F.Fab'))
 
     # create courtyard
     x_courtjard_min = round_to(x_pad_min - kwargs['courtjard'], 0.05)


### PR DESCRIPTION
kicad-footprints pr:
https://github.com/KiCad/kicad-footprints/pull/1474

The smd_shielding.py script was not enabling the paste layer, so I added that. The existing BMI-S-xxx parts in kicad-footprints do have paste.