### PR TITLE
Add script for Microchip TFBGA, 14 x 14 196 pin, 11 x 11mm package, 0.75 mm pitch, 0.32 mm ball diameter

### DIFF
--- a/scripts/Packages/Package_BGA/bga.yaml
+++ b/scripts/Packages/Package_BGA/bga.yaml
@@ -128,7 +128,7 @@ TFBGA-196_11x11mm_Layout14x14_P0.75mm_Ball0.32mm_Pad0.35mm_SMD:
   overall_height: 1.20
   pitch: 0.75
   pad_diameter: 0.35
-  mask_margin: 0.0375
+  mask_margin: -0.0375
   paste_margin: 0.000001
   layout_x: 14
   layout_y: 14

--- a/scripts/Packages/Package_BGA/bga.yaml
+++ b/scripts/Packages/Package_BGA/bga.yaml
@@ -120,7 +120,7 @@ TFBGA-121_10x10mm_Layout11x11_P0.8mm:
   paste_margin: 0.000001
   layout_x: 11
   layout_y: 11
-TFBGA-196_11.0x11.0mm_Layout14x14_P0.75mm_Ball0.32mm_Pad0.35mm_SMD:
+TFBGA-196_11x11mm_Layout14x14_P0.75mm_Ball0.32mm_Pad0.35mm_SMD:
   description: "TFBGA-196"
   size_source: "http://ww1.microchip.com/downloads/en/devicedoc/ds60001476b.pdf#page=2536"
   body_size_x: 11.0

--- a/scripts/Packages/Package_BGA/bga.yaml
+++ b/scripts/Packages/Package_BGA/bga.yaml
@@ -120,7 +120,7 @@ TFBGA-121_10x10mm_Layout11x11_P0.8mm:
   paste_margin: 0.000001
   layout_x: 11
   layout_y: 11
-Microchip_TFBGA-196_11x11mm_Layout14x14_P0.75mm_Pad0.35mm_SMD:
+Microchip_TFBGA-196_11x11mm_Layout14x14_P0.75mm_SMD:
   description: "TFBGA-196"
   size_source: "http://ww1.microchip.com/downloads/en/DeviceDoc/SAMA5D2-Series-Data-Sheet-DS60001476C.pdf#page=2956"
   body_size_x: 11.0

--- a/scripts/Packages/Package_BGA/bga.yaml
+++ b/scripts/Packages/Package_BGA/bga.yaml
@@ -125,6 +125,7 @@ TFBGA-196_11.0x11.0mm_Layout14x14_P0.75mm_Ball0.32mm_Pad0.35mm_SMD:
   size_source: "http://ww1.microchip.com/downloads/en/devicedoc/ds60001476b.pdf#page=2536"
   body_size_x: 11.0
   body_size_y: 11.0
+  overall_height: 1.20
   pitch: 0.75
   pad_diameter: 0.35
   mask_margin: 0.0375

--- a/scripts/Packages/Package_BGA/bga.yaml
+++ b/scripts/Packages/Package_BGA/bga.yaml
@@ -120,7 +120,7 @@ TFBGA-121_10x10mm_Layout11x11_P0.8mm:
   paste_margin: 0.000001
   layout_x: 11
   layout_y: 11
-TFBGA-196_11x11mm_Layout14x14_P0.75mm_Ball0.32mm_Pad0.35mm_SMD:
+TFBGA-196_11x11mm_Layout14x14_P0.75mm_Pad0.35mm_SMD:
   description: "TFBGA-196"
   size_source: "http://ww1.microchip.com/downloads/en/devicedoc/ds60001476b.pdf#page=2536"
   body_size_x: 11.0

--- a/scripts/Packages/Package_BGA/bga.yaml
+++ b/scripts/Packages/Package_BGA/bga.yaml
@@ -120,6 +120,17 @@ TFBGA-121_10x10mm_Layout11x11_P0.8mm:
   paste_margin: 0.000001
   layout_x: 11
   layout_y: 11
+TFBGA-196_11.0x11.0mm_Layout14x14_P0.75mm_Ball0.32mm_Pad0.35mm_SMD:
+  description: "TFBGA-196"
+  size_source: "http://ww1.microchip.com/downloads/en/devicedoc/ds60001476b.pdf#page=2536"
+  body_size_x: 11.0
+  body_size_y: 11.0
+  pitch: 0.75
+  pad_diameter: 0.35
+  mask_margin: 0.0375
+  paste_margin: 0.000001
+  layout_x: 14
+  layout_y: 14
 TFBGA-216_13x13mm_Layout15x15_P0.8mm:
   description: "TFBGA-216"
   size_source: "http://www.st.com/resource/en/datasheet/stm32f746zg.pdf#page=219"

--- a/scripts/Packages/Package_BGA/bga.yaml
+++ b/scripts/Packages/Package_BGA/bga.yaml
@@ -122,7 +122,7 @@ TFBGA-121_10x10mm_Layout11x11_P0.8mm:
   layout_y: 11
 TFBGA-196_11x11mm_Layout14x14_P0.75mm_Pad0.35mm_SMD:
   description: "TFBGA-196"
-  size_source: "http://ww1.microchip.com/downloads/en/devicedoc/ds60001476b.pdf#page=2536"
+  size_source: "http://ww1.microchip.com/downloads/en/DeviceDoc/SAMA5D2-Series-Data-Sheet-DS60001476C.pdf#page=2956"
   body_size_x: 11.0
   body_size_y: 11.0
   overall_height: 1.20

--- a/scripts/Packages/Package_BGA/bga.yaml
+++ b/scripts/Packages/Package_BGA/bga.yaml
@@ -120,7 +120,7 @@ TFBGA-121_10x10mm_Layout11x11_P0.8mm:
   paste_margin: 0.000001
   layout_x: 11
   layout_y: 11
-TFBGA-196_11x11mm_Layout14x14_P0.75mm_Pad0.35mm_SMD:
+Microchip_TFBGA-196_11x11mm_Layout14x14_P0.75mm_Pad0.35mm_SMD:
   description: "TFBGA-196"
   size_source: "http://ww1.microchip.com/downloads/en/DeviceDoc/SAMA5D2-Series-Data-Sheet-DS60001476C.pdf#page=2956"
   body_size_x: 11.0


### PR DESCRIPTION
[Associated symbol PR](https://github.com/KiCad/kicad-symbols/pull/1866)
[Associated footprint PR](https://github.com/KiCad/kicad-footprints/pull/1604)
[Associated abandoned PR that I screwed up because I don't know how to use git, apparently](https://github.com/pointhi/kicad-footprint-generator/pull/364)

Screencap showing pad diameter:
![TFBGA-196_pad_diameter](https://user-images.githubusercontent.com/12487802/59554598-06cece80-8f6b-11e9-9144-0c96f748da79.png)

Screencap showing mask diameter. KiCad's measurement tool rounded off the decimals; it is 0.275 mm:
![TFBGA-196_mask_diameter](https://user-images.githubusercontent.com/12487802/59554602-0cc4af80-8f6b-11e9-8796-91a6f6d3924b.png)

@evanshultz https://github.com/pointhi/kicad-footprint-generator/pull/364#discussion_r292211562
> Add "#page=2956" onto the end of the link to just right to this package's page

Done!

@evanshultz https://github.com/pointhi/kicad-footprint-generator/pull/364#discussion_r292211787
> The ball diameter does not need to be specified, I don't think. What was the reason to add it?

Microchip's ball diameter/pad diameter pairing diverges from IPC recommendations. If you think it is not necessary, I will remove the text. See IPC chart in [this engineering stackexchange post](https://electronics.stackexchange.com/a/165241).

@evanshultz https://github.com/pointhi/kicad-footprint-generator/pull/364#issuecomment-500614143
> Also, would you please add the package height of 1.2mm

Done!

@evanshultz https://github.com/pointhi/kicad-footprint-generator/pull/364#issuecomment-500614143
> I made a couple comments inline.

I think those comments are lost because I screwed up that PR. I'm sorry.