### PR TITLE
Add SOP16 from STC (in essence a SOIC-16)

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
@@ -157,3 +157,29 @@ SOP-18_7.0x12.5mm_P1.27mm:
   pitch: 1.27
   num_pins_x: 0
   num_pins_y: 9
+  
+STC_SOP-16_3.9x9.9mm_P1.27mm:
+  size_source: 'https://www.stcmicro.com/datasheet/STC15F2K60S2-en.pdf'
+  manufacturer: 'STC'
+  body_size_x: # E1
+    minimum: 3.8
+    maximum: 4.0
+  body_size_y: # D
+    minimum: 9.8
+    maximum: 10
+  overall_height: # A
+    minimum: 1.35
+    maximum: 1.75
+  overall_size_x: # E
+    minimum: 5.8
+    maximum: 6.2
+  lead_len: # L
+    minimum: 0.45
+    maximum: 0.8
+  lead_width: # b
+    minimum: 0.35
+    maximum: 0.45
+
+  pitch: 1.27 # e
+  num_pins_x: 0
+  num_pins_y: 8

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
@@ -162,22 +162,28 @@ STC_SOP-16_3.9x9.9mm_P1.27mm:
   size_source: 'https://www.stcmicro.com/datasheet/STC15F2K60S2-en.pdf#page=156'
   manufacturer: 'STC'
   body_size_x: # E1
-    minimum: 3.8
-    maximum: 4.0
+    minimum: 3.80
+    nominal: 3.90
+    maximum: 4.00
   body_size_y: # D
-    minimum: 9.8
-    maximum: 10
+    minimum: 9.80
+    nominal: 9.90
+    maximum: 10.00
   overall_height: # A
     minimum: 1.35
+    nominal: 1.60
     maximum: 1.75
   overall_size_x: # E
-    minimum: 5.8
-    maximum: 6.2
+    minimum: 5.80
+    nominal: 6.00
+    maximum: 6.20
   lead_len: # L
     minimum: 0.45
-    maximum: 0.8
+    nominal: 0.60
+    maximum: 0.80
   lead_width: # b
     minimum: 0.35
+    nominal: 0.40
     maximum: 0.45
 
   pitch: 1.27 # e

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
@@ -159,7 +159,7 @@ SOP-18_7.0x12.5mm_P1.27mm:
   num_pins_y: 9
   
 STC_SOP-16_3.9x9.9mm_P1.27mm:
-  size_source: 'https://www.stcmicro.com/datasheet/STC15F2K60S2-en.pdf'
+  size_source: 'https://www.stcmicro.com/datasheet/STC15F2K60S2-en.pdf#page=156'
   manufacturer: 'STC'
   body_size_x: # E1
     minimum: 3.8


### PR DESCRIPTION
Add the SOP16 from STC. This footprint is a little bit strange, because it is pretty much a SOIC-16.

Datasheet: https://www.stcmicro.com/datasheet/STC15F2K60S2-en.pdf (page 156)

It appears like the datasheet can't be open at the moment (it states "Bandwidth Limit Exceeded"). You can use https://web.archive.org/web/20180713001956/https://www.stcmicro.com/datasheet/STC15F2K60S2-en.pdf in the meantime.