### PR TITLE
Added Bourns SRP6060FA inductor.

### DIFF
--- a/scripts/Inductor_SMD/Inductor_SMD.yml
+++ b/scripts/Inductor_SMD/Inductor_SMD.yml
@@ -28,6 +28,16 @@
 #
 #
 
+L_Bourns_SRP6060FA:
+  description: "Inductor, Bourns, SRP6060FA, 6.4mmx6.6mm"
+  datasheet: "https://www.bourns.com/docs/Product-Datasheets/SRP6060FA.pdf"
+  tags: "Inductor Bourns_SRP6060FA"
+  extratexts: [[-49.0, -0.05, "", "F.SilkS", 3.0, 3.0]]
+  at: [-3.20, 3.30]
+  size: [6.40, 6.60]
+  smd_tht: "smd"
+  pins: [["smd", "1", -2.025, 0, 1.55, 5.6, 0.0], ["smd", "2", 2.025, 0, 1.55, 5.6, 0.0]]
+
 L_TDK_SLF6025:
   description: "Inductor, TDK, SLF6025, 6.0mmx6.0mm"
   datasheet: "https://product.tdk.com/info/en/document/catalog/smd/inductor_commercial_power_slf6025_en.pdf"


### PR DESCRIPTION
Added Bourns SRP6060FA.
Datasheet: https://www.bourns.com/docs/Product-Datasheets/SRP6060FA.pdf
![imagen](https://user-images.githubusercontent.com/24567573/68120019-910cd480-ff04-11e9-8e4c-02d34b111532.png)
