### PR TITLE
Added Wuerth WE-XHMI.

### DIFF
--- a/scripts/Inductor_SMD/Inductor_SMD.yml
+++ b/scripts/Inductor_SMD/Inductor_SMD.yml
@@ -138,3 +138,15 @@ L_TDK_SLF12575:
   size: [12.5, 12.5]
   smd_tht: "smd"
   pins: [["smd", "1", -5.55, 0, 2.6, 3.2, 0.0], ["smd", "2", 5.55, 0, 2.6, 3.2, 0.0]]
+
+L_Wuerth_WE-XHMI:
+  description: "Inductor, Wuerth, WE-XHMI, 8.3mmx8.8mm"
+  datasheet: "https://katalog.we-online.de/pbs/datasheet/74439358068.pdf"
+  tags: "Inductor Wuerth WE-XHMI"
+  extratexts: [[-49.0, -0.05, "", "F.SilkS", 3.0, 3.0]]
+  at: [-4.15, 4.4]
+  size: [8.3, 8.8]
+  smd_tht: "smd"
+  pins: [["smd", "1", -2.5, 0, 1.6, 7.35, 0.0], ["smd", "2", 2.5, 0, 1.6, 7.35, 0.0]]
+
+


### PR DESCRIPTION
Datasheet: https://katalog.we-online.de/pbs/datasheet/74439358068.pdf

![imagen](https://user-images.githubusercontent.com/24567573/68121686-aab01b00-ff08-11e9-8eac-aafd4c5f24f1.png)
