### PR TITLE
DFN: add DFN-10-1EP_3x3mm_P0.5mm_EP1.7x2.5mm

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/dfn.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/dfn.yaml
@@ -297,6 +297,46 @@ DFN-8-1EP_3x3mm_P0.65mm_EP1.7x2.05mm:
   #include_suffix_in_3dpath: 'False'
   #include_pad_size: 'fp_name_only' # 'both' | 'none' (default)
 
+DFN-10-1EP_3x3mm_P0.5mm_EP1.7x2.5mm:
+  device_type: 'DFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'https://www.monolithicpower.com/pub/media/document/MPQ2483_r1.05.pdf'
+  # ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  body_size_x:
+    minimum: 2.9
+    maximum: 3.1
+  body_size_y:
+    minimum: 2.9
+    maximum: 3.1
+  overall_height:
+    minimum: 0.8
+    maximum: 1.0
+
+  lead_width:
+    minimum: 0.18
+    maximum: 0.3
+  lead_len:
+    minimum: 0.3
+    maximum: 0.5
+
+  EP_size_x:
+    minimum: 1.45
+    maximum: 17.5
+  EP_size_x_overwrite: 1.7
+
+  EP_size_y:
+    minimum: 2.25
+    maximum: 2.55
+  EP_size_y_overwrite: 2.5
+
+  EP_num_paste_pads: [2, 2]
+
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 5
+
 Texas_S-PDSO-N10_EP1.2x2.0mm:
   device_type: 'DFN'
   #manufacturer: 'man'


### PR DESCRIPTION
This is a package used by MPS for the MPQ2483 part, as described in the
datasheet:

  https://www.monolithicpower.com/pub/media/document/MPQ2483_r1.05.pdf