### PR TITLE
Modify SMD_chip_package_rlc-etc.py to allow manufacturer PN naming.

### DIFF
--- a/scripts/SMD_chip_package_rlc-etc/SMD_chip_package_rlc-etc.py
+++ b/scripts/SMD_chip_package_rlc-etc/SMD_chip_package_rlc-etc.py
@@ -151,31 +151,40 @@ class TwoTerminalSMDchip():
         code_metric = device_size_data.get('code_metric')
         code_letter = device_size_data.get('code_letter')
         code_imperial = device_size_data.get('code_imperial')
+        manuf = device_size_data.get('manufacturer')
+        manuf_pn = device_size_data.get('manufacturer_pn')
+        description = device_size_data.get('description')
 
         if 'code_letter' in device_size_data:
             name_format = self.configuration['fp_name_tantal_format_string']
         else:
             if 'code_metric' in device_size_data:
                 name_format = self.configuration['fp_name_format_string']
-            else:
+            elif 'code_imperial' in device_size_data:
                 name_format = self.configuration['fp_name_non_metric_format_string']
+            else:
+                name_format = self.configuration['fp_name_manuf_pn_format_string']
 
         fp_name = name_format.format(prefix=prefix,
             code_imperial=code_imperial, code_metric=code_metric,
-            code_letter=code_letter, suffix=suffix)
+            code_letter=code_letter, suffix=suffix,
+            manufacturer=manuf, manuf_pn=manuf_pn)
         fp_name_2 = name_format.format(prefix=prefix,
             code_imperial=code_imperial, code_letter=code_letter,
-            code_metric=code_metric, suffix=suffix_3d)
+            code_metric=code_metric, suffix=suffix_3d,
+            manufacturer=manuf, manuf_pn=manuf_pn)
         model_name = '{model3d_path_prefix:s}{lib_name:s}.3dshapes/{fp_name:s}.wrl'.format(
             model3d_path_prefix=model3d_path_prefix, lib_name=footprint_group_data['fp_lib_name'], fp_name=fp_name_2)
         #print(fp_name)
         #print(pad_details)
 
         kicad_mod = Footprint(fp_name)
-
         # init kicad footprint
-        kicad_mod.setDescription(footprint_group_data['description'].format(code_imperial=code_imperial,
-            code_metric=code_metric, code_letter=code_letter,
+        if 'manufacturer' in device_size_data:
+          kicad_mod.setDescription(description)
+        else:
+          kicad_mod.setDescription(footprint_group_data['description'].format(code_imperial=code_imperial,
+            code_metric=code_metric, code_letter=code_letter, manufacturer=manuf, manuf_pn=manuf_pn,
             size_info=device_size_data.get('size_info')))
         kicad_mod.setTags(footprint_group_data['keywords'])
         kicad_mod.setAttribute('smd')

--- a/scripts/SMD_chip_package_rlc-etc/config_KLCv3.0.yaml
+++ b/scripts/SMD_chip_package_rlc-etc/config_KLCv3.0.yaml
@@ -8,6 +8,7 @@ fp_name_format_string: '{prefix:s}_{code_imperial:s}_{code_metric:s}Metric{suffi
 fp_name_non_metric_format_string: '{prefix:s}_{code_imperial:s}{suffix:s}'
 
 fp_name_tantal_format_string: '{prefix:s}_EIA-{code_metric:s}_{code_letter:s}{suffix:s}'
+fp_name_manuf_pn_format_string: '{manufacturer:s}_{manuf_pn:s}{suffix:s}'
 
 3d_model_prefix: '${KISYS3DMOD}/'
 


### PR DESCRIPTION
I needed to generate a footprint for a ceramic chip antenna, like this one:
  https://www.johansontechnology.com/datasheets/2450AT18A100/2450AT18A100.pdf

I thought it would be great to use SMD_chip_package_rlc-etc.py for this, but it doesn't allow to modify the naming to a manufacturer_part-number scheme.

This patch allows to add 3 more data fields: manufacturer, manufacturer_pn and description.
Using this, I can generate footprints for the above antenna, with correct naming.