### PR TITLE
Added TDFN-8 2x2mm footprint with EP0.8x1.38mm for MAX17620.

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/dfn.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/dfn.yaml
@@ -688,7 +688,7 @@ TDFN-6-1EP_2.5x2.5mm_P0.65mm_EP1.3x2mm:
   #include_suffix_in_3dpath: 'False'
   #include_pad_size: 'fp_name_only' # 'both' | 'none' (default)
 
-TDFN-8-1EP_2x2mm_P0.5mm_EP0.8x1.20mm:
+TDFN-8-1EP_2x2mm_P0.5mm_EP0.8x1.30mm:
   device_type: 'TDFN'
   size_source: 'https://pdfserv.maximintegrated.com/package_dwgs/21-0168.PDF'
   body_size_x: 2.0 +/-0.1
@@ -699,6 +699,7 @@ TDFN-8-1EP_2x2mm_P0.5mm_EP0.8x1.20mm:
 
   EP_size_x: 0.8 +/-0.1
   EP_size_y: 1.20 +/-0.1
+  EP_size_y_overwrite: 1.30 +/-0.1
   EP_num_paste_pads: [2, 2]
 
   pitch: 0.50

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/dfn.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/dfn.yaml
@@ -687,3 +687,26 @@ TDFN-6-1EP_2.5x2.5mm_P0.65mm_EP1.3x2mm:
   suffix: ''
   #include_suffix_in_3dpath: 'False'
   #include_pad_size: 'fp_name_only' # 'both' | 'none' (default)
+
+TDFN-8-1EP_2x2mm_P0.5mm_EP0.8x1.38mm:
+  device_type: 'TDFN'
+  size_source: 'http://pdfserv.maximintegrated.com/land_patterns/90-0065.PDF'
+  body_size_x: 2.0 +/-0.1
+  body_size_y: 2.0 +/-0.1
+  overall_height: 0.75
+  lead_width: 0.3 +/-0.02
+  lead_len: 0.7 +/-0.02
+
+  EP_size_x: 0.8 +/-0.02
+  EP_size_y: 1.38 +/-0.02
+  EP_num_paste_pads: [2, 2]
+
+  pitch: 0.50
+  num_pins_x: 0
+  num_pins_y: 4
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  suffix: ''
+  #include_suffix_in_3dpath: 'False'
+  #include_pad_size: 'fp_name_only' # 'both' | 'none' (default)

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/dfn.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/dfn.yaml
@@ -688,17 +688,17 @@ TDFN-6-1EP_2.5x2.5mm_P0.65mm_EP1.3x2mm:
   #include_suffix_in_3dpath: 'False'
   #include_pad_size: 'fp_name_only' # 'both' | 'none' (default)
 
-TDFN-8-1EP_2x2mm_P0.5mm_EP0.8x1.38mm:
+TDFN-8-1EP_2x2mm_P0.5mm_EP0.8x1.20mm:
   device_type: 'TDFN'
-  size_source: 'http://pdfserv.maximintegrated.com/land_patterns/90-0065.PDF'
+  size_source: 'https://pdfserv.maximintegrated.com/package_dwgs/21-0168.PDF'
   body_size_x: 2.0 +/-0.1
   body_size_y: 2.0 +/-0.1
   overall_height: 0.75
-  lead_width: 0.3 +/-0.02
-  lead_len: 0.7 +/-0.02
+  lead_width: 0.25 +/-0.05
+  lead_len: 0.3 +/-0.1
 
-  EP_size_x: 0.8 +/-0.02
-  EP_size_y: 1.38 +/-0.02
+  EP_size_x: 0.8 +/-0.1
+  EP_size_y: 1.20 +/-0.1
   EP_num_paste_pads: [2, 2]
 
   pitch: 0.50


### PR DESCRIPTION
Hello,

I have created a matching TDFN-8 footprint for the MAX17620 step-down regulator, as discussed in the PR https://github.com/KiCad/kicad-symbols/pull/2559 in the kicad-symbols repo.

Specification can be found here: http://pdfserv.maximintegrated.com/land_patterns/90-0065.PDF

![grafik](https://user-images.githubusercontent.com/11467555/77200512-fc89c400-6aea-11ea-8955-b68996f9b781.png)

A PR for this footprint was also created in the official kicad-footprints library: https://github.com/KiCad/kicad-footprints/pull/2159

