### PR TITLE
Extend dimension parser and fix imperial handling

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/ipc_noLead_generator.py
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/ipc_noLead_generator.py
@@ -124,21 +124,23 @@ class NoLead():
 
     @staticmethod
     def deviceDimensions(device_size_data, fp_id):
+        unit = device_size_data.get('unit')
         dimensions = {
-            'body_size_x': TolerancedSize.fromYaml(device_size_data, base_name='body_size_x'),
-            'body_size_y': TolerancedSize.fromYaml(device_size_data, base_name='body_size_y'),
-            'lead_width': TolerancedSize.fromYaml(device_size_data, base_name='lead_width')
+            'body_size_x': TolerancedSize.fromYaml(device_size_data, base_name='body_size_x', unit=unit),
+            'body_size_y': TolerancedSize.fromYaml(device_size_data, base_name='body_size_y', unit=unit),
+            'lead_width': TolerancedSize.fromYaml(device_size_data, base_name='lead_width', unit=unit),
+            'pitch': TolerancedSize.fromYaml(device_size_data, base_name='pitch', unit=unit).nominal
         }
         dimensions['has_EP'] = False
         if 'EP_size_x_min' in device_size_data and 'EP_size_x_max' in device_size_data or 'EP_size_x' in device_size_data:
-            dimensions['EP_size_x'] = TolerancedSize.fromYaml(device_size_data, base_name='EP_size_x')
-            dimensions['EP_size_y'] = TolerancedSize.fromYaml(device_size_data, base_name='EP_size_y')
+            dimensions['EP_size_x'] = TolerancedSize.fromYaml(device_size_data, base_name='EP_size_x', unit=unit)
+            dimensions['EP_size_y'] = TolerancedSize.fromYaml(device_size_data, base_name='EP_size_y', unit=unit)
             dimensions['has_EP'] = True
             dimensions['EP_center_x'] = TolerancedSize(nominal=0)
             dimensions['EP_center_y'] = TolerancedSize(nominal=0)
             if 'EP_center_x' in device_size_data and 'EP_center_y' in device_size_data:
-              dimensions['EP_center_x'] = TolerancedSize.fromYaml(device_size_data, base_name='EP_center_x')
-              dimensions['EP_center_y'] = TolerancedSize.fromYaml(device_size_data, base_name='EP_center_y')
+                dimensions['EP_center_x'] = TolerancedSize.fromYaml(device_size_data, base_name='EP_center_x', unit=unit)
+                dimensions['EP_center_y'] = TolerancedSize.fromYaml(device_size_data, base_name='EP_center_y', unit=unit)
 
         if 'heel_reduction' in device_size_data:
             print(
@@ -147,30 +149,30 @@ class NoLead():
             dimensions['heel_reduction'] = device_size_data.get('heel_reduction', 0)
 
         if 'lead_to_edge' in device_size_data:
-            dimensions['lead_to_edge'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_to_edge')
+            dimensions['lead_to_edge'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_to_edge', unit=unit)
 
         if 'lead_center_pos_x' in device_size_data:
-            dimensions['lead_center_pos_x'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_center_pos_x')
+            dimensions['lead_center_pos_x'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_center_pos_x', unit=unit)
         if 'lead_center_to_center_x' in device_size_data:
-            dimensions['lead_center_pos_x'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_center_to_center_x')/2
+            dimensions['lead_center_pos_x'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_center_to_center_x', unit=unit)/2
 
         if 'lead_center_pos_y' in device_size_data:
-            dimensions['lead_center_pos_y'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_center_pos_y')
+            dimensions['lead_center_pos_y'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_center_pos_y', unit=unit)
         if 'lead_center_to_center_y' in device_size_data:
-            dimensions['lead_center_pos_y'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_center_to_center_y')/2
+            dimensions['lead_center_pos_y'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_center_to_center_y', unit=unit)/2
 
         dimensions['lead_len_H'] = None
         dimensions['lead_len_V'] = None
         if 'lead_len_H' in device_size_data and 'lead_len_V' in device_size_data:
-            dimensions['lead_len_H'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_len_H')
-            dimensions['lead_len_V'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_len_V')
+            dimensions['lead_len_H'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_len_H', unit=unit)
+            dimensions['lead_len_V'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_len_V', unit=unit)
         elif 'lead_len' in device_size_data or (
                 'lead_len_min' in device_size_data and 'lead_len_max' in device_size_data):
-            dimensions['lead_len_H'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_len')
+            dimensions['lead_len_H'] = TolerancedSize.fromYaml(device_size_data, base_name='lead_len', unit=unit)
             dimensions['lead_len_V'] = dimensions['lead_len_H']
 
         if 'body_to_inside_lead_edge' in device_size_data:
-            dimensions['body_to_inside_lead_edge'] = TolerancedSize.fromYaml(device_size_data, base_name='body_to_inside_lead_edge')
+            dimensions['body_to_inside_lead_edge'] = TolerancedSize.fromYaml(device_size_data, base_name='body_to_inside_lead_edge', unit=unit)
         elif dimensions['lead_len_H'] is None:
             raise KeyError('{}: Either lead lenght or inside lead to edge dimension must be given.'.format(fp_id))
 
@@ -256,7 +258,7 @@ class NoLead():
             pincount=pincount,
             size_y=size_y,
             size_x=size_x,
-            pitch=device_params['pitch'],
+            pitch=device_dimensions['pitch'],
             layout=layout,
             ep_size_x = EP_size['x'],
             ep_size_y = EP_size['y'],
@@ -272,7 +274,7 @@ class NoLead():
             pincount=pincount,
             size_y=size_y,
             size_x=size_x,
-            pitch=device_params['pitch'],
+            pitch=device_dimensions['pitch'],
             layout=layout,
             ep_size_x = EP_size['x'],
             ep_size_y = EP_size['y'],
@@ -422,10 +424,10 @@ class NoLead():
                 width=configuration['silk_line_width'],
                 layer="F.SilkS", x_mirror=0))
         else:
-            sx1 = -(device_params['pitch']*(device_params['num_pins_x']-1)/2.0
+            sx1 = -(device_dimensions['pitch']*(device_params['num_pins_x']-1)/2.0
                 + pad_width/2.0 + silk_pad_offset)
 
-            sy1 = -(device_params['pitch']*(device_params['num_pins_y']-1)/2.0
+            sy1 = -(device_dimensions['pitch']*(device_params['num_pins_y']-1)/2.0
                 + pad_width/2.0 + silk_pad_offset)
 
             poly_silk = [


### PR DESCRIPTION
Continuation of https://github.com/pointhi/kicad-footprint-generator/pull/324

Fixes imperial handling for no lead generator (moved unit specifier to
top level of every size definition instead of having it inside every
dimension. This allows the pin pitch to use non metric units as well.)

Add support for giving dimensions as strings of the styles nom+/-tol,
nom+tolp-toln, min...nom...max and min...max.

Tested against ti qfn size definitions (No changes -> should not break old definitions.)

I will transfer over the size definition files to the new standard sometime in the near future. (Will happen one definition file at a time to ensure everything stays in order and to reduce problems with merge conflicts.)

New dimensions tested with:
```python
import sys
import os
import yaml
from ipc_pad_size_calculators import *

with open("test_dim.yaml", 'r') as config_stream:
    try:
        configuration = yaml.load(config_stream)
    except yaml.YAMLError as exc:
        print(exc)


for v in configuration:
    if "_" in v:
        continue
    print(v)
    print(str(TolerancedSize.fromYaml(configuration, v)))
```

yaml test file (containing all currently supported dimension schemes that i could think of.)

```yaml
dim1: 1.0 +/-0.1
dim2: 2.0 +0.1 -0.05
dim3: 2.9...3.0...3.1
dim4: 3.9...4.1
dim5:
  nominal: 5
  tolerance: 0.1
dim6:
  nominal: 6
  tolerance: [0.1,-0.05]
dim7:
  minimum: 6.9
  nominal: 7
  maximum: 7.1
dim8:
  minimum: 7.9
  maximum: 8.1
dim10: 10
dim10_tol: 0.1
dim11: 11
dim11_tol: [-0.05,0.1]
dim12_min: 11.9
dim12: 12
dim12_max: 12.1
dim13_min: 12.9
dim13_max: 13.1
dim14: 14
dim15:
  nominal: 15
```