### PR TITLE
Add NXP SOT1345-1 footprint

### DIFF
--- a/scripts/Packages/Package_BGA/bga.yaml
+++ b/scripts/Packages/Package_BGA/bga.yaml
@@ -87,6 +87,18 @@ Texas_MicroStar_Junior_BGA-113_7.0x7.0mm_Layout12x12_P0.5mm:
   layout_y: 12
   mask_margin: 0.025
   row_skips: [[], [], [[4, 11]], [3, 10], [3, 10], [3, 6, 7, 10], [3, 6, 7, 10], [3, 10], [3, 10], [[3, 11]], [], []]
+TFBGA-50_5.1x5.1mm_Layout9x9_P0.5mm:
+  description: "TFBGA-50"
+  size_source: "https://www.nxp.com/docs/en/package-information/SOT1345-1.pdf"
+  body_size_x: 5.1
+  body_size_y: 5.1
+  pitch: 0.5
+  pad_diameter: 0.28
+  mask_margin: 0.05
+  paste_margin: 0.01
+  layout_x: 9
+  layout_y: 9
+  row_skips: [[3, 7], [], [1, 3, 4, 5, 6, 7, 9], [3, 4, 5, 6, 7], [3, 4, 5, 6, 7], [3, 4, 5, 6, 7], [1, 3, 4, 5, 6, 7, 9], [], []]
 TFBGA-64_5x5mm_Layout8x8_P0.5mm:
   description: "TFBGA-64"
   size_source: "http://www.st.com/resource/en/datasheet/stm32f100v8.pdf#page=83"


### PR DESCRIPTION
Used on the NXP CBTL06GP213, as well as the TI HD3SS214