### PR TITLE
add Texas_S_ PVQFN_N-16_EP2.1x2.1mm footprint

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn_texas.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn_texas.yaml
@@ -1096,14 +1096,14 @@ Texas_VQFN_RGE0024C:
     # grid:
     # bottom_pad_size:
     paste_avoid_via: False
-Texas_S-PVQFN-N16_EP2.1mmx2.1mm:
+Texas_RGV_S-PVQFN-N16_EP2.1x2.1mm:
   device_type: 'QFN'
   #manufacturer: 'man'
   #part_number: 'mpn'
   size_source: 'http://www.ti.com/lit/ds/symlink/ina3221.pdf#page=44'
   ipc_class: 'qfn' # 'qfn_pull_back'
   #ipc_density: 'least' #overwrite global value for this device.
-  custom_name_format: 'Texas_S-PVQFN-N{pincount}_EP{ep_size_x:g}x{ep_size_y:g}mm{vias:s}'
+  custom_name_format: 'Texas_RGV_S-PVQFN-N{pincount}_EP{ep_size_x:g}x{ep_size_y:g}mm{vias:s}'
   body_size_x:
     minimum: 3.9
     maximum: 4.1
@@ -1149,56 +1149,3 @@ Texas_S-PVQFN-N16_EP2.1mmx2.1mm:
   #pad_length_addition: 0.5
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
-Texas_S-PVQFN-N16_EP2.1mmx2.1mm:
-  device_type: 'QFN'
-  #manufacturer: 'man'
-  #part_number: 'mpn'
-  size_source: 'http://www.ti.com/lit/ds/symlink/ina3221.pdf#page=44'
-  ipc_class: 'qfn' # 'qfn_pull_back'
-  #ipc_density: 'least' #overwrite global value for this device.
-  custom_name_format: 'Texas_S-PVQFN-N{pincount}_EP{ep_size_x:g}x{ep_size_y:g}mm{vias:s}'
-  body_size_x:
-    minimum: 3.85
-    maximum: 4.15
-  body_size_y:
-    minimum: 3.85
-    maximum: 4.15
-  overall_height:
-    minimum: 0.8
-    maximum: 1.0
-
-  lead_width:
-    minimum: 0.23
-    maximum: 0.38
-  lead_len:
-    minimum: 0.45
-    maximum: 0.65
-
-  EP_size_x:
-    nominal: 2.1
-    tolerance: 0.1
-  EP_size_y:
-    nominal: 2.1
-    tolerance: 0.1
-  # EP_paste_coverage: 0.65
-  EP_num_paste_pads: [3, 3]
-
-  thermal_vias:
-    count: [3, 3]
-    drill: 0.2
-    # min_annular_ring: 0.15
-    paste_via_clearance: 0.1
-    # EP_num_paste_pads: [2, 2]
-    EP_paste_coverage: 0.5
-    # grid:
-    # bottom_pad_size:
-    # paste_avoid_via: True
-
-  pitch: 0.65
-  num_pins_x: 4
-  num_pins_y: 4
-  #chamfer_edge_pins: 0.25
-  #pin_count_grid:
-  #pad_length_addition: 0.5
-  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
-  #include_suffix_in_3dpath: 'False'      

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn_texas.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn_texas.yaml
@@ -1136,10 +1136,10 @@ Texas_RGV_S-PVQFN-N16_EP2.1x2.1mm:
     # min_annular_ring: 0.15
     paste_via_clearance: 0.1
     # EP_num_paste_pads: [2, 2]
-    EP_paste_coverage: 0.5
+    EP_paste_coverage: 0.75
     # grid:
     # bottom_pad_size:
-    # paste_avoid_via: True
+    paste_avoid_via: False
 
   pitch: 0.65
   num_pins_x: 4

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn_texas.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn_texas.yaml
@@ -1105,11 +1105,11 @@ Texas_RGV_S-PVQFN-N16_EP2.1x2.1mm:
   #ipc_density: 'least' #overwrite global value for this device.
   custom_name_format: 'Texas_RGV_S-PVQFN-N{pincount}_EP{ep_size_x:g}x{ep_size_y:g}mm{vias:s}'
   body_size_x:
-    minimum: 3.9
-    maximum: 4.1
+    minimum: 3.85
+    maximum: 4.15
   body_size_y:
-    minimum: 3.9
-    maximum: 4.1
+    minimum: 3.85
+    maximum: 4.15
   overall_height:
     minimum: 0.8
     maximum: 1.0
@@ -1118,8 +1118,8 @@ Texas_RGV_S-PVQFN-N16_EP2.1x2.1mm:
     minimum: 0.23
     maximum: 0.38
   lead_len:
-    minimum: 0.3
-    maximum: 0.5
+    minimum: 0.45
+    maximum: 0.65
 
   EP_size_x:
     nominal: 2.1
@@ -1128,7 +1128,7 @@ Texas_RGV_S-PVQFN-N16_EP2.1x2.1mm:
     nominal: 2.1
     tolerance: 0.1
   # EP_paste_coverage: 0.65
-  EP_num_paste_pads: [3, 3]
+  EP_num_paste_pads: [2, 2]
 
   thermal_vias:
     count: [3, 3]

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn_texas.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn_texas.yaml
@@ -1096,3 +1096,109 @@ Texas_VQFN_RGE0024C:
     # grid:
     # bottom_pad_size:
     paste_avoid_via: False
+Texas_S-PVQFN-N16_EP2.1mmx2.1mm:
+  device_type: 'QFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'http://www.ti.com/lit/ds/symlink/ina3221.pdf#page=44'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  custom_name_format: 'Texas_S-PVQFN-N{pincount}_EP{ep_size_x:g}x{ep_size_y:g}mm{vias:s}'
+  body_size_x:
+    minimum: 3.9
+    maximum: 4.1
+  body_size_y:
+    minimum: 3.9
+    maximum: 4.1
+  overall_height:
+    minimum: 0.8
+    maximum: 1.0
+
+  lead_width:
+    minimum: 0.23
+    maximum: 0.38
+  lead_len:
+    minimum: 0.3
+    maximum: 0.5
+
+  EP_size_x:
+    nominal: 2.1
+    tolerance: 0.1
+  EP_size_y:
+    nominal: 2.1
+    tolerance: 0.1
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [3, 3]
+
+  thermal_vias:
+    count: [3, 3]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    EP_paste_coverage: 0.5
+    # grid:
+    # bottom_pad_size:
+    # paste_avoid_via: True
+
+  pitch: 0.65
+  num_pins_x: 4
+  num_pins_y: 4
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'
+Texas_S-PVQFN-N16_EP2.1mmx2.1mm:
+  device_type: 'QFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'http://www.ti.com/lit/ds/symlink/ina3221.pdf#page=44'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  custom_name_format: 'Texas_S-PVQFN-N{pincount}_EP{ep_size_x:g}x{ep_size_y:g}mm{vias:s}'
+  body_size_x:
+    minimum: 3.85
+    maximum: 4.15
+  body_size_y:
+    minimum: 3.85
+    maximum: 4.15
+  overall_height:
+    minimum: 0.8
+    maximum: 1.0
+
+  lead_width:
+    minimum: 0.23
+    maximum: 0.38
+  lead_len:
+    minimum: 0.45
+    maximum: 0.65
+
+  EP_size_x:
+    nominal: 2.1
+    tolerance: 0.1
+  EP_size_y:
+    nominal: 2.1
+    tolerance: 0.1
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [3, 3]
+
+  thermal_vias:
+    count: [3, 3]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    # EP_num_paste_pads: [2, 2]
+    EP_paste_coverage: 0.5
+    # grid:
+    # bottom_pad_size:
+    # paste_avoid_via: True
+
+  pitch: 0.65
+  num_pins_x: 4
+  num_pins_y: 4
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'      


### PR DESCRIPTION
Added Texas_RGV_S_ PVQFN_N-16_EP2.1x2.1mm footprint for INA3221.
Symbol-PR: https://github.com/KiCad/kicad-symbols/pull/1343
Footprint-PR: https://github.com/KiCad/kicad-footprints/pull/1641