### PR TITLE
add Mini-Circuits DB1627

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/mini-circuits.yml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/mini-circuits.yml
@@ -1,0 +1,27 @@
+Mini-Circuits_DB1627:
+  device_type: DFN
+  library: RF_Mini-Circuits
+  manufacturer: Mini-Circuits
+  custom_name_format: "{man}_{mpn}"
+  part_number: DB1627
+  size_source: https://ww2.minicircuits.com/case_style/DB1627.pdf
+  ipc_class: dfn
+  body_size_x:
+    nominal: 3.81
+    tolerance: 0.127
+  body_size_y:
+    nominal: 4.06
+    tolerance: 0.127
+  body_height:
+    maximum: 4.06
+
+  lead_width:
+    nominal: 0.71
+    tolerance: 0.127
+  lead_len:
+    nominal: 1.02
+    tolerance: 0.127
+
+  pitch: 1.27
+  num_pins_x: 3
+  num_pins_y: 0


### PR DESCRIPTION
add size-definition for [Mini-Circuits DB1627](https://ww2.minicircuits.com/case_style/DB1627.pdf) package. The land pattern looks similar to a DFN to me, so I used this for the definition. However the package itself is not a regular DFN, so I put it in the `RF_Mini-Circuits` library and used the naming scheme of this library.