### PR TITLE
Add entry for ST LGA-12 footprint

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lga.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lga.yaml
@@ -1,3 +1,34 @@
+LGA-12_2x2mm_P0.35mm_LayoutBorder2x4y:
+  device_type: 'LGA'
+  library: Package_LGA
+  use_name_format: 'LGA'
+  ipc_density: 'least'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'http://www.st.com/resource/en/datasheet/lis2hh12.pdf'
+  ipc_class: 'qfn_pull_back'
+  body_size_x_min: 1.85
+  body_size_x: 2.0
+  body_size_x_max: 2.15
+  body_size_y_min: 1.85
+  body_size_y: 2.0
+  body_size_y_max: 2.15
+  body_height_max: 1
+  lead_width_min: 0.25
+  lead_width_max: 0.25
+  lead_to_edge:
+    nominal: 0.1
+  lead_len_min: 0.275
+  lead_len_max: 0.275
+  pitch: 0.5
+  num_pins_x: 2
+  num_pins_y: 4
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'
+
 LGA-16_3x3mm_P0.5mm_LayoutBorder3x5y:
   device_type: 'LGA'
   library: Package_LGA


### PR DESCRIPTION
https://www.st.com/resource/en/datasheet/lis2hh12.pdf

@poeschlr 
When I run the generator I get a footprint like this:
![image](https://user-images.githubusercontent.com/1936989/54628210-4ea88d00-4a32-11e9-82c4-330e5fe3a798.png)

1. The courtyard isn't outside the body. Is this a known issue? Or did I do something wrong?
1. Would it be better to have silk all around the body except for the pin 1 corner?

I haven't looked at the code yet but wanted to ping you first.

@pointhi 
Please don't merge until the above questions are settled.