### PR TITLE
Added HVSON8 footprint for NXP PCF8523 RTC

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/hvson8.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/hvson8.yaml
@@ -7,23 +7,23 @@ HVSON-8-1EP_3.25x2.35mm_P0.8mm_E1.1x1.75mm:
   #ipc_density: 'least' #overwrite global value for this device.
   #body_size_x_min: 2.85
   body_size_x:
-  #  minimum: 5.9
-    nominal: 4.95
-  #  maximum: 6.1
+    minimum: 3.9
+    nominal: 4.0
+    maximum: 4.1
   body_size_y:
-  #  minimum: 4.9
-    nominal: 3.25
-  #  maximum: 5.1
+    minimum: 3.9
+    nominal: 4.0
+    maximum: 4.1
   # overall_height:
-  #  minimum: 0.70
-  #  nominal: 0.75
+    minimum: 1.00
+  #  nominal: 1.0
   #  maximum: 0.80
   lead_width:
-  #  minimum: 0.35
+    minimum: 0.30
     nominal: 0.35
-  #  maximum: 0.48
+    maximum: 0.40
   lead_len:
-  #  minimum: 0.55
+  #  minimum: 0.4
     nominal: 0.95
   #  maximum: 0.65
 

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/hvson8.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/hvson8.yaml
@@ -1,40 +1,31 @@
-HVSON-8-1EP_3.25x2.35mm_P0.8mm_E1.1x1.75mm:
+HVSON-8-1EP_4x4mm_P0.8mm_E2.2x3.1mm:
   device_type: 'HVSON'
   library: Package_SON
-  #manufacturer: 'NXP'
-  size_source: 'https://www.nxp.com/docs/en/data-sheet/PCF8523.pdf (page 66)'
-  ipc_class: 'qfn_pull_back' #'qfn' | 'qfn_pull_back'
+  manufacturer: 'NXP'
+  size_source: 'https://www.nxp.com/docs/en/data-sheet/PCF8523.pdf (page 57)'
+  ipc_class: 'qfn' #'qfn' | 'qfn_pull_back'
   #ipc_density: 'least' #overwrite global value for this device.
-  #body_size_x_min: 2.85
   body_size_x:
     minimum: 3.9
-    nominal: 4.0
     maximum: 4.1
   body_size_y:
     minimum: 3.9
-    nominal: 4.0
     maximum: 4.1
-  # overall_height:
+  overall_height:
     minimum: 1.00
-  #  nominal: 1.0
-  #  maximum: 0.80
   lead_width:
     minimum: 0.30
-    nominal: 0.35
     maximum: 0.40
   lead_len:
-  #  minimum: 0.4
-    nominal: 0.95
-  #  maximum: 0.65
+    minimum: 0.4
+    maximum: 0.65
 
   EP_size_x:
-  #  minimum: 3.35
-    nominal: 1.1
-  #  maximum: 3.45
+    minimum: 2.05
+    maximum: 2.35
   EP_size_y:
-  #  minimum: 4.25
-    nominal: 1.75
-  #  maximum: 4.35
+    minimum: 2.95
+    maximum: 3.25
   # EP_paste_coverage: 0.65
   EP_num_paste_pads: [2, 2]
 

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/hvson8.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/hvson8.yaml
@@ -1,4 +1,4 @@
-HVSON-8-1EP_4x4mm_P0.8mm_E2.2x3.1mm:
+HVSON-8-1EP_4x4mm_P0.8mm_EP2.2x3.1mm:
   device_type: 'HVSON'
   library: Package_SON
   manufacturer: 'NXP'

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/hvson8.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/hvson8.yaml
@@ -1,7 +1,6 @@
 HVSON-8-1EP_4x4mm_P0.8mm_EP2.2x3.1mm:
   device_type: 'HVSON'
   library: Package_SON
-  manufacturer: 'NXP'
   size_source: 'https://www.nxp.com/docs/en/data-sheet/PCF8523.pdf (page 57)'
   ipc_class: 'qfn' #'qfn' | 'qfn_pull_back'
   #ipc_density: 'least' #overwrite global value for this device.

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/hvson8.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/hvson8.yaml
@@ -1,0 +1,44 @@
+HVSON-8-1EP_3.25x2.35mm_P0.8mm_E1.1x1.75mm:
+  device_type: 'HVSON'
+  library: Package_SON
+  #manufacturer: 'NXP'
+  size_source: 'https://www.nxp.com/docs/en/data-sheet/PCF8523.pdf (page 66)'
+  ipc_class: 'qfn_pull_back' #'qfn' | 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  #body_size_x_min: 2.85
+  body_size_x:
+  #  minimum: 5.9
+    nominal: 4.95
+  #  maximum: 6.1
+  body_size_y:
+  #  minimum: 4.9
+    nominal: 3.25
+  #  maximum: 5.1
+  # overall_height:
+  #  minimum: 0.70
+  #  nominal: 0.75
+  #  maximum: 0.80
+  lead_width:
+  #  minimum: 0.35
+    nominal: 0.35
+  #  maximum: 0.48
+  lead_len:
+  #  minimum: 0.55
+    nominal: 0.95
+  #  maximum: 0.65
+
+  EP_size_x:
+  #  minimum: 3.35
+    nominal: 1.1
+  #  maximum: 3.45
+  EP_size_y:
+  #  minimum: 4.25
+    nominal: 1.75
+  #  maximum: 4.35
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 2]
+
+  pitch: 0.8
+  num_pins_x: 0
+  num_pins_y: 4
+


### PR DESCRIPTION
I've taken a copy of another footprint's yaml definitions as a base to start from. As a result there's a lot of comments as I've not got min and max values. I was hoping to create PR to check with CI but looks like that's not possible.

datasheet:https://www.nxp.com/docs/en/data-sheet/PCF8523.pdf

![Screenshot from 2019-04-03 18-32-12](https://user-images.githubusercontent.com/15182161/55500113-82450300-563f-11e9-9152-736eab6df2b3.png)
