### PR TITLE
Generate MSOP-8_3x3mm_P0.65 using fine pitch definitions

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/msop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/msop.yaml
@@ -4,6 +4,7 @@ FileHeader:
 
 MSOP-8_3x3mm_P0.65mm:
   size_source: 'https://www.jedec.org/system/files/docs/mo-187F.pdf variant AA'
+  force_small_pitch_ipc_definition: True
   body_size_x: 3 +/-0.2
   body_size_y: 3 +/-0.2
   overall_size_x: 4.9 +/-0.25


### PR DESCRIPTION
Fixes https://github.com/KiCad/kicad-footprints/issues/2082

FP: https://github.com/KiCad/kicad-footprints/pull/2102

![MSOP-8_3x3mm_P0](https://user-images.githubusercontent.com/40901018/75085773-e0672700-552c-11ea-993b-7e18623680c0.png)