### PR TITLE
add 

### DIFF
--- a/scripts/pin-headers_socket-strips/make_pin_headers.py
+++ b/scripts/pin-headers_socket-strips/make_pin_headers.py
@@ -49,6 +49,9 @@ if __name__ == '__main__':
                                 [0, 0, 0], [1, 1, 1], [0, 0, 0])
             makePinHeadAngled(rows, cols, rm, rm, angled_pack_width, angled_pack_offset, angled_pin_length, angled_pin_width, ddrill, pad,
                               [], "${KISYS3DMOD}/Pin_Headers", "Pin_Header", "pin header", [0, 0, 0], [1, 1, 1], [0, 0, 0])
+            makePinHeadAngled(rows, cols, rm, rm, angled_pack_width, angled_pack_offset, angled_pin_length, angled_pin_width, ddrill, pad,
+                              [], "${KISYS3DMOD}/Pin_Headers", "Pin_Header", "pin header", [0, 0, 0], [1, 1, 1], [0, 0, 0], True)
+
             if rows != 1 or cols == 2:
               if cols == 2:
                   makePinHeadStraightSMD(rows, cols, rm, rm, rmx_pad_offset[cols-1], rmx_pin_length[cols-1], pin_width, cols * singlecol_packwidth + singlecol_packoffset,
@@ -99,6 +102,10 @@ if __name__ == '__main__':
             makePinHeadAngled(rows, cols, rm, rm, angled_pack_width, angled_pack_offset, angled_pin_length,
                               angled_pin_width, ddrill, pad,
                               [], "${KISYS3DMOD}/Pin_Headers", "Pin_Header", "pin header", [0, 0, 0], [1, 1, 1], [0, 0, 0])
+            makePinHeadAngled(rows, cols, rm, rm, angled_pack_width, angled_pack_offset, angled_pin_length,
+                              angled_pin_width, ddrill, pad,
+                              [], "${KISYS3DMOD}/Pin_Headers", "Pin_Header", "pin header", [0, 0, 0], [1, 1, 1], [0, 0, 0], True)
+
             if rows != 1 or cols == 2:
               if cols == 2:
                   makePinHeadStraightSMD(rows, cols, rm, rm, rmx_pad_offset[cols-1], rmx_pin_length[cols-1], pin_width,
@@ -149,6 +156,10 @@ if __name__ == '__main__':
             makePinHeadAngled(rows, cols, rm, rm, angled_pack_width, angled_pack_offset, angled_pin_length,
                               angled_pin_width, ddrill, pad,
                               [], "${KISYS3DMOD}/Pin_Headers", "Pin_Header", "pin header", [0, 0, 0], [1, 1, 1], [0, 0, 0])
+            makePinHeadAngled(rows, cols, rm, rm, angled_pack_width, angled_pack_offset, angled_pin_length,
+                              angled_pin_width, ddrill, pad,
+                              [], "${KISYS3DMOD}/Pin_Headers", "Pin_Header", "pin header", [0, 0, 0], [1, 1, 1], [0, 0, 0], True)
+
             if rows != 1 or cols == 2:
                 if cols == 2:
                     makePinHeadStraightSMD(rows, cols, rm, rm, rmx_pad_offset[cols-1], rmx_pin_length[cols-1], pin_width,
@@ -199,7 +210,10 @@ if __name__ == '__main__':
             makePinHeadAngled(rows, cols, rm, rm, angled_pack_width[cols-1], angled_pack_offset[cols-1], angled_pin_length,
                               angled_pin_width, ddrill, pad,
                               [], "${KISYS3DMOD}/Pin_Headers", "Pin_Header", "pin header", [0, 0, 0], [1, 1, 1], [0, 0, 0])
-            
+            makePinHeadAngled(rows, cols, rm, rm, angled_pack_width[cols-1], angled_pack_offset[cols-1], angled_pin_length,
+                              angled_pin_width, ddrill, pad,
+                              [], "${KISYS3DMOD}/Pin_Headers", "Pin_Header", "pin header", [0, 0, 0], [1, 1, 1], [0, 0, 0], True)
+
             if rows != 1 or cols == 2:
                 if cols == 2:
                     makePinHeadStraightSMD(rows, cols, rm, rm, rmx_pad_offset[cols-1], rmx_pin_length[cols-1], pin_width,

--- a/scripts/pin-headers_socket-strips/make_socket_strips.py
+++ b/scripts/pin-headers_socket-strips/make_socket_strips.py
@@ -42,6 +42,10 @@ if __name__ == '__main__':
             makeSocketStripAngled(rows, cols, rm, rm, angled_pack_width, angled_pack_offset, angled_pin_width, ddrill, pad,
                               [], "Socket_Strips",  "Socket_Strip", "socket strip",[-(cols - 1) * rm / 2 / 25.4, -(rows - 1) * rm / 2 / 25.4, 0], [1, 1, 1],
                                 [0, 0, 270])
+            makeSocketStripAngled(rows, cols, rm, rm, angled_pack_width, angled_pack_offset, angled_pin_width, ddrill, pad,
+                                  [], "Socket_Strips",  "Socket_Strip", "socket strip",[-(cols - 1) * rm / 2 / 25.4, -(rows - 1) * rm / 2 / 25.4, 0], [1, 1, 1],
+                                  [0, 0, 270], True)
+
             if cols == 2:
                 makePinHeadStraightSMD(rows, cols, rm, rm, rmx_pad_offset, rmx_pin_length, pin_width,
                                        cols * singlecol_packwidth + singlecol_packoffset,
@@ -74,6 +78,12 @@ if __name__ == '__main__':
                               [], "Socket_Strip", "Socket_Strip", "socket strip", [(cols - 1) * rm / 2 / 25.4, -(rows - 1) * rm / 2 / 25.4, 0],
                               [1, 1, 1],
                               [0, 0, 90])
+            makeSocketStripAngled(rows, cols, rm, rm, angled_pack_width, angled_pack_offset,
+                                  angled_pin_width, ddrill, pad,
+                                  [], "Socket_Strip", "Socket_Strip", "socket strip", [(cols - 1) * rm / 2 / 25.4, -(rows - 1) * rm / 2 / 25.4, 0],
+                                  [1, 1, 1],
+                                  [0, 0, 90], True)
+
             if cols == 2:
                 makePinHeadStraightSMD(rows, cols, rm, rm, rmx_pad_offset, rmx_pin_length, pin_width,
                                        cols * singlecol_packwidth + singlecol_packoffset,
@@ -109,4 +119,3 @@ if __name__ == '__main__':
                                        singlecol_packwidth / 2 + singlecol_packoffset, pad_smd,
                                        True, [], "Socket_Strips", "Socket_Strip", "socket strip", isSocket=True)
 
-            

--- a/scripts/tools/footprint_scripts_pin_headers.py
+++ b/scripts/tools/footprint_scripts_pin_headers.py
@@ -288,9 +288,9 @@ def makePinHeadStraight(rows, cols, rm, coldist, package_width, overlen_top, ove
 #                 +-------+                                    rm
 #
 def makePinHeadAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_length, pin_width, ddrill, pad,
-                      tags_additional=[], lib_name="${{KISYS3DMOD}}/Pin_Headers", classname="Pin_Header",
-                      classname_description="pin header", offset3d=[0, 0, 0], scale3d=[1, 1, 1],
-                      rotate3d=[0, 0, 0], pin_num_invert=False):
+					  tags_additional=[], lib_name="${{KISYS3DMOD}}/Pin_Headers", classname="Pin_Header",
+					  classname_description="pin header", offset3d=[0, 0, 0], scale3d=[1, 1, 1],
+					  rotate3d=[0, 0, 0], pin_num_reverse=False):
     h_fabb = (rows - 1) * rm + rm / 2 + rm / 2
     w_fabb = pack_width
     l_fabb = coldist * (cols - 1) + pack_offset
@@ -341,6 +341,12 @@ def makePinHeadAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_leng
     elif (cols == 3):
         description = description + ", triple rows"
         tags = tags + " triple row"
+
+    if pin_num_reverse:
+        footprint_name = footprint_name + "_reversed"
+        description = description + ", reversed numbering"
+        tags = tags + " reversed numbering"
+
     
     if (len(tags_additional) > 0):
         for t in tags_additional:
@@ -573,9 +579,9 @@ def makePinHeadAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_leng
 #                 +---------------------------------------+
 #
 def makeSocketStripAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_width, ddrill, pad,
-                      tags_additional=[], lib_name="${{KISYS3DMOD}}/Socket_Strips", classname="Socket_Strip",
-                      classname_description="socket strip", offset3d=[0, 0, 0], scale3d=[1, 1, 1],
-                      rotate3d=[0, 0, 0], pin_num_invert=False):
+						  tags_additional=[], lib_name="${{KISYS3DMOD}}/Socket_Strips", classname="Socket_Strip",
+						  classname_description="socket strip", offset3d=[0, 0, 0], scale3d=[1, 1, 1],
+						  rotate3d=[0, 0, 0], pin_num_reverse=False):
     h_fabb = (rows - 1) * rm + rm / 2 + rm / 2
     w_fabb = -pack_width
     l_fabb = -1*(coldist * (cols - 1) + pack_offset)
@@ -616,7 +622,12 @@ def makeSocketStripAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_
     elif (cols == 3):
         description = description + ", triple rows"
         tags = tags + " triple row"
-    
+
+    if pin_num_reverse:
+        footprint_name = footprint_name + "_reversed"
+        description = description + ", reversed numbering"
+        tags = tags + " reversed numbering"
+
     if (len(tags_additional) > 0):
         for t in tags_additional:
             footprint_name = footprint_name + "_" + t
@@ -705,7 +716,7 @@ def makeSocketStripAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_
     pad_shapeother = Pad.SHAPE_OVAL
     pad_layers = Pad.LAYERS_THT 
 
-    if pin_num_invert:
+    if pin_num_reverse:
         p = rows*cols
         step = -1
     else:

--- a/scripts/tools/footprint_scripts_pin_headers.py
+++ b/scripts/tools/footprint_scripts_pin_headers.py
@@ -290,7 +290,7 @@ def makePinHeadStraight(rows, cols, rm, coldist, package_width, overlen_top, ove
 def makePinHeadAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_length, pin_width, ddrill, pad,
                       tags_additional=[], lib_name="${{KISYS3DMOD}}/Pin_Headers", classname="Pin_Header",
                       classname_description="pin header", offset3d=[0, 0, 0], scale3d=[1, 1, 1],
-                      rotate3d=[0, 0, 0]):
+                      rotate3d=[0, 0, 0], pin_num_invert=False):
     h_fabb = (rows - 1) * rm + rm / 2 + rm / 2
     w_fabb = pack_width
     l_fabb = coldist * (cols - 1) + pack_offset
@@ -522,7 +522,12 @@ def makePinHeadAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_leng
     pad_shapeother = Pad.SHAPE_OVAL
     pad_layers = Pad.LAYERS_THT
     
-    p = 1
+    if pin_num_invert:
+        p = rows*cols
+        step = -1
+    else:
+        p = 1
+        step = 1
     
     for r in range(1, rows + 1):
         x1 = 0
@@ -535,7 +540,7 @@ def makePinHeadAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_leng
                     Pad(number=p, type=pad_type, shape=pad_shapeother, at=[x1, y1], size=pad, drill=ddrill,
                         layers=pad_layers))
             
-            p = p + 1
+            p = p + step
             x1 = x1 + coldist
         
         y1 = y1 + rm
@@ -570,7 +575,7 @@ def makePinHeadAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_leng
 def makeSocketStripAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_width, ddrill, pad,
                       tags_additional=[], lib_name="${{KISYS3DMOD}}/Socket_Strips", classname="Socket_Strip",
                       classname_description="socket strip", offset3d=[0, 0, 0], scale3d=[1, 1, 1],
-                      rotate3d=[0, 0, 0]):
+                      rotate3d=[0, 0, 0], pin_num_invert=False):
     h_fabb = (rows - 1) * rm + rm / 2 + rm / 2
     w_fabb = -pack_width
     l_fabb = -1*(coldist * (cols - 1) + pack_offset)
@@ -700,7 +705,14 @@ def makeSocketStripAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_
     pad_shapeother = Pad.SHAPE_OVAL
     pad_layers = Pad.LAYERS_THT 
 
-    p = 1
+    if pin_num_invert:
+        p = rows*cols
+        step = -1
+    else:
+        p = 1
+        step = 1
+
+
     for r in range(1, rows + 1):
         x1 = 0
         for c in range(1, cols + 1):
@@ -712,7 +724,7 @@ def makeSocketStripAngled(rows, cols, rm, coldist, pack_width, pack_offset, pin_
                     Pad(number=p, type=pad_type, shape=pad_shapeother, at=[x1, y1], size=pad, drill=ddrill,
                         layers=pad_layers))
         
-            p = p + 1
+            p = p + step
             x1 = x1 - coldist
     
         y1 = y1 + rm


### PR DESCRIPTION
Hi,

Just like a SMD-Pin-Header can start with the first pin left or right, angled/horizontal pin-headers/sockets can also be 'bent' to the left or to the right:
Imagine a single column of e.g. 4 straight (vertical) pins with the top one being pin 1.
I can now "bend" those pins either to the left or to the right to get the respective horizontal version.
These two variants are axisymmetrical but can't be tranformed into one another by only rotating. (Unlike the straight/vertical ones, which can be rotated to "invert" the pin numbering)

Since these connectors are very basic and commonly used in many Projects, I think both variants should be included in the library, instead of forcing everybody to add them manually on their own.

Your script only generated the right-bent variant, where the first pin is on the right (when looking at the tips of the pins), so i added a new parameter `pin_num_reverse` to `makePinHeadAngled` and `makeSocketStripAngled`. The parameter was added at the end and defaults to False, so existing usages of the functions still behave in the same way.

If pin_num_reverse is True, the pin-number `p` starts with the max-value and gets decreased in the Pad-creating loops.
So the pins-positions are still created in the same order but assigned a different number:
The pin at the first position gets the last pin-number and vice versa.
Additionally, a 'reversed' is appended to footprint name, description and tags.


I also edited the Scripts in `/scripts/pin-headers_socket-strips/` to use the new parameter to create both versions of angled/horizontal pin headers.

