### PR TITLE
add Texas Power PAD SO-20 (pick relevant changes from #340)

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/so.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/so.yaml
@@ -47,3 +47,55 @@ SO-4_4.4x3.9mm_P2.54mm:
   pitch: 2.54
   num_pins_x: 0
   num_pins_y: 2
+
+Texas_PowerPAD_SO-20-1EP_7.52x12.83mm_P1.27mm:
+  size_source: 'http://www.ti.com/lit/ds/symlink/opa569.pdf, http://www.ti.com/lit/an/slma004b/slma004b.pdf'
+  #custom_name_format: Texas_PowerPAD_SO-{pincount:d}-1EP_{size_x:.2g}x{size_y:.2g}mm_P{pitch:.2g}mm
+  body_size_x:
+    minimum: 7.45
+    maximum: 7.59
+  body_size_y:
+    minimum: 12.7
+    maximum: 12.95
+  overall_size_x:
+    minimum: 10.16
+    maximum: 10.65
+  overall_height:
+    nominal: 2.65
+    tolerance: 0
+  lead_width:
+    minimum: 0.35
+    maximum: 0.51
+  lead_len:
+    minimum: 0.4
+    maximum: 1.27
+  pitch: 1.27
+  num_pins_x: 0
+  num_pins_y: 10
+
+  # EP_size from OPA569 datasheet
+  # _overwrite from PowerPad app note slma004b.pdf
+  # mask size from OPA569 datasheet Figure 16: 3.56 mm x 4.47 mm
+  # Thermal vias from OPA569 datasheet Figure 16: 3x8=24pcs 13mil
+  EP_size_x:
+    minimum: 2.72
+    maximum: 3.81
+  EP_size_x_overwrite: 6.045 # 0.238"
+  EP_mask_x: 3.56
+  EP_size_y:
+    minimum: 3.49
+    maximum: 4.32
+  EP_size_y_overwrite: 12.09 # 0.476"
+  EP_mask_y: 4.47
+  
+  thermal_vias:
+    count: [3, 8]
+    # x-pitch 0.026" = 0.66 mm
+    # y-pitch 0.039"/2 = 0.495 mm
+    drill: 0.33 # 0.013"
+    min_annular_ring: 0.08 # (0.495 spacing - 0.33 drill)/2 =  0.08 mm max ring
+    paste_via_clearance: 0.1
+    EP_paste_coverage: 0.75
+    grid: [0.66, 0.495]
+    paste_avoid_via: False
+    EP_num_paste_pads: [2, 2]  


### PR DESCRIPTION
This adds a Texas PowerPAD SO-20.

Used by e.g. OPA569:
http://www.ti.com/lit/ds/symlink/opa569.pdf

Further details on footprint at:
http://www.ti.com/lit/an/slma004b/slma004b.pdf


#340 had the original work but this PR accidentally contained too much else also (rebase on master etc)
This closes #340 