### PR TITLE
Added UQFN-20_3x3mm_P0.4mm without exposed pad

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/uqfn.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/uqfn.yaml
@@ -123,6 +123,66 @@ UQFN-16-1EP_4x4mm_P0.65mm_EP2.6x2.6mm:
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
 
+UQFN-20_3x3mm_P0.4mm: # No exposed pad
+  device_type: 'UQFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'https://resurgentsemi.com/wp-content/uploads/2018/09/MPR121_rev5-Resurgent.pdf?d453f8&d453f8'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  #ipc_density: 'least' #overwrite global value for this device.
+  # custom_name_format:
+  body_size_x:
+    nominal: 3
+  body_size_y:
+    nominal: 3
+  overall_height:
+    minimum: 0.5
+    nominal: 0.55
+    maximum: 0.60
+
+  lead_width:
+    minimum: 0.15
+    nominal: 0.20
+    maximum: 0.25
+  lead_len:
+    minimum: 0.35 # Would be 0.4mm, but set to 0.35 to make this compatible with 'http://ww1.microchip.com/downloads/en/PackagingSpec/00000049BQ.pdf#page=561'
+    nominal: 0.5
+    maximum: 0.6
+
+#  EP_size_x:
+#    minimum: 1.65
+#    nominal: 1.75
+#    maximum: 1.85
+#  EP_size_x_overwrite: 1.85
+#  EP_size_y:
+#    minimum: 1.65
+#    nominal: 1.75
+#    maximum: 1.85
+#  EP_size_y_overwrite: 1.85
+#  EP_num_paste_pads: [2, 2]
+
+#  thermal_vias:
+#    count: [2, 2]
+#    drill: 0.2
+#    # min_annular_ring: 0.15
+#    paste_via_clearance: 0.1
+#    EP_num_paste_pads: [2, 2]
+#    #paste_between_vias: 1
+#    #paste_rings_outside: 1
+#    EP_paste_coverage: 0.75
+#    #grid: [1, 1]
+#    # bottom_pad_size:
+#    paste_avoid_via: False
+
+  pitch: 0.4
+  num_pins_x: 5
+  num_pins_y: 5
+  chamfer_edge_pins: 0.12
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'
+
 UQFN-20-1EP_3x3mm_P0.4mm_EP1.85x1.85mm:
   device_type: 'UQFN'
   #manufacturer: 'man'


### PR DESCRIPTION
Datasheet: https://resurgentsemi.com/wp-content/uploads/2018/09/MPR121_rev5-Resurgent.pdf?d453f8&d453f8
![Captura de pantalla de 2020-03-30 14-40-55](https://user-images.githubusercontent.com/24567573/77913420-83c9fb00-7294-11ea-9d5f-9da206148ced.png)
![Captura de pantalla de 2020-03-30 14-41-08](https://user-images.githubusercontent.com/24567573/77913426-84629180-7294-11ea-8fc5-5bfafe9d8144.png)
