### PR TITLE
add LFCSP-64 (Analog Devices CP-64-7)

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
@@ -106,7 +106,7 @@ LFCSP-64-1EP_9x9mm_P0.5mm_EP5.21x5.21mm:
   EP_num_paste_pads: [2, 2]
   #heel_reduction: 0.05 #for relatively large EP pads (increase clearance)
   thermal_vias:
-    count: [3, 3]
+    count: [4, 4]
     drill: 0.3
     # min_annular_ring: 0.15
     paste_via_clearance: 0.1

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
@@ -62,3 +62,55 @@ LFCSP-16-1EP_3x3mm_P0.5mm_EP1.6x1.6mm:
   #pad_length_addition: 0.5
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
+  
+LFCSP-64-1EP_9x9mm_P0.5mm_EP5.21x5.21mm:
+  device_type: 'LFCSP'
+  library: Package_CSP
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'https://www.analog.com/media/en/package-pcb-resources/package/pkg_pdf/lfcspcp/cp_64_7.pdf'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  # custom_name_format:
+  body_size_x:
+    minimum: 8.9
+    nominal: 9
+    minimum: 9.1
+  body_size_y:
+    minimum: 8.9
+    nominal: 9
+    minimum: 9.1
+  body_height:
+    minimum: 0.8
+    nominal: 0.85
+    maximum: 1.0
+
+  lead_width:
+    maximum: 0.30
+    nominal: 0.25
+    minimum: 0.18
+  lead_len:
+    minimum: 0.3
+    nominal: 0.4
+    maximum: 0.5
+
+  EP_size_x:
+    maximum: 5.36
+    nominal: 5.21
+    minimum: 5.06
+  EP_size_y:
+    maximum: 5.36
+    nominal: 5.21
+    minimum: 5.06
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 2]
+  #heel_reduction: 0.05 #for relatively large EP pads (increase clearance)
+
+  pitch: 0.5
+  num_pins_x: 16
+  num_pins_y: 16
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
@@ -105,7 +105,20 @@ LFCSP-64-1EP_9x9mm_P0.5mm_EP5.21x5.21mm:
   # EP_paste_coverage: 0.65
   EP_num_paste_pads: [2, 2]
   #heel_reduction: 0.05 #for relatively large EP pads (increase clearance)
-
+  thermal_vias:
+    count: [3, 3]
+    drill: 0.3
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    EP_num_paste_pads: [2, 2]
+    #paste_between_vias: 1
+    #paste_rings_outside: 1
+    EP_paste_coverage: 0.75
+    #grid: [1, 1]
+    # bottom_pad_size:
+    paste_avoid_via: False
+    
+    
   pitch: 0.5
   num_pins_x: 16
   num_pins_y: 16


### PR DESCRIPTION
dimensions for https://www.analog.com/media/en/package-pcb-resources/package/pkg_pdf/lfcspcp/cp_64_7.pdf

![LFCSP-64-1EP_9x9mm_P0 5mm_EP5 21x5](https://user-images.githubusercontent.com/909509/54702553-c0223180-4b3f-11e9-8e6d-dd325f4a2d45.png)
