### PR TITLE
Add SON-8-1.5x2.0mm

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/wson.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/wson.yaml
@@ -338,3 +338,44 @@ WSON-12-1EP_4x4mm_P0.5mm_EP2.6x3mm:
   #suffix: '_PullBack'
   #include_suffix_in_3dpath: 'False'
   #include_pad_size: 'fp_name_only' # 'both' | 'none' (default)
+
+
+SON-8_1.5x2.0mm_P0.5mm:
+  device_type: 'SON'
+  library: Package_SON
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'http://www.ti.com/lit/ds/symlink/tps62840.pdf'
+  ipc_class: 'qfn_pull_back' #'qfn' | 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  #body_size_x_min: 2.85
+  body_size_x:
+    nominal: 1.5
+    tolerance: 0.1
+  #body_size_x_max: 3.15
+  #body_size_y_min: 2.85
+  body_size_y:
+    nominal: 2.0
+    tolerance: 0.1
+  #body_size_y_max: 3.15
+  lead_width_min: 0.20
+  lead_width_max: 0.30
+  lead_len_min: 0.30
+  lead_len_max: 0.50
+
+
+  #EP_size_x: 1.4
+  #EP_size_y: 1.6
+  # EP_paste_coverage: 0.65
+  #EP_num_paste_pads: [2, 2]
+
+  pitch: 0.50
+  num_pins_x: 0
+  num_pins_y: 4
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_PullBack'
+  #include_suffix_in_3dpath: 'False'
+  #include_pad_size: 'fp_name_only' # 'both' | 'none' (default)
+


### PR DESCRIPTION
This PR is to add SON-8_1.5x2.0mm_P0.5mm footprint in to the wson.yaml file.
The data-sheet can be found [here](http://www.ti.com/lit/ds/symlink/tps62840.pdf).