### PR TITLE
Correct Micro-Fit 3.0 drill sizes to datasheet

### DIFF
--- a/scripts/Connector/Connector_Molex/conn_molex_micro-fit-3.0_tht_top_dual_row.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_micro-fit-3.0_tht_top_dual_row.py
@@ -51,8 +51,8 @@ variant_params = {
 
 pins_per_row_range = range(1,13)
 pitch = 3.0
-drill = 1.0
-peg_drill = 1.0
+drill = 1.02
+peg_drill = 1.02
 pad_to_pad_clearance = 1.5 # Voltage rating is up to 600V (http://www.molex.com/pdm_docs/ps/PS-43045.pdf)
 max_annular_ring = 0.5
 min_annular_ring = 0.15

--- a/scripts/Connector/Connector_Molex/conn_molex_micro-fit-3.0_tht_top_single_row.py
+++ b/scripts/Connector/Connector_Molex/conn_molex_micro-fit-3.0_tht_top_single_row.py
@@ -51,8 +51,8 @@ variant_params = {
 
 pins_per_row_range = range(2,13)
 pitch = 3.0
-drill = 1.0
-peg_drill = 1.0
+drill = 1.02
+peg_drill = 1.27
 pad_to_pad_clearance = 1.5 # Voltage rating is up to 600V (http://www.molex.com/pdm_docs/ps/PS-43650.pdf)
 max_annular_ring = 0.5
 min_annular_ring = 0.15


### PR DESCRIPTION
As reported at https://github.com/KiCad/kicad-footprints/issues/1518. THT pad drill from 1mm to 1.02mm are minor, but the mounting holes were 1mm and should have been 1.27mm.