### PR TITLE
Allow custom numbering scheme in PadArray and QFN scripts

### DIFF
--- a/KicadModTree/nodes/specialized/PadArray.py
+++ b/KicadModTree/nodes/specialized/PadArray.py
@@ -16,6 +16,7 @@
 # (C) 2017 by @SchrodingersGat
 # (C) 2017 by Thomas Pointhuber, <thomas.pointhuber@gmx.at>
 
+from types import GeneratorType
 from KicadModTree.nodes.base.Pad import *
 from KicadModTree.nodes.specialized.ChamferedPad import *
 from KicadModTree.nodes.Node import Node
@@ -208,8 +209,10 @@ class PadArray(Node):
             pad_numbers = [self.initialPin]
             for idx in range(1, self.pincount):
                 pad_numbers.append(self.increment(pad_numbers[-1]))
+        elif type(self.increment) == GeneratorType:
+            pad_numbers = [next(self.increment) for i in range(self.pincount)]
         else:
-            raise TypeError("Wrong type for increment. It must be either a int or callable.")
+            raise TypeError("Wrong type for increment. It must be either a int, callable or generator.")
 
         end_pad_params = copy(kwargs)
         if kwargs.get('end_pads_size_reduction'):

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/ipc_noLead_generator.py
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/ipc_noLead_generator.py
@@ -326,13 +326,14 @@ class NoLead():
             pad_shape_details['maximum_radius'] = configuration['round_rect_max_radius']
 
         if device_dimensions['has_EP']:
+            ep_pad_number = device_params.get('EP_pin_number', pincount+1)
             if with_thermal_vias:
                 thermals = device_params['thermal_vias']
                 paste_coverage = thermals.get('EP_paste_coverage',
                                                device_params.get('EP_paste_coverage', DEFAULT_PASTE_COVERAGE))
 
                 kicad_mod.append(ExposedPad(
-                    number=pincount+1, size=EP_size,
+                    number=ep_pad_number, size=EP_size,
                     at=EP_center,
                     paste_layout=thermals.get('EP_num_paste_pads', device_params.get('EP_num_paste_pads', 1)),
                     paste_coverage=paste_coverage,
@@ -350,7 +351,7 @@ class NoLead():
                     ))
             else:
                 kicad_mod.append(ExposedPad(
-                    number=pincount+1, size=EP_size,
+                    number=ep_pad_number, size=EP_size,
                     at=EP_center,
                     paste_layout=device_params.get('EP_num_paste_pads', 1),
                     paste_coverage=device_params.get('EP_paste_coverage', DEFAULT_PASTE_COVERAGE),

--- a/scripts/tools/pad_number_generators.py
+++ b/scripts/tools/pad_number_generators.py
@@ -1,0 +1,160 @@
+"""
+Pad number generator functions.
+
+Some ICs have a non-standard pin numbering scheme.
+Using the generators an iterable is generated following the scheme.
+
+Available generators:
+----------------------
+- increment: Is a simple generator that increments the pin number by one.
+- cw_dual: Generates pin numbers counting clockwise from the starting position
+- ccw_dual: Generates pin numbers counting counter-clockwise from the starting position
+
+Examples:
+---------
+To use a generator add the following to the device config:
+
+  pad_numbers:
+    generator: 'ccw_dual'
+    axis: 'x'
+
+"""
+
+
+def increment(pincount, init=1, **kwargs):
+    i = init
+    while i <= pincount:
+        yield i
+        i += 1
+
+
+def _get_pin_cw(pincount, loc):
+    """Helper function to locate pin number for cw_dual.
+
+    Args:
+        pincount: Total number of pins
+        loc: Starting location
+
+    Returns:
+        pin_number: Starting pin number
+    """
+    pins_per_side = pincount // 2
+    if loc == "top_left":
+        return 0
+    elif loc == "bottom_left":
+        return pins_per_side * 2 + 1
+    elif loc == "bottom_right":
+        return pins_per_side
+    elif loc == "top_right":
+        return pins_per_side + 1
+    return 0
+
+
+def _get_pin_ccw(pincount, loc):
+    """Helper function to locate pin number for ccw_dual.
+
+        Args:
+            pincount: Total number of pins
+            loc: Starting location
+
+        Returns:
+            pin_number: Starting pin number
+    """
+    pins_per_side = pincount // 2
+    if loc == "top_left":
+        return 0
+    elif loc == "bottom_left":
+        return pins_per_side + 1
+    elif loc == "bottom_right":
+        return pins_per_side
+    elif loc == "top_right":
+        return pins_per_side * 2 + 1
+    return 0
+
+
+def clockwise_dual(pincount, init=1, start="top_left", axis="x", **kwargs):
+    """Generator for dual row packages counting clockwise.
+
+    Args:
+        pincount: Total number of pins
+        init: Initial starting count (default: 1)
+        start: The starting corner, top/bottom - left/right
+        axis: Pin axis, either x or y. Is depended on num_pins_{x,y}
+        **kwargs: Other keyword arguments
+
+    Returns:
+        Iterator
+    """
+    i = _get_pin_cw(pincount, start)
+
+    if axis == "y":
+        pins = iter(range(pincount, 0, -1))
+    else:
+        pins = iter(range(pincount))
+
+    for ind in pins:
+        yield ((i + ind) % pincount) + init
+
+
+def counter_clockwise_dual(pincount, init=1, start="top_left", axis="x", **kwargs):
+    """Generator for dual row packages counting counter clockwise.
+
+     Args:
+         pincount: Total number of pins
+         init: Initial starting count (default: 1)
+         start: The starting corner, top/bottom - left/right
+         axis: Pin axis, either x or y. Is depended on num_pins_{x,y}
+         **kwargs: Other keyword arguments
+
+     Returns:
+         Iterator
+     """
+    i = _get_pin_ccw(pincount, start)
+
+    if axis == "x":
+        pins = iter(range(pincount, 0, -1))
+    else:
+        pins = iter(range(pincount))
+
+    for ind in pins:
+        yield ((i + ind) % pincount) + init
+
+
+# Add available generators to the dictionary
+generators = {
+    "increment": increment,
+    "cw_dual": clockwise_dual,
+    "ccw_dual": counter_clockwise_dual,
+}
+
+
+def get_generator(device_params):
+    """Returns a pad number iterator based on device_params and selected generator.
+    Fallback to plain increment.
+
+    Args:
+        device_params: Device parameters dictionary 
+
+    Returns:
+        Pad number iterator
+
+    Raises:
+        KeyError: If generator not available
+    """
+    # Fallback to plain increment
+    pincount = device_params["num_pins_x"] * 2 + device_params["num_pins_y"] * 2
+    pad_nums = device_params.get("pad_numbers")
+
+    if not pad_nums:
+        return generators["increment"](pincount)
+
+    init = pad_nums.get("init", 1)
+
+    gen = generators.get(pad_nums.get("generator"))
+    if not gen:
+        gens = ", ".join(generators.keys())
+        pad_generator = pad_nums.get("generator")
+        raise KeyError("{}: Use one of [{}]".format(pad_generator, gens))
+
+    iterator = gen(pincount, init, **pad_nums)
+    return iterator

--- a/scripts/tools/quad_dual_pad_border.py
+++ b/scripts/tools/quad_dual_pad_border.py
@@ -3,7 +3,7 @@ from __future__ import division
 import sys, os
 sys.path.append(os.path.join(sys.path[0],"..","..")) # load kicad_mod path
 from KicadModTree import *  # NOQA
-
+from pad_number_generators import get_generator
 
 def add_dual_or_quad_pad_border(kicad_mod, configuration, pad_details, device_params):
     pad_shape_details = {}
@@ -29,13 +29,17 @@ def add_dual_or_quad_pad_border(kicad_mod, configuration, pad_details, device_pa
 
 def add_dual_pad_border_y(kicad_mod, pad_details, device_params, pad_shape_details):
     init = 1
+    increment = get_generator(device_params)
+
     pa = PadArray(
             initial= init,
             type=Pad.TYPE_SMT,
             layers=Pad.LAYERS_SMT,
             pincount=device_params['num_pins_y'],
             x_spacing=0, y_spacing=device_params['pitch'],
-            **pad_details['left'], **pad_shape_details)
+            increment=increment,
+            **pad_details['left'], **pad_shape_details,
+            )
     kicad_mod.append(pa)
     init += device_params['num_pins_y']
     kicad_mod.append(PadArray(
@@ -44,7 +48,10 @@ def add_dual_pad_border_y(kicad_mod, pad_details, device_params, pad_shape_detai
         layers=Pad.LAYERS_SMT,
         pincount=device_params['num_pins_y'],
         x_spacing=0, y_spacing=-device_params['pitch'],
-        **pad_details['right'], **pad_shape_details))
+        increment=increment,
+        **pad_details['right'], **pad_shape_details,
+        )
+    )
 
     pads = pa.getVirtualChilds()
     pad = pads[0]
@@ -54,13 +61,17 @@ def add_dual_pad_border_y(kicad_mod, pad_details, device_params, pad_shape_detai
 def add_dual_pad_border_x(kicad_mod, pad_details, device_params, pad_shape_details):
     #for devices with clockwise numbering
     init = 1
+    increment = get_generator(device_params)
+
     pa = PadArray(
             initial= init,
             type=Pad.TYPE_SMT,
             layers=Pad.LAYERS_SMT,
             pincount=device_params['num_pins_x'],
             y_spacing=0, x_spacing=device_params['pitch'],
-            **pad_details['top'], **pad_shape_details)
+            increment=increment,
+            **pad_details['top'], **pad_shape_details,
+    )
     kicad_mod.append(pa)
     init += device_params['num_pins_x']
     kicad_mod.append(PadArray(
@@ -69,7 +80,10 @@ def add_dual_pad_border_x(kicad_mod, pad_details, device_params, pad_shape_detai
         layers=Pad.LAYERS_SMT,
         pincount=device_params['num_pins_x'],
         y_spacing=0, x_spacing=-device_params['pitch'],
-        **pad_details['bottom'], **pad_shape_details))
+        increment=increment,
+        **pad_details['bottom'], **pad_shape_details,
+        )
+    )
 
     pads = pa.getVirtualChilds()
     pad = pads[0]
@@ -89,6 +103,7 @@ def add_quad_pad_border(kicad_mod, pad_details, device_params, pad_shape_details
     corner_first = CornerSelection({CornerSelection.TOP_RIGHT: True})
     corner_last = CornerSelection({CornerSelection.BOTTOM_RIGHT: True})
     pad_size_reduction = {'x+': pad_size_red} if pad_size_red > 0 else None
+    increment = get_generator(device_params)
 
     pa = PadArray(
             initial= init,
@@ -100,7 +115,9 @@ def add_quad_pad_border(kicad_mod, pad_details, device_params, pad_shape_details
             chamfer_corner_selection_first=corner_first,
             chamfer_corner_selection_last=corner_last,
             end_pads_size_reduction = pad_size_reduction,
-            **pad_details['left'], **pad_shape_details)
+            increment=increment,
+            **pad_details['left'], **pad_shape_details,
+            )
     kicad_mod.append(pa)
 
     init += device_params['num_pins_y']
@@ -118,7 +135,10 @@ def add_quad_pad_border(kicad_mod, pad_details, device_params, pad_shape_details
         chamfer_corner_selection_first=corner_first,
         chamfer_corner_selection_last=corner_last,
         end_pads_size_reduction = pad_size_reduction,
-        **pad_details['bottom'], **pad_shape_details))
+        increment=increment,
+        **pad_details['bottom'], **pad_shape_details,
+        )
+    )
 
     init += device_params['num_pins_x']
     corner_first = copy(corner_first).rotateCCW()
@@ -135,7 +155,10 @@ def add_quad_pad_border(kicad_mod, pad_details, device_params, pad_shape_details
         chamfer_corner_selection_first=corner_first,
         chamfer_corner_selection_last=corner_last,
         end_pads_size_reduction = pad_size_reduction,
-        **pad_details['right'], **pad_shape_details))
+        increment=increment,
+        **pad_details['right'], **pad_shape_details,
+        )
+    )
 
     init += device_params['num_pins_y']
     corner_first = copy(corner_first).rotateCCW()
@@ -152,7 +175,10 @@ def add_quad_pad_border(kicad_mod, pad_details, device_params, pad_shape_details
         chamfer_corner_selection_first=corner_first,
         chamfer_corner_selection_last=corner_last,
         end_pads_size_reduction = pad_size_reduction,
-        **pad_details['top'], **pad_shape_details))
+        increment=increment,
+        **pad_details['top'], **pad_shape_details,
+        )
+    )
 
     pads = pa.getVirtualChilds()
     pad = pads[0]


### PR DESCRIPTION
Custom pin numbers for the pad array can be passed to PadArray
as a list through the keyword argument `pad_numbers`.
This bypasses the increment functionality.

Additonally, add the ability to define custom pin numbers per side on a QFN
package, as some packages use a non-standard numbering scheme.

This is needed for KiCad/kicad-footprints#1553 and it seems that there is also related issues (#323, #280) 

As an example, here is the definition from the pull request mentioned above using the changes I suggest. Notice the `EP_pin_number` for the exposed pad and `pad_numbers_{top,right,left,bottom}`

```yaml
Texas_X2SON-4-1EP_1.1x1.4mm_P0.5mm_EP0.8x0.6mm:
  device_type: 'X2SON'
  library: Package_SON
  manufacturer: 'Texas'
  #part_number: 'mpn'
  size_source: 'http://www.ti.com/lit/ds/symlink/drv5032.pdf#page=28'
  ipc_class: 'qfn' #'qfn' | 'qfn_pull_back'
  #ipc_density: 'least' #overwrite global value for this device. (if used, pad values are closer to TI's suggested fp)

  body_size_x:
    minimum: 1.05
    maximum: 1.15
  body_size_y:
    minimum: 1.35
    maximum: 1.45
  overall_height:
    maximum: 0.4

  lead_width:
    minimum: 0.17
    maximum: 0.27
  lead_len:
    minimum: 0.15
    maximum: 0.25

  EP_size_x:
    nominal: 0.8
    tolerance: 0.05
  EP_size_y:
    nominal: 0.6
    tolerance: 0.05
  # EP_paste_coverage: 0.65
  EP_num_paste_pads: 1 #[2, 2]
  EP_pin_number: 5

  pitch: 0.5
  num_pins_x: 2
  num_pins_y: 0
  #include_suffix_in_3dpath: 'False'
  #include_pad_size: 'fp_name_only' # 'both' | 'none' (default)

  pad_numbers_top: [1, 4] # left to right
  #pad_numbers_right: [5, 6] # top to bottom
  pad_numbers_bottom: [2, 3] # left to right
  #pad_numbers_left: [8, 7] # top to bottom

  thermal_vias:
    count: 1
    drill: 0.2
    # min_annular_ring: 0.15
    paste_via_clearance: 0.1
    EP_num_paste_pads: 1 # [2, 2]
    EP_paste_coverage: 0.75
    grid: [1, 1]
    paste_avoid_via: False
```
And the resulting footprint:

![DMR004A_script_fp3](https://user-images.githubusercontent.com/49786134/59103347-84209080-8926-11e9-91b8-f1753a7e0cb3.png)

Edit: Add related issue