### PR TITLE
qfn: add Texas_S-PWQFN-N32_EP2.8x2.8mm

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn_texas.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn_texas.yaml
@@ -497,21 +497,21 @@ Texas_S-PWQFN-N32_EP:
   #ipc_density: 'least' #overwrite global value for this device.
   custom_name_format: 'Texas_S-PWQFN-N{pincount}_EP{ep_size_x:g}x{ep_size_y:g}mm{vias:s}'
   body_size_x:
-    minimum: 4.85
-    maximum: 5.15
+    minimum: 3.85
+    maximum: 4.15
   body_size_y:
-    minimum: 4.85
-    maximum: 5.15
+    minimum: 3.85
+    maximum: 4.15
   overall_height:
     minimum: 0.7
     maximum: 0.8
 
   lead_width:
-    minimum: 0.18
-    maximum: 0.3
+    minimum: 0.15
+    maximum: 0.25
   lead_len:
-    minimum: 0.3
-    maximum: 0.5
+    minimum: 0.25
+    maximum: 0.45
 
   EP_size_x:
     nominal: 2.8
@@ -522,7 +522,7 @@ Texas_S-PWQFN-N32_EP:
   # EP_paste_coverage: 0.65
   EP_num_paste_pads: [2, 2]
 
-  pitch: 0.5
+  pitch: 0.4
   num_pins_x: 8
   num_pins_y: 8
   #chamfer_edge_pins: 0.25

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn_texas.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn_texas.yaml
@@ -488,6 +488,62 @@ Texas_R-PWQFN-N28_EP:
     # bottom_pad_size:
     paste_avoid_via: False
 
+Texas_S-PWQFN-N32_EP:
+  device_type: 'QFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'https://www.ti.com/lit/ds/symlink/bq25703a.pdf#page=91'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  custom_name_format: 'Texas_S-PWQFN-N{pincount}_EP{ep_size_x:g}x{ep_size_y:g}mm{vias:s}'
+  body_size_x:
+    minimum: 4.85
+    maximum: 5.15
+  body_size_y:
+    minimum: 4.85
+    maximum: 5.15
+  overall_height:
+    minimum: 0.7
+    maximum: 0.8
+
+  lead_width:
+    minimum: 0.18
+    maximum: 0.3
+  lead_len:
+    minimum: 0.3
+    maximum: 0.5
+
+  EP_size_x:
+    nominal: 2.8
+    tolerance: 0.1
+  EP_size_y:
+    nominal: 2.8
+    tolerance: 0.1
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 2]
+
+  pitch: 0.5
+  num_pins_x: 8
+  num_pins_y: 8
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'
+  thermal_vias:
+    count: [3, 3]
+    drill: 0.3
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.05
+    EP_paste_coverage: 0.7
+    # paste_between_vias: 1
+    # paste_rings_outside: 1
+    # EP_num_paste_pads: [2, 2]
+    # EP_paste_coverage: 0.5
+    # grid:
+    # bottom_pad_size:
+    paste_avoid_via: False
+
 Texas_S-PVQFN-N32_EP:
   device_type: 'QFN'
   #manufacturer: 'man'


### PR DESCRIPTION
Used by this part:

  https://www.ti.com/lit/ds/symlink/bq25703a.pdf (page 91)