### PR TITLE
QFN-64 with 5.2x5.2mm exposed pad.

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-6x.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/qfn-6x.yaml
@@ -116,6 +116,62 @@ QFN-64-1EP_9x9mm_P0.5mm_EP4.35x4.35mm:
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
 
+QFN-64-1EP_9x9mm_P0.5mm_EP5.2x5.2mm:
+  device_type: 'QFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'https://www.silabs.com/documents/public/data-sheets/Si5345-44-42-D-DataSheet.pdf#page=51'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  body_size_x:
+    nominal: 9
+    tolerance: 0
+  body_size_y:
+    nominal: 9
+    tolerance: 0
+  overall_height:
+    maximum: 0.9
+
+  lead_width:
+    minimum: 0.18
+    nominal: 0.25
+    maximum: 0.30
+  lead_len:
+    minimum: 0.3
+    nominal: 0.4
+    maximum: 0.5
+
+  EP_size_x:
+    minimum: 5.10
+    nominal: 5.20
+    maximum: 5.30
+  EP_size_y:
+    minimum: 5.10
+    nominal: 5.20
+    maximum: 5.30
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [4, 4]
+
+  thermal_vias:
+    count: [5, 5]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    #paste_between_vias: 1
+    #paste_rings_outside: 1
+    EP_paste_coverage: 0.6
+    #grid: [1, 1]
+    # bottom_pad_size:
+    # paste_avoid_via: False
+
+  pitch: 0.5
+  num_pins_x: 16
+  num_pins_y: 16
+  #chamfer_edge_pins: 0.25
+  #pin_count_grid:
+  #pad_length_addition: 0.5
+  #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
+  #include_suffix_in_3dpath: 'False'
+  
 QFN-64-1EP_9x9mm_P0.5mm_EP5.45x5.45mm:
   device_type: 'QFN'
   #manufacturer: 'man'
@@ -171,7 +227,7 @@ QFN-64-1EP_9x9mm_P0.5mm_EP5.45x5.45mm:
   #pad_length_addition: 0.5
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
-
+  
 QFN-68-1EP_8x8mm_P0.4mm_EP5.2x5.2mm:
   device_type: 'QFN'
   #manufacturer: 'man'


### PR DESCRIPTION
Documentation: https://www.silabs.com/documents/public/data-sheets/Si5345-44-42-D-DataSheet.pdf#page=51