### PR TITLE
Add ipc noLead silkscreen calculator

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/ipc_noLead_generator.py
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/ipc_noLead_generator.py
@@ -16,6 +16,7 @@ sys.path.append(os.path.join(sys.path[0], "..", "..", "tools"))  # load parent p
 from footprint_text_fields import addTextFields
 from ipc_pad_size_calculators import *
 from quad_dual_pad_border import add_dual_or_quad_pad_border
+from silkscreen_calc import calc_silk_x, calc_silk_y
 
 sys.path.append(os.path.join(sys.path[0], "..", "utils"))
 from ep_handling_utils import getEpRoundRadiusParams
@@ -405,32 +406,34 @@ class NoLead():
         silk_pad_offset = configuration['silk_pad_clearance'] + configuration['silk_line_width']/2
         silk_offset = configuration['silk_fab_offset']
         if device_params['num_pins_x'] == 0:
+            x1, x2 = calc_silk_x(device_params, body_edge)
             kicad_mod.append(Line(
-                start={'x':0,
+                start={'x':x1[0],
                     'y':body_edge['top']-silk_offset},
-                end={'x':body_edge['right'],
+                end={'x':x1[1],
                     'y':body_edge['top']-silk_offset},
                 width=configuration['silk_line_width'],
                 layer="F.SilkS"))
             kicad_mod.append(Line(
-                start={'x':body_edge['left'],
+                start={'x':x2[0],
                     'y':body_edge['bottom']+silk_offset},
-                end={'x':body_edge['right'],
+                end={'x':x2[1],
                     'y':body_edge['bottom']+silk_offset},
                 width=configuration['silk_line_width'],
                 layer="F.SilkS", y_mirror=0))
         elif device_params['num_pins_y'] == 0:
+            y1, y2 = calc_silk_y(device_params, body_edge)
             kicad_mod.append(Line(
-                start={'y':0,
+                start={'y':y1[0],
                     'x':body_edge['left']-silk_offset},
-                end={'y':body_edge['bottom'],
+                end={'y':y1[1],
                     'x':body_edge['left']-silk_offset},
                 width=configuration['silk_line_width'],
                 layer="F.SilkS"))
             kicad_mod.append(Line(
-                start={'y':body_edge['top'],
+                start={'y':y2[0],
                     'x':body_edge['right']+silk_offset},
-                end={'y':body_edge['bottom'],
+                end={'y':y2[1],
                     'x':body_edge['right']+silk_offset},
                 width=configuration['silk_line_width'],
                 layer="F.SilkS", x_mirror=0))

--- a/scripts/tools/silkscreen_calc.py
+++ b/scripts/tools/silkscreen_calc.py
@@ -1,0 +1,149 @@
+""" Calculates the silkscreen lines for components with
+non-standard pin number positions.
+
+calc_silk_y: Calculates the start and end coordinates for
+    the left and right lines on either side of the part.
+
+    Showing silk arrangement for CCW pin count.
+    Silkscreen indpendent of CW/CCW.
+
+    l1      l2
+               top_left
+               --------
+      1*  4 | l1 (0, body_edge['bottom'])
+    | 2   3 | l2 (body_edge['top'], body_edge['bottom'])
+
+               bottom_left
+               -----------
+    | 4   3 | l1 (0, body_edge['top'])
+      1*  2 | l2 (body_edge['top'], body_edge['bottom'])
+
+               bottom_right
+               ------------
+    | 3   2 | l1 (body_edge['top'], body_edge['bottom'])
+    | 4   1*  l2 (0, body_edge['top'])
+
+               top_right
+               ---------
+    | 2   1*  l1 (body_edge['top'], body_edge['bottom'])
+    | 3   4 | l2 (0, body_edge['bottom'])
+
+    There are three different lines:
+     1. (0, body_edge['top'])
+     2. (0, body_edge['bottom'])
+     3. (body_edge['top'], body_edge['bottom'])
+
+calc_silk_x: Calculates the start and end coordinates for
+    the top and bottom lines on either side of the part.
+
+    Showing silk arrangement for CCW pin count.
+    Silkscreen indpendent of CW/CCW.
+
+               top_left
+l1    ---      --------
+    1*  4  l1 (0, body_edge['right'])
+    2   3  l2 (body_edge['left'], body_edge['right'])
+l2  -----
+                bottom_left
+    _____      -----------
+    4   3  l1 (body_edge['left'], body_edge['right'])
+    1*  2  l2 (0, body_edge['right'])
+      ---
+                bottom_right
+    _____      ------------
+    3   2  l1 (body_edge['left'], body_edge['right'])
+    4   1* l2 (0, body_edge['left'])
+    ---
+                top_right
+    ___         ---------
+    2   1* l1 (0, body_edge['left'])
+    3   4  l2 (body_edge['left'], body_edge['right'])
+    -----
+
+    There are three different lines:
+      1. (0, body_edge['top'])
+      2. (0, body_edge['bottom'])
+      3. (body_edge['top'], body_edge['bottom'])
+
+"""
+
+
+def calc_silk_x(device_params, body_edge):
+    """Calculates the start and end coordinates for
+    the top and bottom lines on either side of the part.
+
+    Args:
+        device_params: Device parameters dictionary
+        body_edge: Part's body edge dict
+
+    Returns:
+       line1, line2: Silkscreen lines
+
+    """
+    lines = [
+        (0, body_edge["left"]),
+        (0, body_edge["right"]),
+        (body_edge["left"], body_edge["right"]),
+    ]
+
+    # Default silkscreen lines
+    line1, line2 = lines[1], lines[2]
+
+    if device_params.get("pad_numbers"):
+        start = device_params["pad_numbers"].get("start") or "top_left"
+        # start can be either of "[top, bottom]_[left, right]"
+        tb, lr = start.split("_")
+
+        if "top" in tb:
+            line2 = lines[2]
+            if "left" in lr:
+                line1 = lines[1]
+            else:
+                line1 = lines[0]
+        else:
+            line1 = lines[2]
+            if "left" in lr:
+                line2 = lines[1]
+            else:
+                line2 = lines[0]
+    return line1, line2
+
+
+def calc_silk_y(device_params, body_edge):
+    """Calculates the start and end coordinates for
+    the left and right lines on either side of the part.
+
+    Args:
+        device_params: Device parameters dictionary
+        body_edge: Part's body edge dict
+
+    Returns:
+       line1, line2: Silkscreen lines
+    """
+    lines = [
+        (0, body_edge["top"]),
+        (0, body_edge["bottom"]),
+        (body_edge["top"], body_edge["bottom"]),
+    ]
+
+    # Default silkscreen lines
+    line1, line2 = lines[1], lines[2]
+
+    if device_params.get("pad_numbers"):
+        start = device_params["pad_numbers"].get("start") or "top_left"
+        # start can be either of "[top, bottom]_[left, right]"
+        tb, lr = start.split("_")
+
+        if "left" in lr:
+            line2 = lines[2]
+            if "top" in tb:
+                line1 = lines[1]
+            else:
+                line1 = lines[0]
+        else:
+            line1 = lines[2]
+            if "top" in tb:
+                line2 = lines[1]
+            else:
+                line2 = lines[0]
+    return line1, line2


### PR DESCRIPTION
When the custom pin number generator is used pin 1
is in a different location than the expected.

Pin 1 can be in one of the four corners:
  top left/right and bottom left/right

Add calc_silk_(x,y) to calculate the silkscreen line coords.