### PR TITLE
Add 3.5x3.5mm QFN-20 with 2mm pad.

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-20.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-20.yaml
@@ -367,6 +367,61 @@ QFN-20-1EP_4x4mm_P0.5mm_EP2.7x2.7mm:
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
 
+QFN-20-1EP_3.5x3.5mm_P0.5mm_EP2x2mm:
+  device_type: 'QFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'http://www.ti.com/lit/ml/mpqf239/mpqf239.pdf'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  # custom_name_format:
+  body_size_x:
+    minimum: 3.35
+    maximum: 3.65
+  body_size_y:
+    minimum: 3.35
+    maximum: 3.65
+  overall_height:
+    minimum: 0.8
+    maximum: 1.0
+
+  lead_width:
+    minimum: 0.18
+    maximum: 0.3
+  lead_len:
+    minimum: 0.3
+    maximum: 0.5
+
+  EP_size_x:
+    nominal: 2
+  EP_size_y:
+    nominal: 2
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 2]
+
+
+  thermal_vias:
+    count: [2, 2]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    #EP_num_paste_pads: [2, 2]
+    paste_between_vias: 2
+    #paste_rings_outside: 1
+    EP_paste_coverage: 0.75
+    #grid: [1, 1]
+    # bottom_pad_size:
+    paste_avoid_via: False
+
+  pitch: 0.5
+  num_pins_x: 5
+  num_pins_y: 5
+  #chamfer_edge_pins: 0.15
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'
+
 MLF-20-1EP_4x4mm_P0.5mm_EP2.6x2.6mm:
   device_type: 'MLF'
   #manufacturer: 'man'


### PR DESCRIPTION
Also known as TI's S-PVQFN-N20

http://www.ti.com/lit/ml/mpqf239/mpqf239.pdf

![qfn-20-doc](https://user-images.githubusercontent.com/171339/55926755-d1d98f00-5c3c-11e9-9f3d-8236f7faf6c2.png)

![qfn-20](https://user-images.githubusercontent.com/171339/55926682-73141580-5c3c-11e9-9d87-7d6dcbd9178e.png)
