### PR TITLE
QFP_SOIC_SO: add size definition for TSOP-6 in 1.5x2.9mm package

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sc-74.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sc-74.yaml
@@ -1,8 +1,8 @@
 FileHeader:
   library_Suffix: 'SO'
-  device_type: 'TSOP'
+  device_type: 'SC-74'
 
-TSOP-6_1.50mmx2.90mm_P0.95mm:
+SC-74-6_1.50mmx2.90mm_P0.95mm:
   size_source: 'https://www.nxp.com/docs/en/package-information/SOT457.pdf'
   body_size_x:
     minimum: 1.3

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tsop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tsop.yaml
@@ -1,0 +1,27 @@
+FileHeader:
+  library_Suffix: 'SO'
+  device_type: 'TSOP'
+
+TSOP-6_1.50mmx2.90mm_P0.95mm:
+  size_source: 'https://www.nxp.com/docs/en/package-information/SOT457.pdf'
+  body_size_x:
+    minimum: 1.3
+    maximum: 1.7
+  body_size_y:
+    minimum: 2.7
+    maximum: 3.1
+  overall_size_x:
+    minimum: 2.5
+    maximum: 3.0
+  overall_height:
+    minimum: 0.9
+    maximum: 1.1
+  lead_width:
+    minimum: 0.25
+    maximum: 0.40
+  lead_len:
+    minimum: 0.2
+    maximum: 0.6
+  pitch: 0.95
+  num_pins_x: 0
+  num_pins_y: 3


### PR DESCRIPTION
The footprint PR is here: https://github.com/KiCad/kicad-footprints/pull/1511