### PR TITLE
Fix Wago 236 naming, drill diameters, differentiate between 1 and 2 pin

### DIFF
--- a/scripts/TerminalBlock_WAGO/make_TerminalBlock_WAGO.py
+++ b/scripts/TerminalBlock_WAGO/make_TerminalBlock_WAGO.py
@@ -121,15 +121,12 @@ if __name__ == '__main__':
                                   nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
                                   tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
 
-   
 
-
-    
-    pins=[1,2,3,4,5,6,7,8,9,10,12,16,24]
+    pins=[1]
     rm=5
     package_height=14
-    leftbottom_offset=[3.5, 4, 3]
-    ddrill=1.0
+    leftbottom_offset=[2.1, 9, 2.9]
+    ddrill=1.1
     pad=[1.5,3]
     screw_diameter=2.2
     bevel_height=[1,6.7,9.5]
@@ -137,14 +134,14 @@ if __name__ == '__main__':
     opening_xoffset=0.5
     opening_yoffset=1.3#package_height-leftbottom_offset[1]-opening[1]/2
     secondDrillDiameter=ddrill
-    secondDrillOffset=[0,-5]
+    secondDrillOffset=[0,5]
     secondDrillPad=pad
     secondHoleDiameter=[5,14]
-    secondHoleOffset=[0.5,-3]
+    secondHoleOffset=[0.5,2]
     thirdHoleDiameter=[4,1]
-    thirdHoleOffset=[0.5,-2.2]
+    thirdHoleOffset=[0.5,3.2]
     fourthHoleDiameter=[1,2.5]
-    fourthHoleOffset=[0.5,-8.4]
+    fourthHoleOffset=[0.5,-3.4]
     fabref_offset=[0,-1]
     nibbleSize=[]
     nibblePos=[]
@@ -159,16 +156,30 @@ if __name__ == '__main__':
                                   ddrill=ddrill, pad=pad, 
                                   opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
                                   bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
+                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
+                                  stackable=True,
+                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
+        name="236-{0}".format(400+p);
+        webpage="";
+        classname_description="Terminal Block WAGO {0}".format(name);
+        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
+        makeTerminalBlock45Degree(footprint_name=footprint_name, 
+                                  pins=p, rm=rm, 
+                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
+                                  ddrill=ddrill, pad=pad, 
+                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
+                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
                                   secondDrillDiameter=secondDrillDiameter,secondDrillOffset=secondDrillOffset,secondDrillPad=secondDrillPad,
                                   nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
+                                  stackable=True,
                                   tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
 
-      
-    pins=[1,2,3,4,5,6,7,8,9,10,12,16,24]
-    rm=7.5
+
+    pins=[2,3,4,6,8,12,16,24,36,48]
+    rm=5
     package_height=14
-    leftbottom_offset=[3.5, 4, 5.5]
-    ddrill=1.0
+    leftbottom_offset=[3.5, 9, 3.8]
+    ddrill=1.1
     pad=[1.5,3]
     screw_diameter=2.2
     bevel_height=[1,6.7,9.5]
@@ -176,14 +187,65 @@ if __name__ == '__main__':
     opening_xoffset=0.5
     opening_yoffset=1.3#package_height-leftbottom_offset[1]-opening[1]/2
     secondDrillDiameter=ddrill
-    secondDrillOffset=[0,-5]
+    secondDrillOffset=[0,5]
     secondDrillPad=pad
-    secondHoleDiameter=[rm,package_height]
-    secondHoleOffset=[1.75,-3]
+    secondHoleDiameter=[5,14]
+    secondHoleOffset=[0.5,2]
     thirdHoleDiameter=[4,1]
-    thirdHoleOffset=[0.5,-2.2]
-    fourthHoleDiameter=1,2.5
-    fourthHoleOffset=[0.5,-8.4]
+    thirdHoleOffset=[0.5,3.2]
+    fourthHoleDiameter=[1,2.5]
+    fourthHoleOffset=[0.5,-3.4]
+    fabref_offset=[0,-1]
+    nibbleSize=[]
+    nibblePos=[]
+    for p in pins:
+        name="236-{0}".format(100+p);
+        webpage="";
+        classname_description="Terminal Block WAGO {0}".format(name);
+        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
+        makeTerminalBlock45Degree(footprint_name=footprint_name, 
+                                  pins=p, rm=rm, 
+                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
+                                  ddrill=ddrill, pad=pad, 
+                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
+                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
+                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
+                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
+        name="236-{0}".format(400+p);
+        webpage="";
+        classname_description="Terminal Block WAGO {0}".format(name);
+        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
+        makeTerminalBlock45Degree(footprint_name=footprint_name, 
+                                  pins=p, rm=rm, 
+                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
+                                  ddrill=ddrill, pad=pad, 
+                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
+                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
+                                  secondDrillDiameter=secondDrillDiameter,secondDrillOffset=secondDrillOffset,secondDrillPad=secondDrillPad,
+                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
+                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
+
+
+    pins=[1]
+    rm=7.5
+    package_height=14
+    leftbottom_offset=[2.1, 9, 5.4]
+    ddrill=1.1
+    pad=[1.5,3]
+    screw_diameter=2.2
+    bevel_height=[1,6.7,9.5]
+    opening=[4,3.3]
+    opening_xoffset=0.5
+    opening_yoffset=1.3#package_height-leftbottom_offset[1]-opening[1]/2
+    secondDrillDiameter=ddrill
+    secondDrillOffset=[0,5]
+    secondDrillPad=pad
+    secondHoleDiameter=[5,14]
+    secondHoleOffset=[0.5,2]
+    thirdHoleDiameter=[4,1]
+    thirdHoleOffset=[0.5,3.2]
+    fourthHoleDiameter=[1,2.5]
+    fourthHoleOffset=[0.5,-3.4]
     fabref_offset=[0,-1]
     nibbleSize=[]
     nibblePos=[]
@@ -198,16 +260,30 @@ if __name__ == '__main__':
                                   ddrill=ddrill, pad=pad, 
                                   opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
                                   bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
+                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
+                                  stackable=True,
+                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
+        name="236-{0}".format(500+p);
+        webpage="";
+        classname_description="Terminal Block WAGO {0}".format(name);
+        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
+        makeTerminalBlock45Degree(footprint_name=footprint_name, 
+                                  pins=p, rm=rm, 
+                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
+                                  ddrill=ddrill, pad=pad, 
+                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
+                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
                                   secondDrillDiameter=secondDrillDiameter,secondDrillOffset=secondDrillOffset,secondDrillPad=secondDrillPad,
                                   nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
+                                  stackable=True,
                                   tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
 
-       
-    pins=[1,2,3,4,5,6,7,8,9,10,12,16,24]
-    rm=10
+
+    pins=[2,3,4,6,8,12,16,24]
+    rm=7.5
     package_height=14
-    leftbottom_offset=[3.5, 4, 8]
-    ddrill=1.0
+    leftbottom_offset=[3.5, 9, 6.3]
+    ddrill=1.1
     pad=[1.5,3]
     screw_diameter=2.2
     bevel_height=[1,6.7,9.5]
@@ -215,14 +291,65 @@ if __name__ == '__main__':
     opening_xoffset=0.5
     opening_yoffset=1.3#package_height-leftbottom_offset[1]-opening[1]/2
     secondDrillDiameter=ddrill
-    secondDrillOffset=[0,-5]
+    secondDrillOffset=[0,5]
     secondDrillPad=pad
     secondHoleDiameter=[rm,package_height]
-    secondHoleOffset=[3,-3]
+    secondHoleOffset=[1.75,2]
     thirdHoleDiameter=[4,1]
-    thirdHoleOffset=[0.5,-2.2]
+    thirdHoleOffset=[0.5,3.2]
     fourthHoleDiameter=1,2.5
-    fourthHoleOffset=[0.5,-8.4]
+    fourthHoleOffset=[0.5,-3.4]
+    fabref_offset=[0,-1]
+    nibbleSize=[]
+    nibblePos=[]
+    for p in pins:
+        name="236-{0}".format(200+p);
+        webpage="";
+        classname_description="Terminal Block WAGO {0}".format(name);
+        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
+        makeTerminalBlock45Degree(footprint_name=footprint_name, 
+                                  pins=p, rm=rm, 
+                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
+                                  ddrill=ddrill, pad=pad, 
+                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
+                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
+                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
+                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
+        name="236-{0}".format(500+p);
+        webpage="";
+        classname_description="Terminal Block WAGO {0}".format(name);
+        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
+        makeTerminalBlock45Degree(footprint_name=footprint_name, 
+                                  pins=p, rm=rm, 
+                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
+                                  ddrill=ddrill, pad=pad, 
+                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
+                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
+                                  secondDrillDiameter=secondDrillDiameter,secondDrillOffset=secondDrillOffset,secondDrillPad=secondDrillPad,
+                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
+                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
+
+
+    pins=[1]
+    rm=10
+    package_height=14
+    leftbottom_offset=[2.1, 9, 7.9]
+    ddrill=1.1
+    pad=[1.5,3]
+    screw_diameter=2.2
+    bevel_height=[1,6.7,9.5]
+    opening=[4,3.3]
+    opening_xoffset=0.5
+    opening_yoffset=1.3#package_height-leftbottom_offset[1]-opening[1]/2
+    secondDrillDiameter=ddrill
+    secondDrillOffset=[0,5]
+    secondDrillPad=pad
+    secondHoleDiameter=[5,14]
+    secondHoleOffset=[0.5,2]
+    thirdHoleDiameter=[4,1]
+    thirdHoleOffset=[0.5,3.2]
+    fourthHoleDiameter=[1,2.5]
+    fourthHoleOffset=[0.5,-3.4]
     fabref_offset=[0,-1]
     nibbleSize=[]
     nibblePos=[]
@@ -237,8 +364,72 @@ if __name__ == '__main__':
                                   ddrill=ddrill, pad=pad, 
                                   opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
                                   bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
+                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
+                                  stackable=True,
+                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
+        name="236-{0}".format(600+p);
+        webpage="";
+        classname_description="Terminal Block WAGO {0}".format(name);
+        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
+        makeTerminalBlock45Degree(footprint_name=footprint_name, 
+                                  pins=p, rm=rm, 
+                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
+                                  ddrill=ddrill, pad=pad, 
+                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
+                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
+                                  secondDrillDiameter=secondDrillDiameter,secondDrillOffset=secondDrillOffset,secondDrillPad=secondDrillPad,
+                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
+                                  stackable=True,
+                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
+
+
+    pins=[2,3,4,6,8,12,16,24]
+    rm=10
+    package_height=14
+    leftbottom_offset=[3.5, 9, 8.8]
+    ddrill=1.1
+    pad=[1.5,3]
+    screw_diameter=2.2
+    bevel_height=[1,6.7,9.5]
+    opening=[4,3.3]
+    opening_xoffset=0.5
+    opening_yoffset=1.3#package_height-leftbottom_offset[1]-opening[1]/2
+    secondDrillDiameter=ddrill
+    secondDrillOffset=[0,5]
+    secondDrillPad=pad
+    secondHoleDiameter=[rm,package_height]
+    secondHoleOffset=[3,2]
+    thirdHoleDiameter=[4,1]
+    thirdHoleOffset=[0.5,3.2]
+    fourthHoleDiameter=1,2.5
+    fourthHoleOffset=[0.5,-3.4]
+    fabref_offset=[0,-1]
+    nibbleSize=[]
+    nibblePos=[]
+    for p in pins:
+        name="236-{0}".format(300+p);
+        webpage="";
+        classname_description="Terminal Block WAGO {0}".format(name);
+        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
+        makeTerminalBlock45Degree(footprint_name=footprint_name, 
+                                  pins=p, rm=rm, 
+                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
+                                  ddrill=ddrill, pad=pad, 
+                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
+                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
+                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
+                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
+        name="236-{0}".format(600+p);
+        webpage="";
+        classname_description="Terminal Block WAGO {0}".format(name);
+        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
+        makeTerminalBlock45Degree(footprint_name=footprint_name, 
+                                  pins=p, rm=rm, 
+                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
+                                  ddrill=ddrill, pad=pad, 
+                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
+                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
                                   secondDrillDiameter=secondDrillDiameter,secondDrillOffset=secondDrillOffset,secondDrillPad=secondDrillPad,
                                   nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
                                   tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
 
-      

--- a/scripts/TerminalBlock_WAGO/make_TerminalBlock_WAGO.py
+++ b/scripts/TerminalBlock_WAGO/make_TerminalBlock_WAGO.py
@@ -126,7 +126,7 @@ if __name__ == '__main__':
     rm=5
     package_height=14
     leftbottom_offset=[3.5, 9, 3.8]
-    ddrill=1.1
+    ddrill=1.15
     pad=[1.5,3]
     screw_diameter=2.2
     bevel_height=[1,6.7,9.5]
@@ -176,7 +176,7 @@ if __name__ == '__main__':
     rm=7.5
     package_height=14
     leftbottom_offset=[3.5, 9, 6.3]
-    ddrill=1.1
+    ddrill=1.15
     pad=[1.5,3]
     screw_diameter=2.2
     bevel_height=[1,6.7,9.5]
@@ -226,7 +226,7 @@ if __name__ == '__main__':
     rm=10
     package_height=14
     leftbottom_offset=[3.5, 9, 8.8]
-    ddrill=1.1
+    ddrill=1.15
     pad=[1.5,3]
     screw_diameter=2.2
     bevel_height=[1,6.7,9.5]

--- a/scripts/TerminalBlock_WAGO/make_TerminalBlock_WAGO.py
+++ b/scripts/TerminalBlock_WAGO/make_TerminalBlock_WAGO.py
@@ -122,60 +122,7 @@ if __name__ == '__main__':
                                   tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
 
 
-    pins=[1]
-    rm=5
-    package_height=14
-    leftbottom_offset=[2.1, 9, 2.9]
-    ddrill=1.1
-    pad=[1.5,3]
-    screw_diameter=2.2
-    bevel_height=[1,6.7,9.5]
-    opening=[4,3.3]
-    opening_xoffset=0.5
-    opening_yoffset=1.3#package_height-leftbottom_offset[1]-opening[1]/2
-    secondDrillDiameter=ddrill
-    secondDrillOffset=[0,5]
-    secondDrillPad=pad
-    secondHoleDiameter=[5,14]
-    secondHoleOffset=[0.5,2]
-    thirdHoleDiameter=[4,1]
-    thirdHoleOffset=[0.5,3.2]
-    fourthHoleDiameter=[1,2.5]
-    fourthHoleOffset=[0.5,-3.4]
-    fabref_offset=[0,-1]
-    nibbleSize=[]
-    nibblePos=[]
-    for p in pins:
-        name="236-{0}".format(100+p);
-        webpage="";
-        classname_description="Terminal Block WAGO {0}".format(name);
-        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
-        makeTerminalBlock45Degree(footprint_name=footprint_name, 
-                                  pins=p, rm=rm, 
-                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
-                                  ddrill=ddrill, pad=pad, 
-                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
-                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
-                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
-                                  stackable=True,
-                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
-        name="236-{0}".format(400+p);
-        webpage="";
-        classname_description="Terminal Block WAGO {0}".format(name);
-        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
-        makeTerminalBlock45Degree(footprint_name=footprint_name, 
-                                  pins=p, rm=rm, 
-                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
-                                  ddrill=ddrill, pad=pad, 
-                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
-                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
-                                  secondDrillDiameter=secondDrillDiameter,secondDrillOffset=secondDrillOffset,secondDrillPad=secondDrillPad,
-                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
-                                  stackable=True,
-                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
-
-
-    pins=[2,3,4,6,8,12,16,24,36,48]
+    pins=[1,2,3,4,6,8,12,16,24,36,48]
     rm=5
     package_height=14
     leftbottom_offset=[3.5, 9, 3.8]
@@ -225,61 +172,7 @@ if __name__ == '__main__':
                                   nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
                                   tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
 
-
-    pins=[1]
-    rm=7.5
-    package_height=14
-    leftbottom_offset=[2.1, 9, 5.4]
-    ddrill=1.1
-    pad=[1.5,3]
-    screw_diameter=2.2
-    bevel_height=[1,6.7,9.5]
-    opening=[4,3.3]
-    opening_xoffset=0.5
-    opening_yoffset=1.3#package_height-leftbottom_offset[1]-opening[1]/2
-    secondDrillDiameter=ddrill
-    secondDrillOffset=[0,5]
-    secondDrillPad=pad
-    secondHoleDiameter=[5,14]
-    secondHoleOffset=[0.5,2]
-    thirdHoleDiameter=[4,1]
-    thirdHoleOffset=[0.5,3.2]
-    fourthHoleDiameter=[1,2.5]
-    fourthHoleOffset=[0.5,-3.4]
-    fabref_offset=[0,-1]
-    nibbleSize=[]
-    nibblePos=[]
-    for p in pins:
-        name="236-{0}".format(200+p);
-        webpage="";
-        classname_description="Terminal Block WAGO {0}".format(name);
-        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
-        makeTerminalBlock45Degree(footprint_name=footprint_name, 
-                                  pins=p, rm=rm, 
-                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
-                                  ddrill=ddrill, pad=pad, 
-                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
-                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
-                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
-                                  stackable=True,
-                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
-        name="236-{0}".format(500+p);
-        webpage="";
-        classname_description="Terminal Block WAGO {0}".format(name);
-        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
-        makeTerminalBlock45Degree(footprint_name=footprint_name, 
-                                  pins=p, rm=rm, 
-                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
-                                  ddrill=ddrill, pad=pad, 
-                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
-                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
-                                  secondDrillDiameter=secondDrillDiameter,secondDrillOffset=secondDrillOffset,secondDrillPad=secondDrillPad,
-                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
-                                  stackable=True,
-                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
-
-
-    pins=[2,3,4,6,8,12,16,24]
+    pins=[1,2,3,4,6,8,12,16,24]
     rm=7.5
     package_height=14
     leftbottom_offset=[3.5, 9, 6.3]
@@ -329,61 +222,7 @@ if __name__ == '__main__':
                                   nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
                                   tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
 
-
-    pins=[1]
-    rm=10
-    package_height=14
-    leftbottom_offset=[2.1, 9, 7.9]
-    ddrill=1.1
-    pad=[1.5,3]
-    screw_diameter=2.2
-    bevel_height=[1,6.7,9.5]
-    opening=[4,3.3]
-    opening_xoffset=0.5
-    opening_yoffset=1.3#package_height-leftbottom_offset[1]-opening[1]/2
-    secondDrillDiameter=ddrill
-    secondDrillOffset=[0,5]
-    secondDrillPad=pad
-    secondHoleDiameter=[5,14]
-    secondHoleOffset=[0.5,2]
-    thirdHoleDiameter=[4,1]
-    thirdHoleOffset=[0.5,3.2]
-    fourthHoleDiameter=[1,2.5]
-    fourthHoleOffset=[0.5,-3.4]
-    fabref_offset=[0,-1]
-    nibbleSize=[]
-    nibblePos=[]
-    for p in pins:
-        name="236-{0}".format(300+p);
-        webpage="";
-        classname_description="Terminal Block WAGO {0}".format(name);
-        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
-        makeTerminalBlock45Degree(footprint_name=footprint_name, 
-                                  pins=p, rm=rm, 
-                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
-                                  ddrill=ddrill, pad=pad, 
-                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
-                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
-                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
-                                  stackable=True,
-                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
-        name="236-{0}".format(600+p);
-        webpage="";
-        classname_description="Terminal Block WAGO {0}".format(name);
-        footprint_name="TerminalBlock_WAGO_{0}_1x{2:02}_P{1:3.2f}mm_45Degree".format(name, rm, p)
-        makeTerminalBlock45Degree(footprint_name=footprint_name, 
-                                  pins=p, rm=rm, 
-                                  package_height=package_height, leftbottom_offset=leftbottom_offset, 
-                                  ddrill=ddrill, pad=pad, 
-                                  opening=opening, opening_xoffset=opening_xoffset, opening_yoffset=opening_yoffset, 
-                                  bevel_height=bevel_height, secondHoleDiameter=secondHoleDiameter, secondHoleOffset=secondHoleOffset, thirdHoleDiameter=thirdHoleDiameter, thirdHoleOffset=thirdHoleOffset, fourthHoleDiameter=fourthHoleDiameter, fourthHoleOffset=fourthHoleOffset, 
-                                  secondDrillDiameter=secondDrillDiameter,secondDrillOffset=secondDrillOffset,secondDrillPad=secondDrillPad,
-                                  nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
-                                  stackable=True,
-                                  tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
-
-
-    pins=[2,3,4,6,8,12,16,24]
+    pins=[1,2,3,4,6,8,12,16,24]
     rm=10
     package_height=14
     leftbottom_offset=[3.5, 9, 8.8]
@@ -432,4 +271,3 @@ if __name__ == '__main__':
                                   secondDrillDiameter=secondDrillDiameter,secondDrillOffset=secondDrillOffset,secondDrillPad=secondDrillPad,
                                   nibbleSize=nibbleSize, nibblePos=nibblePos, fabref_offset=fabref_offset,
                                   tags_additional=[], lib_name="${KISYS3DMOD}/"+classname, classname=classname, classname_description=classname_description, webpage=webpage, script_generated_note=script_generated_note)
-

--- a/scripts/tools/footprint_scripts_terminal_blocks.py
+++ b/scripts/tools/footprint_scripts_terminal_blocks.py
@@ -33,6 +33,7 @@ slk_offset = lw_slk
 #
 #
 def makeTerminalBlockStd(footprint_name, pins, rm, package_height, leftbottom_offset, ddrill, pad, screw_diameter, bevel_height, slit_screw=True, screw_pin_offset=[0,0], secondHoleDiameter=0, secondHoleOffset=[0,0], thirdHoleDiameter=0, thirdHoleOffset=[0,0], fourthHoleDiameter=0, fourthHoleOffset=[0,0],secondDrillDiameter=0,secondDrillOffset=[0,0],secondDrillPad=[0,0],nibbleSize=[],nibblePos=[], fabref_offset=[0,0],
+                        stackable=False,
                         tags_additional=[], lib_name="${{KISYS3DMOD}}/Connectors_Terminal_Blocks", classname="Connectors_Terminal_Blocks", classname_description="terminal block", webpage="", script_generated_note=""):
 
     package_size=[2*leftbottom_offset[0]+(pins-1)*rm, package_height];
@@ -50,8 +51,8 @@ def makeTerminalBlockStd(footprint_name, pins, rm, package_height, leftbottom_of
     t_slk = t_fab - slk_offset
 
     h_crt = h_fab + 2 * crt_offset
-    w_crt = w_fab + 2 * crt_offset
-    l_crt = l_fab - crt_offset
+    w_crt = w_fab + (0 if stackable else 2 * crt_offset)
+    l_crt = l_fab - (0 if stackable else crt_offset)
     t_crt = t_fab - crt_offset
 
 
@@ -253,6 +254,7 @@ def makeTerminalBlockStd(footprint_name, pins, rm, package_height, leftbottom_of
 #
 #
 def makeTerminalBlockVertical(footprint_name, pins, rm, package_height, leftbottom_offset, ddrill, pad, opening, opening_yoffset, bevel_height, opening_xoffset=0, secondHoleDiameter=0, secondHoleOffset=[0,0], thirdHoleDiameter=0, thirdHoleOffset=[0,0], fourthHoleDiameter=0, fourthHoleOffset=[0,0],secondDrillDiameter=0,secondDrillOffset=[0,0],secondDrillPad=[0,0],nibbleSize=[],nibblePos=[], fabref_offset=[0,0],
+                        stackable=False,
                         tags_additional=[], lib_name="${{KISYS3DMOD}}/Connectors_Terminal_Blocks", classname="Connectors_Terminal_Blocks", classname_description="terminal block", webpage="", script_generated_note=""):
 
     package_size=[2*leftbottom_offset[0]+(pins-1)*rm, package_height];
@@ -270,8 +272,8 @@ def makeTerminalBlockVertical(footprint_name, pins, rm, package_height, leftbott
     t_slk = t_fab - slk_offset
 
     h_crt = h_fab + 2 * crt_offset
-    w_crt = w_fab + 2 * crt_offset
-    l_crt = l_fab - crt_offset
+    w_crt = w_fab + (0 if stackable else 2 * crt_offset)
+    l_crt = l_fab - (0 if stackable else crt_offset)
     t_crt = t_fab - crt_offset
 
 
@@ -475,6 +477,7 @@ def makeTerminalBlockVertical(footprint_name, pins, rm, package_height, leftbott
 #
 #
 def makeTerminalBlock45Degree(footprint_name, pins, rm, package_height, leftbottom_offset, ddrill, pad, opening, opening_xoffset, opening_yoffset, opening_elliptic=False, bevel_height=[], vsegment_lines_offset=[], secondHoleDiameter=0, secondHoleOffset=[0,0], thirdHoleDiameter=0, thirdHoleOffset=[0,0], fourthHoleDiameter=0, fourthHoleOffset=[0,0], fifthHoleDiameter=0, fifthHoleOffset=[0,0],secondDrillDiameter=0,secondDrillOffset=[0,0],secondDrillPad=[0,0],nibbleSize=[],nibblePos=[], fabref_offset=[0,0],secondEllipseSize=[0,0],secondEllipseOffset=[0,0],
+                        stackable=False,
                         tags_additional=[], lib_name="${{KISYS3DMOD}}/Connectors_Terminal_Blocks", classname="Connectors_Terminal_Blocks", classname_description="terminal block", webpage="", script_generated_note=""):
 
     package_size=[2*leftbottom_offset[0]+(pins-1)*rm, package_height];
@@ -492,8 +495,8 @@ def makeTerminalBlock45Degree(footprint_name, pins, rm, package_height, leftbott
     t_slk = t_fab - slk_offset
 
     h_crt = h_fab + 2 * crt_offset
-    w_crt = w_fab + 2 * crt_offset
-    l_crt = l_fab - crt_offset
+    w_crt = w_fab + (0 if stackable else 2 * crt_offset)
+    l_crt = l_fab - (0 if stackable else crt_offset)
     t_crt = t_fab - crt_offset
 
 


### PR DESCRIPTION
Fix Wago 236 naming, drill diameters, differentiate between 1 and 2 pin

Script got part numbers wrong before, ~courtyards inadequate for single pole blocks,~ drill diameter too small, created nonexistent parts.

FP PR https://github.com/KiCad/kicad-footprints/pull/1752
FP PR https://github.com/KiCad/kicad-footprints/pull/1753