### PR TITLE
Added Bourns SRF1260 inductor

### DIFF
--- a/scripts/Inductor_SMD/Inductor_SMD.yml
+++ b/scripts/Inductor_SMD/Inductor_SMD.yml
@@ -28,6 +28,16 @@
 #
 #
 
+L_Bourns_SRF1260:
+  description: "Inductor, Bourns, SRF1260, 12.5mmx12.5mm"
+  datasheet: "https://www.bourns.com/docs/Product-Datasheets/SRF1260.pdf"
+  tags: "Inductor Bourns_SRF1260"
+  extratexts: [[-49.0, -0.05, "", "F.SilkS", 3.0, 3.0]]
+  at: [-6.25, 6.25]
+  size: [12.50, 12.50]
+  smd_tht: "smd"
+  pins: [["smd", "1", -1.715, 4.25, 2.15, 4.5, 0.0], ["smd", "2", 1.715, 4.25, 2.15, 4.5, 0.0], ["smd", "3", 1.715, -4.25, 2.15, 4.5, 0.0], ["smd", "4", -1.715, -4.25, 2.15, 4.5, 0.0]]
+
 L_TDK_SLF6025:
   description: "Inductor, TDK, SLF6025, 6.0mmx6.0mm"
   datasheet: "https://product.tdk.com/info/en/document/catalog/smd/inductor_commercial_power_slf6025_en.pdf"


### PR DESCRIPTION
Datasheet: https://www.bourns.com/docs/Product-Datasheets/SRF1260.pdf
![Captura de pantalla de 2020-03-17 14-30-13](https://user-images.githubusercontent.com/24567573/76860766-d6022980-685b-11ea-91d2-bb33bb64e4ad.png)
![Captura de pantalla de 2020-03-17 14-31-30](https://user-images.githubusercontent.com/24567573/76860910-0a75e580-685c-11ea-8224-506280024859.png)
