### PR TITLE
Added Bourns SRP5030T SMD inductor

### DIFF
--- a/scripts/Inductor_SMD/Inductor_SMD.yml
+++ b/scripts/Inductor_SMD/Inductor_SMD.yml
@@ -28,6 +28,17 @@
 #
 #
 
+L_Bourns_SRP5030T:
+  description: "Inductor, Bourns, SRP5030T, 5.7mmx5.2mm"
+  datasheet: "https://www.bourns.com/data/global/pdfs/SRP5030T.pdf"
+  tags: "Inductor Bourns_SRP5030T"
+  extratexts: [[-49.0, -0.05, "", "F.SilkS", 3.0, 3.0]]
+  at: [-2.85, 2.60]
+  size: [5.70, 5.20]
+  smd_tht: "smd"
+  pins: [["smd", "1", -2.25, 0, 2.0, 1.8, 0.0], ["smd", "2", 2.25, 0, 2.0, 1.8, 0.0]]
+
+
 L_TDK_SLF6025:
   description: "Inductor, TDK, SLF6025, 6.0mmx6.0mm"
   datasheet: "https://product.tdk.com/info/en/document/catalog/smd/inductor_commercial_power_slf6025_en.pdf"


### PR DESCRIPTION
Datasheet: https://www.bourns.com/data/global/pdfs/SRP5030T.pdf
![Captura de pantalla de 2020-03-16 10-01-59](https://user-images.githubusercontent.com/24567573/76739894-36ff0400-676d-11ea-96d1-341e15e47118.png)
![Captura de pantalla de 2020-03-16 10-03-03](https://user-images.githubusercontent.com/24567573/76739949-57c75980-676d-11ea-8eb2-565da55cd09a.png)
