### PR TITLE
Adding CHP DIP Piano Switches. Fixing generating script for DIP Piano Switches

### DIFF
--- a/scripts/Buttons_Switches/make_DIPSwitches.py
+++ b/scripts/Buttons_Switches/make_DIPSwitches.py
@@ -213,30 +213,12 @@ if __name__ == '__main__':
         makeDIPSwitch(p, rm, pinrow_distance, package_width, overlen_top, overlen_bottom, ddrill, pad_smd, switch_width,
                       switch_height, 'Slide', True, ["JPin"], "Button_Switch_SMD", [0, 0, 0], [1, 1, 1],
                       [0, 0, 0], "", True, webpage="http://www.kingtek.net.cn/pic/201601201446313350.pdf", device_name="KingTek_DSHP{0:02}TJ".format(int(p/2)),switchtype=switchtype)
-    
-    # KingTek CHP B piano DIP-switches (https://www.nidec-copal-electronics.com/e/catalog/switch/chp.pdf):
-    pins = [4,8,16]
-    rm = 1.27
-    pinrow_distance = 7.62
-    package_width = 5.9
-    switch_width = 0.75
-    switch_height = 0.8
-    overlen_top = 1.65
-    overlen_bottom = overlen_top
-    ddrill = 0
-    pad_smd = [1.27, 0.76]
-    
-    os.chdir(cwd)
-    os.chdir("SMD")
-    for p in pins:
-        makeDIPSwitch(p, rm, pinrow_distance, package_width, overlen_top, overlen_bottom, ddrill, pad_smd, switch_width,
-                      switch_height, 'Piano', True, [], "Button_Switch_SMD", [0, 0, 0], [1, 1, 1],
-                      [0, 0, 0], "", True, webpage="https://www.nidec-copal-electronics.com/e/catalog/switch/chp.pdf", device_name="CHP-{0:02}xB".format(int(p/2)),switchtype=switchtype)
-    
-    # KingTek CHP A piano DIP-switches (https://www.nidec-copal-electronics.com/e/catalog/switch/chp.pdf):
+
+    # Copal CHP A,B piano DIP-switches (https://www.nidec-copal-electronics.com/e/catalog/switch/chp.pdf):
     pins = [4,8,16]
     rm = 1.27
     pinrow_distance = 5.08
+    pinrow_distanceB = 7.62
     package_width = 5.9
     switch_width = 0.75
     switch_height = 0.8
@@ -244,12 +226,16 @@ if __name__ == '__main__':
     overlen_bottom = overlen_top
     ddrill = 0
     pad_smd = [1.6, 0.76]
+    pad_smdB = [1.27, 0.76]
     
     os.chdir(cwd)
     os.chdir("SMD")
     for p in pins:
         makeDIPSwitch(p, rm, pinrow_distance, package_width, overlen_top, overlen_bottom, ddrill, pad_smd, switch_width,
                       switch_height, 'Piano', True, ["JPin"], "Button_Switch_SMD", [0, 0, 0], [1, 1, 1],
-                      [0, 0, 0], "", True, webpage="https://www.nidec-copal-electronics.com/e/catalog/switch/chp.pdf", device_name="CHP-{0:02}xA".format(int(p/2)),switchtype=switchtype)
-    
+                      [0, 0, 0], "", True, webpage="https://www.nidec-copal-electronics.com/e/catalog/switch/chp.pdf", device_name="Copal_CHP-{0:02}xA".format(int(p/2)),switchtype=switchtype)
+        makeDIPSwitch(p, rm, pinrow_distanceB, package_width, overlen_top, overlen_bottom, ddrill, pad_smdB, switch_width,
+                      switch_height, 'Piano', True, [], "Button_Switch_SMD", [0, 0, 0], [1, 1, 1],
+                      [0, 0, 0], "", True, webpage="https://www.nidec-copal-electronics.com/e/catalog/switch/chp.pdf", device_name="Copal_CHP-{0:02}xB".format(int(p/2)),switchtype=switchtype)
+
     os.chdir(cwd)

--- a/scripts/Buttons_Switches/make_DIPSwitches.py
+++ b/scripts/Buttons_Switches/make_DIPSwitches.py
@@ -214,4 +214,42 @@ if __name__ == '__main__':
                       switch_height, 'Slide', True, ["JPin"], "Button_Switch_SMD", [0, 0, 0], [1, 1, 1],
                       [0, 0, 0], "", True, webpage="http://www.kingtek.net.cn/pic/201601201446313350.pdf", device_name="KingTek_DSHP{0:02}TJ".format(int(p/2)),switchtype=switchtype)
     
+    # KingTek CHP B piano DIP-switches (https://www.nidec-copal-electronics.com/e/catalog/switch/chp.pdf):
+    pins = [4,8,16]
+    rm = 1.27
+    pinrow_distance = 7.62
+    package_width = 5.9
+    switch_width = 0.75
+    switch_height = 0.8
+    overlen_top = 1.65
+    overlen_bottom = overlen_top
+    ddrill = 0
+    pad_smd = [1.27, 0.76]
+    
+    os.chdir(cwd)
+    os.chdir("SMD")
+    for p in pins:
+        makeDIPSwitch(p, rm, pinrow_distance, package_width, overlen_top, overlen_bottom, ddrill, pad_smd, switch_width,
+                      switch_height, 'Piano', True, [], "Button_Switch_SMD", [0, 0, 0], [1, 1, 1],
+                      [0, 0, 0], "", True, webpage="https://www.nidec-copal-electronics.com/e/catalog/switch/chp.pdf", device_name="CHP-{0:02}xB".format(int(p/2)),switchtype=switchtype)
+    
+    # KingTek CHP A piano DIP-switches (https://www.nidec-copal-electronics.com/e/catalog/switch/chp.pdf):
+    pins = [4,8,16]
+    rm = 1.27
+    pinrow_distance = 5.08
+    package_width = 5.9
+    switch_width = 0.75
+    switch_height = 0.8
+    overlen_top = 1.65
+    overlen_bottom = overlen_top
+    ddrill = 0
+    pad_smd = [1.6, 0.76]
+    
+    os.chdir(cwd)
+    os.chdir("SMD")
+    for p in pins:
+        makeDIPSwitch(p, rm, pinrow_distance, package_width, overlen_top, overlen_bottom, ddrill, pad_smd, switch_width,
+                      switch_height, 'Piano', True, ["JPin"], "Button_Switch_SMD", [0, 0, 0], [1, 1, 1],
+                      [0, 0, 0], "", True, webpage="https://www.nidec-copal-electronics.com/e/catalog/switch/chp.pdf", device_name="CHP-{0:02}xA".format(int(p/2)),switchtype=switchtype)
+    
     os.chdir(cwd)

--- a/scripts/tools/footprint_scripts_DIP.py
+++ b/scripts/tools/footprint_scripts_DIP.py
@@ -253,8 +253,14 @@ def makeDIPSwitch(pins, rm, pinrow_distance, package_width, overlen_top, overlen
     t_crt = min(t_slk - crt_offset, (pins / 2 - 1) * rm / 2 - h_crt / 2)
     
     if (mode == 'Piano'):
-        l_crt = l_crt - switch_width
-        w_crt = w_crt + switch_width
+        if package_width>(pinrow_distance + pad[0]):
+            l_crt = l_crt - switch_width
+            w_crt = w_crt + switch_width
+        else:
+            overhang = package_width / 2 + switch_width - (pinrow_distance + pad[0]) / 2
+            if overhang>0:
+                l_crt = l_crt - overhang
+                w_crt = w_crt + overhang
     
     smdtext=''
     smddescription=''

--- a/scripts/tools/footprint_scripts_DIP.py
+++ b/scripts/tools/footprint_scripts_DIP.py
@@ -391,9 +391,9 @@ def makeDIPSwitch(pins, rm, pinrow_distance, package_width, overlen_top, overlen
         x = pinrow_distance / 2
         y = sw * rm
         if (mode == 'Piano'):
-            kicad_modg.append(
-                RectLine(start=[l_fab, y - switch_height / 2], end=[l_fab - switch_width, y + switch_height / 2],
-                         layer='F.Fab', width=lw_fab))
+            kicad_modg.append(Line(start=[l_fab, y - switch_height / 2], end=[l_fab - switch_width, y - switch_height / 2], layer='F.Fab', width=lw_fab))
+            kicad_modg.append(Line(start=[l_fab - switch_width, y - switch_height / 2], end=[l_fab - switch_width, y + switch_height / 2], layer='F.Fab', width=lw_fab))
+            kicad_modg.append(Line(start=[l_fab - switch_width, y + switch_height / 2], end=[l_fab, y + switch_height / 2], layer='F.Fab', width=lw_fab))
         else:
             kicad_modg.append(RectLine(start=[x - switch_width / 2, y - switch_height / 2],
                                        end=[x + switch_width / 2, y + switch_height / 2], layer='F.Fab', width=lw_fab))


### PR DESCRIPTION
Adding CHP Piano Switches
[Datasheet](https://www.nidec-copal-electronics.com/e/catalog/switch/chp.pdf)

Fixed 2 problems in `footprint_scripts_DIP.py`:

- first one caused incorrect courtyard drawing for SMD piano switches:
![Piano_A_OLD](https://user-images.githubusercontent.com/12682042/68071138-afa68a80-fda1-11e9-9c50-fa3cdb841ec9.png)

![Piano_B_OLD](https://user-images.githubusercontent.com/12682042/68071141-be8d3d00-fda1-11e9-8f5f-b39425746846.png)

Examples after fix:
![Piano_A](https://user-images.githubusercontent.com/12682042/68071154-d6fd5780-fda1-11e9-8a8b-7063d44914b8.png)

![Piano_B](https://user-images.githubusercontent.com/12682042/68071157-df559280-fda1-11e9-9bda-0db1ff6e4cfe.png)

- second one caused Travis errors during KLC F5.4 checking: piano switches drawings overlaps with main body on F.Fab:
![Piano_B_overlapping](https://user-images.githubusercontent.com/12682042/68071266-f8127800-fda2-11e9-8eb2-4bc4ff6a3c29.png)
