### PR TITLE
Added TQFP-48-1EP_7x7mm_P0.5mm_EP3.62x3.62mm

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tqfp.yaml
@@ -53,6 +53,57 @@ TQFP-48-1EP_7x7mm_P0.5mm_EP5.0x5.0mm:
     # bottom_pad_size:
     # paste_avoid_via: True
 
+TQFP-48-1EP_7x7mm_P0.5mm_EP3.62x3.62mm:
+  size_source: 'http://www.ti.com/lit/ml/mpqf051a/mpqf051a.pdf'
+  body_size_x:
+    nominal: 7
+    tolerance: 0
+  body_size_y:
+    nominal: 7
+    tolerance: 0
+  overall_size_x:
+    nominal: 9
+    tolerance: 0
+  overall_size_y:
+    nominal: 9
+    tolerance: 0
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    minimum: 0.45
+    maximum: 0.75
+  pitch: 0.5
+  num_pins_x: 12
+  num_pins_y: 12
+
+  EP_size_x:
+    minimum: 3.52
+    nominal: 3.62
+    maximum: 5.72
+  EP_size_y:
+    minimum: 3.52
+    nominal: 3.62
+    maximum: 5.72
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [4, 4]
+  #heel_reduction: 0.1 #for relatively large EP pads (increase clearance)
+  # EP_size_limit_x: 3.6  #for relatively large EP pads (increase clearance)
+  # EP_size_limit_y: 3.6  #for relatively large EP pads (increase clearance)
+
+  thermal_vias:
+    count: [3, 3]
+    drill: 0.3
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    #paste_between_vias: 1
+    #paste_rings_outside: 1
+    #EP_paste_coverage: 0.65
+    grid: [1, 1]
+    # bottom_pad_size:
+    # paste_avoid_via: True
+
 TQFP_64:
   size_source: 'http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=131095'
   body_size_x:

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tqfp.yaml
@@ -54,18 +54,22 @@ TQFP-48-1EP_7x7mm_P0.5mm_EP5.0x5.0mm:
     # paste_avoid_via: True
 
 TQFP-48-1EP_7x7mm_P0.5mm_EP3.62x3.62mm:
-  size_source: 'http://www.ti.com/lit/ml/mpqf051a/mpqf051a.pdf'
+  size_source: 'http://www.ti.com/lit/ds/symlink/tusb4020bi.pdf#page=42'
   body_size_x:
-    nominal: 7
+    minimum: 6.8
+    maximum: 7.2
     tolerance: 0
   body_size_y:
-    nominal: 7
+    minimum: 6.8
+    maximum: 7.2
     tolerance: 0
   overall_size_x:
-    nominal: 9
+    minimum: 8.8
+    maximum: 9.2
     tolerance: 0
   overall_size_y:
-    nominal: 9
+    minimum: 8.8
+    maximum: 9.2
     tolerance: 0
   lead_width:
     minimum: 0.17
@@ -78,18 +82,11 @@ TQFP-48-1EP_7x7mm_P0.5mm_EP3.62x3.62mm:
   num_pins_y: 12
 
   EP_size_x:
-    minimum: 3.52
     nominal: 3.62
-    maximum: 5.72
   EP_size_y:
-    minimum: 3.52
     nominal: 3.62
-    maximum: 5.72
   # EP_paste_coverage: 0.65
   EP_num_paste_pads: [2, 2]
-  #heel_reduction: 0.1 #for relatively large EP pads (increase clearance)
-  # EP_size_limit_x: 3.6  #for relatively large EP pads (increase clearance)
-  # EP_size_limit_y: 3.6  #for relatively large EP pads (increase clearance)
 
   thermal_vias:
     count: [3, 3]

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tqfp.yaml
@@ -86,7 +86,7 @@ TQFP-48-1EP_7x7mm_P0.5mm_EP3.62x3.62mm:
     nominal: 3.62
     maximum: 5.72
   # EP_paste_coverage: 0.65
-  EP_num_paste_pads: [4, 4]
+  EP_num_paste_pads: [2, 2]
   #heel_reduction: 0.1 #for relatively large EP pads (increase clearance)
   # EP_size_limit_x: 3.6  #for relatively large EP pads (increase clearance)
   # EP_size_limit_y: 3.6  #for relatively large EP pads (increase clearance)
@@ -100,7 +100,7 @@ TQFP-48-1EP_7x7mm_P0.5mm_EP3.62x3.62mm:
     #paste_between_vias: 1
     #paste_rings_outside: 1
     #EP_paste_coverage: 0.65
-    grid: [1, 1]
+    #grid: [1, 1]
     # bottom_pad_size:
     # paste_avoid_via: True
 


### PR DESCRIPTION
Footprint Datasheet: http://www.ti.com/lit/ml/mpqf051a/mpqf051a.pdf
Footprint is used in http://www.ti.com/lit/ds/symlink/tusb4020bi.pdf