### PR TITLE
Add user text example

### DIFF
--- a/KicadModTree/nodes/base/Text.py
+++ b/KicadModTree/nodes/base/Text.py
@@ -48,6 +48,7 @@ class Text(Node):
     >>> from KicadModTree import *
     >>> Text(type='reference', text='REF**', at=[0, -3], layer='F.SilkS')
     >>> Text(type='value', text="footprint name", at=[0, 3], layer='F.Fab')
+    >>> Text(type='user', text='test', at=[0, 0], layer='Cmts.User')
     """
 
     TYPE_REFERENCE = 'reference'


### PR DESCRIPTION
I've gotten tripped up too many times on the proper `type` for text that isn't the footprint refdes or value. Text.py doesn't have an example of this so to save myself (and hopefully other people) from spending time chasing down the proper value I added a simple example in the docstring.