### PR TITLE
add LFCSP-20-1EP-4x4mm_P0.5mm_EP2.6x2.6mm

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
@@ -180,7 +180,7 @@ LFCSP-20-1EP_4x4mm_P0.5mm_EP2.6x2.6mm:
     EP_num_paste_pads: [2, 2]
     #paste_between_vias: 1
     #paste_rings_outside: 1
-    EP_paste_coverage: 0.75
+    EP_paste_coverage: 0.70
     #grid: [1, 1]
     # bottom_pad_size:
     paste_avoid_via: False

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
@@ -10,11 +10,11 @@ LFCSP-16-1EP_3x3mm_P0.5mm_EP1.6x1.6mm:
   body_size_x:
     minimum: 2.9
     nominal: 3
-    minimum: 3.1
+    maximum: 3.1
   body_size_y:
     minimum: 2.9
     nominal: 3
-    minimum: 3.1
+    maximum: 3.1
   body_height:
     minimum: 0.7
     nominal: 0.75
@@ -75,11 +75,11 @@ LFCSP-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm:
   body_size_x:
     minimum: 2.9
     nominal: 3
-    minimum: 3.1
+    maximum: 3.1
   body_size_y:
     minimum: 2.9
     nominal: 3
-    minimum: 3.1
+    maximum: 3.1
   body_height:
     minimum: 0.75
     nominal: 0.85
@@ -141,11 +141,11 @@ LFCSP-20-1EP_4x4mm_P0.5mm_EP2.6x2.6mm:
   body_size_x:
     minimum: 3.9
     nominal: 4
-    minimum: 4.1
+    maximum: 4.1
   body_size_y:
     minimum: 3.9
     nominal: 4
-    minimum: 4.1
+    maximum: 4.1
   body_height:
     minimum: 0.70
     nominal: 0.75

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/lfcsp.yaml
@@ -128,6 +128,73 @@ LFCSP-16-1EP_3x3mm_P0.5mm_EP1.7x1.7mm:
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
 
+
+LFCSP-20-1EP_4x4mm_P0.5mm_EP2.6x2.6mm:
+  device_type: 'LFCSP'
+  library: Package_CSP
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'https://www.analog.com/media/en/package-pcb-resources/package/pkg_pdf/lfcspcp/cp-20/CP_20_8.pdf'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  # custom_name_format:
+  body_size_x:
+    minimum: 3.9
+    nominal: 4
+    minimum: 4.1
+  body_size_y:
+    minimum: 3.9
+    nominal: 4
+    minimum: 4.1
+  body_height:
+    minimum: 0.70
+    nominal: 0.75
+    maximum: 0.80
+
+  lead_width:
+    maximum: 0.30
+    nominal: 0.25
+    minimum: 0.18
+  lead_len:
+    maximum: 0.50
+    nominal: 0.40
+    minimum: 0.30
+
+  EP_size_x:
+    maximum: 2.75
+    nominal: 2.60
+    minimum: 2.35
+  EP_size_y:
+    maximum: 2.75
+    nominal: 2.60
+    minimum: 2.35
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 2]
+  #heel_reduction: 0.05 #for relatively large EP pads (increase clearance)
+
+  thermal_vias:
+    count: [3, 3]
+    drill: 0.3
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    EP_num_paste_pads: [2, 2]
+    #paste_between_vias: 1
+    #paste_rings_outside: 1
+    EP_paste_coverage: 0.75
+    #grid: [1, 1]
+    # bottom_pad_size:
+    paste_avoid_via: False
+
+  pitch: 0.5
+  num_pins_x: 5
+  num_pins_y: 5
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'
+
+
 LFCSP-64-1EP_9x9mm_P0.5mm_EP5.21x5.21mm:
   device_type: 'LFCSP'
   library: Package_CSP


### PR DESCRIPTION
This adds the size definition for another LFCSP footprint from Analog. In their naming it is CP-20-8 ([Datasheet](https://www.analog.com/media/en/package-pcb-resources/package/pkg_pdf/lfcspcp/cp-20/CP_20_8.pdf))