### PR TITLE
add SOIC-8 for THS3491

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/soic.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/soic.yaml
@@ -243,6 +243,59 @@ SOIC-8-1EP_3.9x4.9mm_P1.27mm_EP2.41x3.1mm:
     # bottom_pad_size:
     paste_avoid_via: False
 
+SOIC-8-1EP_3.9x4.9mm_P1.27mm_EP2.4x3.1mm:
+  size_source: 'http://www.ti.com/lit/ds/symlink/ths3491.pdf'
+  body_size_x:
+    minimum: 3.8
+    maximum: 4.0
+  body_size_y:
+    minimum: 4.8
+    maximum: 5.0
+  overall_height:
+    maximum: 1.7
+
+  overall_size_x:
+    minimum: 5.8
+    maximum: 6.2
+  lead_len:
+    minimum: 0.4
+    maximum: 1.27
+  lead_width:
+    minimum: 0.31
+    maximum: 0.51
+
+  pitch: 1.27
+  num_pins_x: 0
+  num_pins_y: 4
+
+  EP_size_x:
+    minimum: 1.65
+    maximum: 2.4
+  EP_size_x_overwrite: 2.95
+  EP_mask_x: 2.4
+
+  EP_size_y:
+    minimum: 2.65
+    maximum: 3.1
+  EP_size_y_overwrite: 4.9
+  EP_mask_y: 3.1
+
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 2]
+
+  thermal_vias:
+    count: [2, 3]
+    drill: 0.33
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    EP_num_paste_pads: [2, 2]
+    # paste_between_vias: 1
+    # paste_rings_outside: 1
+    EP_paste_coverage: 0.7
+    grid: [1.3, 1.3]
+    # bottom_pad_size:
+    paste_avoid_via: False
+
 SOIC-8-1EP_3.9x4.9mm_P1.27mm_EP2.41x3.3mm:
   size_source: 'http://www.allegromicro.com/~/media/Files/Datasheets/A4950-Datasheet.ashx#page=8'
   body_size_x:


### PR DESCRIPTION
SOIC-8 variant for THS3491. dimensions from datasheet page 48/53
http://www.ti.com/lit/ds/symlink/ths3491.pdf

kicad-footprints PR https://github.com/KiCad/kicad-footprints/pull/1541