### PR TITLE
Generate P0.65mm gullwing packages using fine pitch defs

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/pqfp.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/pqfp.yaml
@@ -2,8 +2,9 @@ FileHeader:
   library_Suffix: 'QFP'
   device_type: 'PQFP'
 
-PQFP_100:
+PQFP-100_14x20mm_P0.65mm:
   size_source: 'http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=131095'
+  force_small_pitch_ipc_definition: True
   body_size_x:
     nominal: 14
     tolerance: 0
@@ -28,8 +29,9 @@ PQFP_100:
   num_pins_x: 20
   num_pins_y: 30
 
-PQFP_144:
+PQFP-144_28x28mm_P0.65mm:
   size_source: 'http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=131095'
+  force_small_pitch_ipc_definition: True
   body_size_x:
     nominal: 28
   body_size_y:
@@ -48,8 +50,9 @@ PQFP_144:
   num_pins_x: 36
   num_pins_y: 36
 
-PQFP_160:
+PQFP-160_28x28mm_P0.65mm:
   size_source: 'http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=131095'
+  force_small_pitch_ipc_definition: True
   body_size_x:
     nominal: 28
   body_size_y:


### PR DESCRIPTION
See https://github.com/KiCad/kicad-footprints/issues/2082

FP: https://github.com/KiCad/kicad-footprints/pull/2103

* Fix PQFP

![PQFP-100_14x20mm_P0](https://user-images.githubusercontent.com/40901018/75088677-10282600-5551-11ea-95c1-0bca8b8fa391.png)
![PQFP-144_28x28mm_P0](https://user-images.githubusercontent.com/40901018/75088678-13bbad00-5551-11ea-9973-5a63d4532751.png)
![PQFP-160_28x28mm_P0](https://user-images.githubusercontent.com/40901018/75088681-174f3400-5551-11ea-8478-ca46a8466ea8.png)