### PR TITLE
Add support for imperial units to ipc toleranced size class

### DIFF
--- a/scripts/tools/ipc_pad_size_calculators.py
+++ b/scripts/tools/ipc_pad_size_calculators.py
@@ -5,7 +5,18 @@ def roundToBase(value, base):
     return round(value/base) * base
 
 class TolerancedSize():
-    def __init__(self, minimum=None, nominal=None, maximum=None, tolerance=None):
+    def to_metric(value, unit):
+        if unit == "inch":
+            factor = 25.4
+        elif unit == "mil":
+            factor = 25.4/1000
+        else:
+            factor = 1
+        return value * factor
+
+    def __init__(self, minimum=None, nominal=None, maximum=None, tolerance=None, unit=None):
+
+
         if nominal is not None:
             self.nominal = nominal
         else:
@@ -36,6 +47,10 @@ class TolerancedSize():
 
         if self.maximum < self.minimum:
             raise ValueError("Maximum is smaller than minimum. Tolerance ranges given wrong or parameters confused.")
+
+        self.minimum = TolerancedSize.to_metric(self.minimum, unit)
+        self.nominal = TolerancedSize.to_metric(self.nominal, unit)
+        self.maximum = TolerancedSize.to_metric(self.maximum, unit)
 
         self.ipc_tol = self.maximum - self.minimum
         self.ipc_tol_RMS = self.ipc_tol
@@ -131,7 +146,8 @@ class TolerancedSize():
                     minimum=dim.get("minimum"),
                     nominal=dim.get("nominal"),
                     maximum=dim.get("maximum"),
-                    tolerance=dim.get("tolerance")
+                    tolerance=dim.get("tolerance"),
+                    unit=dim.get("unit")
                     )
 
             return TolerancedSize(
@@ -145,7 +161,8 @@ class TolerancedSize():
                 minimum=yaml.get("minimum"),
                 nominal=yaml.get("nominal"),
                 maximum=yaml.get("maximum"),
-                tolerance=yaml.get("tolerance")
+                tolerance=yaml.get("tolerance"),
+                unit=dim.get("unit")
                 )
     def __str__(self):
         return 'nom: {}, min: {}, max: {}  | min_rms: {}, max_rms: {}'.format(self.nominal, self.minimum, self.maximum, self.minimum_RMS, self.maximum_RMS)


### PR DESCRIPTION
https://github.com/pointhi/kicad-footprint-generator/pull/314 references a datasheet with imperial only dimensioned drawings. This adds a unit switch for every dimension of a component. (options are inch and mil, anything else will be assumed to be mm.)

This does not change the generation of existing footprints (tested on the texas instrument qfn footprints as i still had generated footprints from before the change. diff only showed a change in the timestamp which is what i expected if this works.)

The dimensions for the part in the linked footprint will be added as a testcase shortly