### PR TITLE
Add QFN-40 footprint for IS31FL3736/7

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-4x.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-4x.yaml
@@ -1,3 +1,65 @@
+QFN-40-1EP_5x5mm_P0.4mm_EP3.475x3.475mm:
+  device_type: 'QFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'http://www.issi.com/WW/pdf/31FL3736.pdf#page=28'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  # custom_name_format:
+  body_size_x:
+    minimum: 4.9
+    nominal: 5
+    maximum: 5.1
+  body_size_y:
+    minimum: 4.9
+    nominal: 5
+    maximum: 5.1
+  overall_height:
+    minimum: 0.7
+    nominal: 0.75
+    maximum: 0.8
+
+  lead_width:
+    minimum: 0.15
+    nominal: 0.2
+    maximum: 0.25
+  lead_len:
+    minimum: 0.3
+    nominal: 0.4
+    maximum: 0.5
+
+  EP_size_x:
+    minimum: 3.15
+    maximum: 3.8
+  EP_size_y:
+    minimum: 3.15
+    maximum: 3.8
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [3, 3]
+  # heel_reduction: 0.1 #deprecated
+
+  thermal_vias:
+    count: [4, 4]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    #paste_between_vias: 1
+    #paste_rings_outside: 1
+    EP_paste_coverage: 0.6
+    #grid: [1, 1]
+    # bottom_pad_size:
+    # paste_avoid_via: False
+
+  pitch: 0.4
+  num_pins_x: 10
+  num_pins_y: 10
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'
+
 QFN-40-1EP_5x5mm_P0.4mm_EP3.6x3.6mm:
   device_type: 'QFN'
   #manufacturer: 'man'

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-4x.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-4x.yaml
@@ -1,65 +1,3 @@
-QFN-40-1EP_5x5mm_P0.4mm_EP3.475x3.475mm:
-  device_type: 'QFN'
-  #manufacturer: 'man'
-  #part_number: 'mpn'
-  size_source: 'http://www.issi.com/WW/pdf/31FL3736.pdf#page=28'
-  ipc_class: 'qfn' # 'qfn_pull_back'
-  #ipc_density: 'least' #overwrite global value for this device.
-  # custom_name_format:
-  body_size_x:
-    minimum: 4.9
-    nominal: 5
-    maximum: 5.1
-  body_size_y:
-    minimum: 4.9
-    nominal: 5
-    maximum: 5.1
-  overall_height:
-    minimum: 0.7
-    nominal: 0.75
-    maximum: 0.8
-
-  lead_width:
-    minimum: 0.15
-    nominal: 0.2
-    maximum: 0.25
-  lead_len:
-    minimum: 0.3
-    nominal: 0.4
-    maximum: 0.5
-
-  EP_size_x:
-    minimum: 3.15
-    maximum: 3.8
-  EP_size_y:
-    minimum: 3.15
-    maximum: 3.8
-  # EP_paste_coverage: 0.65
-  EP_num_paste_pads: [3, 3]
-  # heel_reduction: 0.1 #deprecated
-
-  thermal_vias:
-    count: [4, 4]
-    drill: 0.2
-    # min_annular_ring: 0.15
-    paste_via_clearance: 0.1
-    # EP_num_paste_pads: [2, 2]
-    #paste_between_vias: 1
-    #paste_rings_outside: 1
-    EP_paste_coverage: 0.6
-    #grid: [1, 1]
-    # bottom_pad_size:
-    # paste_avoid_via: False
-
-  pitch: 0.4
-  num_pins_x: 10
-  num_pins_y: 10
-  #chamfer_edge_pins: 0.25
-  #pin_count_grid:
-  #pad_length_addition: 0.5
-  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
-  #include_suffix_in_3dpath: 'False'
-
 QFN-40-1EP_5x5mm_P0.4mm_EP3.6x3.6mm:
   device_type: 'QFN'
   #manufacturer: 'man'
@@ -94,6 +32,70 @@ QFN-40-1EP_5x5mm_P0.4mm_EP3.6x3.6mm:
   EP_size_y:
     nominal: 3.6
     tolerance: 0
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [3, 3]
+  # heel_reduction: 0.1 #deprecated
+
+  thermal_vias:
+    count: [4, 4]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    #paste_between_vias: 1
+    #paste_rings_outside: 1
+    EP_paste_coverage: 0.6
+    #grid: [1, 1]
+    # bottom_pad_size:
+    # paste_avoid_via: False
+
+  pitch: 0.4
+  num_pins_x: 10
+  num_pins_y: 10
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'
+
+QFN-40-1EP_5x5mm_P0.4mm_EP3.8x3.8mm:
+  device_type: 'QFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'http://www.issi.com/WW/pdf/31FL3736.pdf#page=28'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  # custom_name_format:
+  body_size_x:
+    minimum: 4.9
+    nominal: 5
+    maximum: 5.1
+  body_size_y:
+    minimum: 4.9
+    nominal: 5
+    maximum: 5.1
+  overall_height:
+    minimum: 0.7
+    nominal: 0.75
+    maximum: 0.8
+
+  lead_width:
+    minimum: 0.15
+    nominal: 0.2
+    maximum: 0.25
+  lead_len:
+    minimum: 0.3
+    nominal: 0.4
+    maximum: 0.5
+
+  EP_size_x:
+    minimum: 3.15
+    maximum: 3.8
+  EP_size_x_overwrite: 3.8
+  EP_size_y:
+    minimum: 3.15
+    maximum: 3.8
+  EP_size_y_overwrite: 3.8
   # EP_paste_coverage: 0.65
   EP_num_paste_pads: [3, 3]
   # heel_reduction: 0.1 #deprecated


### PR DESCRIPTION
![fp](https://user-images.githubusercontent.com/4781841/58840971-30564300-86ab-11e9-8bed-8a7a126a7739.png)

Datasheet: http://www.issi.com/WW/pdf/31FL3736.pdf#page=28
Footprint: https://github.com/KiCad/kicad-footprints/pull/1625

The drawing shows chamfered corner pins, but note 5 seems to say the shape ("sharp") differs depending on the factory, so I left that out.