### PR TITLE
Added TSSOP footprint variants as specified in JEDEC MO-153.

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tssop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tssop.yaml
@@ -9,92 +9,48 @@ FileHeader:
 
 TSSOP-24_4.4x5mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var CA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 5.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 5.0 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 12
 
 TSSOP-32_4.4x6.5mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var CB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 6.5
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 6.5 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 16
 
 TSSOP-36_4.4x7.8mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var CC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 7.8
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 7.8 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 18
 
 TSSOP-48_4.4x9.7mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var CD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 9.7
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 9.7 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 24
@@ -106,138 +62,72 @@ TSSOP-48_4.4x9.7mm_P0.4mm:
 
 TSSOP-36_6.1x7.8mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var FA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 7.8
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 7.8 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 18
 
 TSSOP-48_6.1x9.7mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var FB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 9.7
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 9.7 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 24
 
 TSSOP-52_6.1x11mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var FC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 11.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 11.0 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 26
 
 TSSOP-56_6.1x12.5mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var FD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 12.5
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 12.5 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 28
 
 TSSOP-64_6.1x14mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var FE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 14.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 14.0 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 32
 
 TSSOP-80_6.1x17mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var FF https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 17.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 17.0 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 40
@@ -249,138 +139,72 @@ TSSOP-80_6.1x17mm_P0.4mm:
 
 TSSOP-48_8x9.7mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var JA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 8.0
-    tolerance: 0.1
-  body_size_y:
-    nominal: 9.7
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 10.0
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 8.0 +/-0.1
+  body_size_y: 9.7 +/-0.1
+  overall_size_x: 10.0 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 24
 
 TSSOP-52_8x11mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var JB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 8.0
-    tolerance: 0.1
-  body_size_y:
-    nominal: 11.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 10.0
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 8.0 +/-0.1
+  body_size_y: 11.0 +/-0.1
+  overall_size_x: 10.0 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 26
 
 TSSOP-56_8x12.5mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var JC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 8.0
-    tolerance: 0.1
-  body_size_y:
-    nominal: 12.5
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 10.0
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 8.0 +/-0.1
+  body_size_y: 12.5 +/-0.1
+  overall_size_x: 10.0 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 28
 
 TSSOP-60_8x12.5mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var JC-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 8.0
-    tolerance: 0.1
-  body_size_y:
-    nominal: 12.5
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 10.0
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 8.0 +/-0.1
+  body_size_y: 12.5 +/-0.1
+  overall_size_x: 10.0 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 30
 
 TSSOP-64_8x14mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var JD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 8.0
-    tolerance: 0.1
-  body_size_y:
-    nominal: 14.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 10.0
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 8.0 +/-0.1
+  body_size_y: 14.0 +/-0.1
+  overall_size_x: 10.0 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 32
 
 TSSOP-68_8x14mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var JD-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 8.0
-    tolerance: 0.1
-  body_size_y:
-    nominal: 14.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 10.0
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.13
-    maximum: 0.23
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 8.0 +/-0.1
+  body_size_y: 14.0 +/-0.1
+  overall_size_x: 10.0 +/-0.1
+  body_height: 1.2
+  lead_width: 0.13 .. 0.23
+  lead_len: 0.6 +/-0.15
   pitch: 0.4
   num_pins_x: 0
   num_pins_y: 34
@@ -392,184 +216,96 @@ TSSOP-68_8x14mm_P0.4mm:
 
 TSSOP-20_4.4x5mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 5.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 5.0 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 10
 
 TSSOP-24_4.4x6.5mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 6.5
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 6.5 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 12
 
 TSSOP-28_4.4x7.8mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 7.8
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 7.8 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 14
 
 TSSOP-30_4.4x7.8mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BC-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 7.8
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 7.8 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 15
 
 TSSOP-36_4.4x9.7mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 9.7
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 9.7 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 18
 
 TSSOP-38_4.4x9.7mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 9.7
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 9.7 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 19
 
 TSSOP-44_4.4x11mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 11.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 11.0 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 22
 
 TSSOP-50_4.4x12.5mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BF https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 12.5
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 12.5 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 25
@@ -581,161 +317,84 @@ TSSOP-50_4.4x12.5mm_P0.5mm:
 
 TSSOP-28_6.1x7.8mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var EA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 7.8
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 7.8 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 14
 
 TSSOP-36_6.1x9.7mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var EB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 9.7
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 9.7 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 18
 
 TSSOP-40_6.1x11mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var EC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 11.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 11.0 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 20
 
 TSSOP-44_6.1x11mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var EC-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 11.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 11.0 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 22
 
 TSSOP-48_6.1x12.5mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var ED https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 12.5
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 12.5 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 24
 
 TSSOP-56_6.1x14mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var EE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 14.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 14.0 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 28
 
 TSSOP-64_6.1x17mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var EF https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 17.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.27
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 17.0 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.27
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 32
@@ -747,92 +406,48 @@ TSSOP-64_6.1x17mm_P0.5mm:
 
 TSSOP-36_8x9.7mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var HA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 8.0
-    tolerance: 0.1
-  body_size_y:
-    nominal: 9.7
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 10.0
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 8.0 +/-0.1
+  body_size_y: 9.7 +/-0.1
+  overall_size_x: 10.0 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 18
 
 TSSOP-40_8x11mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var HB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 8.0
-    tolerance: 0.1
-  body_size_y:
-    nominal: 11.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 10.0
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 8.0 +/-0.1
+  body_size_y: 11.0 +/-0.1
+  overall_size_x: 10.0 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 20
 
 TSSOP-48_8x12.5mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var HC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 8.0
-    tolerance: 0.1
-  body_size_y:
-    nominal: 12.5
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 10.0
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 8.0 +/-0.1
+  body_size_y: 12.5 +/-0.1
+  overall_size_x: 10.0 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 24
 
 TSSOP-56_8x14mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var HD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 8.0
-    tolerance: 0.1
-  body_size_y:
-    nominal: 14.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 10.0
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 8.0 +/-0.1
+  body_size_y: 14.0 +/-0.1
+  overall_size_x: 10.0 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.5
   num_pins_x: 0
   num_pins_y: 28
@@ -844,141 +459,72 @@ TSSOP-56_8x14mm_P0.5mm:
 
 TSSOP-8_4.4x3mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var AA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    minimum: 2.9
-    nominal: 3
-    maximum: 3.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 3.0 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 4
 
 TSSOP-16_4.4x5mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var AB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    minimum: 4.9
-    nominal: 5
-    maximum: 5.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 5.0 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 8
 
 TSSOP-14_4.4x5mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var AB-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    minimum: 4.9
-    nominal: 5
-    maximum: 5.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 5.0 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 7
 
 TSSOP-20_4.4x6.5mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var AC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 6.5
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 6.5 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 10
 
 TSSOP-24_4.4x7.8mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var AD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 7.8
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 7.8 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 12
 
 TSSOP-28_4.4x9.7mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var AE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 4.4
-    tolerance: 0.1
-  body_size_y:
-    nominal: 9.7
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 6.4
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 4.4 +/-0.1
+  body_size_y: 9.7 +/-0.1
+  overall_size_x: 6.4 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 14
@@ -990,161 +536,84 @@ TSSOP-28_4.4x9.7mm_P0.65mm:
 
 TSSOP-24_6.1x7.8mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var DA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 7.8
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 7.8 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 12
 
 TSSOP-28_6.1x9.7mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var DB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 9.7
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 9.7 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 14
 
 TSSOP-30_6.1x9.7mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var DB-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 9.7
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 9.7 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 15
 
 TSSOP-32_6.1x11mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var DC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 11.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 11.0 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 16
 
 TSSOP-36_6.1x12.5mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var DD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 12.5
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 12.5 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 18
 
 TSSOP-38_6.1x12.5mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var DD-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 12.5
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 12.5 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 19
 
 TSSOP-40_6.1x14mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var DE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 6.1
-    tolerance: 0.1
-  body_size_y:
-    nominal: 14.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 8.1
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 6.1 +/-0.1
+  body_size_y: 14.0 +/-0.1
+  overall_size_x: 8.1 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 20
@@ -1156,92 +625,48 @@ TSSOP-40_6.1x14mm_P0.65mm:
 
 TSSOP-28_8x9.7mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var GA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 8.0
-    tolerance: 0.1
-  body_size_y:
-    nominal: 9.7
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 10.0
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 8.0 +/-0.1
+  body_size_y: 9.7 +/-0.1
+  overall_size_x: 10.0 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 14
 
 TSSOP-32_8x11mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var GB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 8.0
-    tolerance: 0.1
-  body_size_y:
-    nominal: 11.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 10.0
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 8.0 +/-0.1
+  body_size_y: 11.0 +/-0.1
+  overall_size_x: 10.0 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 16
 
 TSSOP-36_8x12.5mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var GC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 8.0
-    tolerance: 0.1
-  body_size_y:
-    nominal: 12.5
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 10.0
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 8.0 +/-0.1
+  body_size_y: 12.5 +/-0.1
+  overall_size_x: 10.0 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 18
 
 TSSOP-40_8x14mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var GD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
-  body_size_x:
-    nominal: 8.0
-    tolerance: 0.1
-  body_size_y:
-    nominal: 14.0
-    tolerance: 0.1
-  body_height:
-    maximum: 1.2
-  overall_size_x:
-    nominal: 10.0
-    tolerance: 0.1
-  lead_width:
-    minimum: 0.17
-    maximum: 0.30
-  lead_len:
-    nominal: 0.6
-    tolerance: 0.15
+  body_size_x: 8.0 +/-0.1
+  body_size_y: 14.0 +/-0.1
+  overall_size_x: 10.0 +/-0.1
+  body_height: 1.2
+  lead_width: 0.17 .. 0.30
+  lead_len: 0.6 +/-0.15
   pitch: 0.65
   num_pins_x: 0
   num_pins_y: 20

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tssop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tssop.yaml
@@ -756,7 +756,7 @@ TSSOP-36_8x9.7mm_P0.5mm:
   body_height:
     maximum: 1.2
   overall_size_x:
-    nominal: 8.1
+    nominal: 10.0
     tolerance: 0.1
   lead_width:
     minimum: 0.17
@@ -779,7 +779,7 @@ TSSOP-40_8x11mm_P0.5mm:
   body_height:
     maximum: 1.2
   overall_size_x:
-    nominal: 8.1
+    nominal: 10.0
     tolerance: 0.1
   lead_width:
     minimum: 0.17
@@ -802,7 +802,7 @@ TSSOP-48_8x12.5mm_P0.5mm:
   body_height:
     maximum: 1.2
   overall_size_x:
-    nominal: 8.1
+    nominal: 10.0
     tolerance: 0.1
   lead_width:
     minimum: 0.17
@@ -825,7 +825,7 @@ TSSOP-56_8x14mm_P0.5mm:
   body_height:
     maximum: 1.2
   overall_size_x:
-    nominal: 8.1
+    nominal: 10.0
     tolerance: 0.1
   lead_width:
     minimum: 0.17

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tssop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tssop.yaml
@@ -11,7 +11,7 @@ TSSOP-24_4.4x5mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var CA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 5.0 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -23,7 +23,7 @@ TSSOP-32_4.4x6.5mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var CB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 6.5 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -35,7 +35,7 @@ TSSOP-36_4.4x7.8mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var CC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 7.8 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -47,7 +47,7 @@ TSSOP-48_4.4x9.7mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var CD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 9.7 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -64,7 +64,7 @@ TSSOP-36_6.1x7.8mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var FA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 7.8 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -76,7 +76,7 @@ TSSOP-48_6.1x9.7mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var FB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 9.7 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -88,7 +88,7 @@ TSSOP-52_6.1x11mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var FC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 11.0 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -100,7 +100,7 @@ TSSOP-56_6.1x12.5mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var FD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 12.5 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -112,7 +112,7 @@ TSSOP-64_6.1x14mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var FE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 14.0 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -124,7 +124,7 @@ TSSOP-80_6.1x17mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var FF https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 17.0 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -141,7 +141,7 @@ TSSOP-48_8x9.7mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var JA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 8.0 +/-0.1
   body_size_y: 9.7 +/-0.1
-  overall_size_x: 10.0 +/-0.1
+  overall_size_x: 10.0
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -153,7 +153,7 @@ TSSOP-52_8x11mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var JB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 8.0 +/-0.1
   body_size_y: 11.0 +/-0.1
-  overall_size_x: 10.0 +/-0.1
+  overall_size_x: 10.0
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -165,7 +165,7 @@ TSSOP-56_8x12.5mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var JC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 8.0 +/-0.1
   body_size_y: 12.5 +/-0.1
-  overall_size_x: 10.0 +/-0.1
+  overall_size_x: 10.0
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -177,7 +177,7 @@ TSSOP-60_8x12.5mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var JC-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 8.0 +/-0.1
   body_size_y: 12.5 +/-0.1
-  overall_size_x: 10.0 +/-0.1
+  overall_size_x: 10.0
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -189,7 +189,7 @@ TSSOP-64_8x14mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var JD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 8.0 +/-0.1
   body_size_y: 14.0 +/-0.1
-  overall_size_x: 10.0 +/-0.1
+  overall_size_x: 10.0
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -201,7 +201,7 @@ TSSOP-68_8x14mm_P0.4mm:
   size_source: 'JEDEC MO-153 Var JD-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 8.0 +/-0.1
   body_size_y: 14.0 +/-0.1
-  overall_size_x: 10.0 +/-0.1
+  overall_size_x: 10.0
   body_height: 1.2
   lead_width: 0.13 .. 0.23
   lead_len: 0.6 +/-0.15
@@ -218,7 +218,7 @@ TSSOP-20_4.4x5mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 5.0 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -230,7 +230,7 @@ TSSOP-24_4.4x6.5mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 6.5 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -242,7 +242,7 @@ TSSOP-28_4.4x7.8mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 7.8 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -254,7 +254,7 @@ TSSOP-30_4.4x7.8mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BC-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 7.8 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -266,7 +266,7 @@ TSSOP-36_4.4x9.7mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 9.7 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -278,7 +278,7 @@ TSSOP-38_4.4x9.7mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 9.7 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -290,7 +290,7 @@ TSSOP-44_4.4x11mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 11.0 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -302,7 +302,7 @@ TSSOP-50_4.4x12.5mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var BF https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 12.5 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -319,7 +319,7 @@ TSSOP-28_6.1x7.8mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var EA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 7.8 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -331,7 +331,7 @@ TSSOP-36_6.1x9.7mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var EB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 9.7 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -343,7 +343,7 @@ TSSOP-40_6.1x11mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var EC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 11.0 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -355,7 +355,7 @@ TSSOP-44_6.1x11mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var EC-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 11.0 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -367,7 +367,7 @@ TSSOP-48_6.1x12.5mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var ED https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 12.5 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -379,7 +379,7 @@ TSSOP-56_6.1x14mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var EE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 14.0 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -391,7 +391,7 @@ TSSOP-64_6.1x17mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var EF https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 17.0 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.17 .. 0.27
   lead_len: 0.6 +/-0.15
@@ -408,7 +408,7 @@ TSSOP-36_8x9.7mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var HA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 8.0 +/-0.1
   body_size_y: 9.7 +/-0.1
-  overall_size_x: 10.0 +/-0.1
+  overall_size_x: 10.0
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -420,7 +420,7 @@ TSSOP-40_8x11mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var HB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 8.0 +/-0.1
   body_size_y: 11.0 +/-0.1
-  overall_size_x: 10.0 +/-0.1
+  overall_size_x: 10.0
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -432,7 +432,7 @@ TSSOP-48_8x12.5mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var HC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 8.0 +/-0.1
   body_size_y: 12.5 +/-0.1
-  overall_size_x: 10.0 +/-0.1
+  overall_size_x: 10.0
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -444,7 +444,7 @@ TSSOP-56_8x14mm_P0.5mm:
   size_source: 'JEDEC MO-153 Var HD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 8.0 +/-0.1
   body_size_y: 14.0 +/-0.1
-  overall_size_x: 10.0 +/-0.1
+  overall_size_x: 10.0
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -461,7 +461,7 @@ TSSOP-8_4.4x3mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var AA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 3.0 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -473,7 +473,7 @@ TSSOP-16_4.4x5mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var AB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 5.0 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -485,7 +485,7 @@ TSSOP-14_4.4x5mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var AB-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 5.0 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -497,7 +497,7 @@ TSSOP-20_4.4x6.5mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var AC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 6.5 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -509,7 +509,7 @@ TSSOP-24_4.4x7.8mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var AD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 7.8 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -521,7 +521,7 @@ TSSOP-28_4.4x9.7mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var AE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 4.4 +/-0.1
   body_size_y: 9.7 +/-0.1
-  overall_size_x: 6.4 +/-0.1
+  overall_size_x: 6.4
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -538,7 +538,7 @@ TSSOP-24_6.1x7.8mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var DA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 7.8 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -550,7 +550,7 @@ TSSOP-28_6.1x9.7mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var DB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 9.7 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -562,7 +562,7 @@ TSSOP-30_6.1x9.7mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var DB-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 9.7 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -574,7 +574,7 @@ TSSOP-32_6.1x11mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var DC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 11.0 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -586,7 +586,7 @@ TSSOP-36_6.1x12.5mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var DD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 12.5 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -598,7 +598,7 @@ TSSOP-38_6.1x12.5mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var DD-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 12.5 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -610,7 +610,7 @@ TSSOP-40_6.1x14mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var DE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 6.1 +/-0.1
   body_size_y: 14.0 +/-0.1
-  overall_size_x: 8.1 +/-0.1
+  overall_size_x: 8.1
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -627,7 +627,7 @@ TSSOP-28_8x9.7mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var GA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 8.0 +/-0.1
   body_size_y: 9.7 +/-0.1
-  overall_size_x: 10.0 +/-0.1
+  overall_size_x: 10.0
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -639,7 +639,7 @@ TSSOP-32_8x11mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var GB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 8.0 +/-0.1
   body_size_y: 11.0 +/-0.1
-  overall_size_x: 10.0 +/-0.1
+  overall_size_x: 10.0
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -651,7 +651,7 @@ TSSOP-36_8x12.5mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var GC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 8.0 +/-0.1
   body_size_y: 12.5 +/-0.1
-  overall_size_x: 10.0 +/-0.1
+  overall_size_x: 10.0
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15
@@ -663,7 +663,7 @@ TSSOP-40_8x14mm_P0.65mm:
   size_source: 'JEDEC MO-153 Var GD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
   body_size_x: 8.0 +/-0.1
   body_size_y: 14.0 +/-0.1
-  overall_size_x: 10.0 +/-0.1
+  overall_size_x: 10.0
   body_height: 1.2
   lead_width: 0.17 .. 0.30
   lead_len: 0.6 +/-0.15

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tssop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/tssop.yaml
@@ -1,0 +1,1247 @@
+FileHeader:
+  library_Suffix: 'SO'
+  device_type: 'TSSOP'
+
+##############################################################################
+# TSSOP Variations - 0.40 PITCH
+# BODY WIDTH (E1) = 4.40 NOM
+##############################################################################
+
+TSSOP-24_4.4x5mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var CA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 5.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 12
+
+TSSOP-32_4.4x6.5mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var CB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 6.5
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 16
+
+TSSOP-36_4.4x7.8mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var CC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 7.8
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 18
+
+TSSOP-48_4.4x9.7mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var CD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 9.7
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 24
+
+##############################################################################
+# TSSOP Variations - 0.40 PITCH
+# BODY WIDTH (E1) = 6.10 NOM
+##############################################################################
+
+TSSOP-36_6.1x7.8mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var FA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 7.8
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 18
+
+TSSOP-48_6.1x9.7mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var FB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 9.7
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 24
+
+TSSOP-52_6.1x11mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var FC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 11.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 26
+
+TSSOP-56_6.1x12.5mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var FD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 12.5
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 28
+
+TSSOP-64_6.1x14mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var FE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 14.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 32
+
+TSSOP-80_6.1x17mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var FF https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 17.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 40
+
+##############################################################################
+# TSSOP Variations - 0.40 PITCH
+# BODY WIDTH (E1) = 8.00 NOM
+##############################################################################
+
+TSSOP-48_8x9.7mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var JA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 8.0
+    tolerance: 0.1
+  body_size_y:
+    nominal: 9.7
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 10.0
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 24
+
+TSSOP-52_8x11mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var JB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 8.0
+    tolerance: 0.1
+  body_size_y:
+    nominal: 11.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 10.0
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 26
+
+TSSOP-56_8x12.5mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var JC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 8.0
+    tolerance: 0.1
+  body_size_y:
+    nominal: 12.5
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 10.0
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 28
+
+TSSOP-60_8x12.5mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var JC-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 8.0
+    tolerance: 0.1
+  body_size_y:
+    nominal: 12.5
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 10.0
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 30
+
+TSSOP-64_8x14mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var JD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 8.0
+    tolerance: 0.1
+  body_size_y:
+    nominal: 14.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 10.0
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 32
+
+TSSOP-68_8x14mm_P0.4mm:
+  size_source: 'JEDEC MO-153 Var JD-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 8.0
+    tolerance: 0.1
+  body_size_y:
+    nominal: 14.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 10.0
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.13
+    maximum: 0.23
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.4
+  num_pins_x: 0
+  num_pins_y: 34
+
+##############################################################################
+# TSSOP Variations - 0.50 PITCH
+# BODY WIDTH (E1) = 4.40 NOM
+##############################################################################
+
+TSSOP-20_4.4x5mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var BA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 5.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 10
+
+TSSOP-24_4.4x6.5mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var BB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 6.5
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 12
+
+TSSOP-28_4.4x7.8mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var BC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 7.8
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 14
+
+TSSOP-30_4.4x7.8mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var BC-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 7.8
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 15
+
+TSSOP-36_4.4x9.7mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var BD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 9.7
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 18
+
+TSSOP-38_4.4x9.7mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var BD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 9.7
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 19
+
+TSSOP-44_4.4x11mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var BE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 11.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 22
+
+TSSOP-50_4.4x12.5mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var BF https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 12.5
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 25
+
+##############################################################################
+# TSSOP Variations - 0.50 PITCH
+# BODY WIDTH (E1) = 6.10 NOM
+##############################################################################
+
+TSSOP-28_6.1x7.8mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var EA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 7.8
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 14
+
+TSSOP-36_6.1x9.7mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var EB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 9.7
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 18
+
+TSSOP-40_6.1x11mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var EC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 11.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 20
+
+TSSOP-44_6.1x11mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var EC-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 11.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 22
+
+TSSOP-48_6.1x12.5mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var ED https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 12.5
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 24
+
+TSSOP-56_6.1x14mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var EE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 14.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 28
+
+TSSOP-64_6.1x17mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var EF https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 17.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.27
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 32
+
+##############################################################################
+# TSSOP Variations - 0.50 PITCH
+# BODY WIDTH (E1) = 8.00 NOM
+##############################################################################
+
+TSSOP-36_8x9.7mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var HA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 8.0
+    tolerance: 0.1
+  body_size_y:
+    nominal: 9.7
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 18
+
+TSSOP-40_8x11mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var HB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 8.0
+    tolerance: 0.1
+  body_size_y:
+    nominal: 11.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 20
+
+TSSOP-48_8x12.5mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var HC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 8.0
+    tolerance: 0.1
+  body_size_y:
+    nominal: 12.5
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 24
+
+TSSOP-56_8x14mm_P0.5mm:
+  size_source: 'JEDEC MO-153 Var HD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 8.0
+    tolerance: 0.1
+  body_size_y:
+    nominal: 14.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.5
+  num_pins_x: 0
+  num_pins_y: 28
+
+##############################################################################
+# TSSOP Variations - 0.65 PITCH
+# BODY WIDTH (E1) = 4.40 NOM
+##############################################################################
+
+TSSOP-8_4.4x3mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var AA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    minimum: 2.9
+    nominal: 3
+    maximum: 3.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 4
+
+TSSOP-16_4.4x5mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var AB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    minimum: 4.9
+    nominal: 5
+    maximum: 5.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 8
+
+TSSOP-14_4.4x5mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var AB-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    minimum: 4.9
+    nominal: 5
+    maximum: 5.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 7
+
+TSSOP-20_4.4x6.5mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var AC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 6.5
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 10
+
+TSSOP-24_4.4x7.8mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var AD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 7.8
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 12
+
+TSSOP-28_4.4x9.7mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var AE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 4.4
+    tolerance: 0.1
+  body_size_y:
+    nominal: 9.7
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 6.4
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 14
+
+##############################################################################
+# TSSOP Variations - 0.65 PITCH
+# BODY WIDTH (E1) = 6.10 NOM
+##############################################################################
+
+TSSOP-24_6.1x7.8mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var DA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 7.8
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 12
+
+TSSOP-28_6.1x9.7mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var DB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 9.7
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 14
+
+TSSOP-30_6.1x9.7mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var DB-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 9.7
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 15
+
+TSSOP-32_6.1x11mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var DC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 11.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 16
+
+TSSOP-36_6.1x12.5mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var DD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 12.5
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 18
+
+TSSOP-38_6.1x12.5mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var DD-1 https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 12.5
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 19
+
+TSSOP-40_6.1x14mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var DE https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 6.1
+    tolerance: 0.1
+  body_size_y:
+    nominal: 14.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 8.1
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 20
+
+##############################################################################
+# TSSOP Variations - 0.65 PITCH
+# BODY WIDTH (E1) = 8.0 NOM
+##############################################################################
+
+TSSOP-28_8x9.7mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var GA https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 8.0
+    tolerance: 0.1
+  body_size_y:
+    nominal: 9.7
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 10.0
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 14
+
+TSSOP-32_8x11mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var GB https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 8.0
+    tolerance: 0.1
+  body_size_y:
+    nominal: 11.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 10.0
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 16
+
+TSSOP-36_8x12.5mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var GC https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 8.0
+    tolerance: 0.1
+  body_size_y:
+    nominal: 12.5
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 10.0
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 18
+
+TSSOP-40_8x14mm_P0.65mm:
+  size_source: 'JEDEC MO-153 Var GD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153'
+  body_size_x:
+    nominal: 8.0
+    tolerance: 0.1
+  body_size_y:
+    nominal: 14.0
+    tolerance: 0.1
+  body_height:
+    maximum: 1.2
+  overall_size_x:
+    nominal: 10.0
+    tolerance: 0.1
+  lead_width:
+    minimum: 0.17
+    maximum: 0.30
+  lead_len:
+    nominal: 0.6
+    tolerance: 0.15
+  pitch: 0.65
+  num_pins_x: 0
+  num_pins_y: 20


### PR DESCRIPTION
Datasheet:
https://www.jedec.org/standards-documents/docs/mo-153-f

This includes all the variants listed in the JEDEC registration. I can also add all the other TSSOP variants that are in the KiCad library but not in the JEDEC registration. But to make review bit easier I thought it might be better to add those as a separate pull request.

Let me know what you would prefer.