### PR TITLE
Add JST-PA (SMT no-boss/side-entry only)

### DIFF
--- a/scripts/Connector/Connector_SMD_single_row_plus_mounting_pad/conn_jst.yaml
+++ b/scripts/Connector/Connector_SMD_single_row_plus_mounting_pad/conn_jst.yaml
@@ -221,6 +221,27 @@ device_definition:
                     reference_is: 'center' # 'center' | 'first' | 'last'
                     count: 'pincount' # 'pincount' | value
 
+    PA_side_entry:
+        series: 'PA'
+        mpn_format_string: 'SM{pincount:02}B-PASS'
+        orientation: 'H'
+        datasheet: 'https://www.jst-mfg.com/product/pdf/eng/ePA-F.pdf'
+        pinrange: ['list', [2,3,4,5,6,7,8,9,10,11,12,13,15]]
+        text_inside_pos: 1.5
+        pitch: 2
+        pad1_position: 'top-left' # 'top-left' | 'bottom-left' -> pin 2 always to the right of pin 1
+        mounting_pad_size: [1.8, 3.8]
+        # x position mounting inner mounting pad edge relative to nearest pad center
+        center_pad_to_mounting_pad_edge: 1.6
+        # y dimensions for pad given relative to mounting pad edge
+        rel_pad_y_outside_edge: 7.85
+        rel_pad_y_inside_edge: 5.15
+        pad_size_x: 1
+        # y position for body edge relative to mounting pad edge (positive -> body extends outside bounding box)
+        rel_body_edge_y: 2.8
+        body_size_y: 8.9
+        # x body edge relative to nearest pin
+        rel_body_edge_x: 3 #(8-2)/2
 
     PH_side_entry:
         series: 'PH'

--- a/scripts/Connector/Connector_SMD_single_row_plus_mounting_pad/conn_jst_pa.yaml
+++ b/scripts/Connector/Connector_SMD_single_row_plus_mounting_pad/conn_jst_pa.yaml
@@ -1,0 +1,66 @@
+group_definitions:
+    manufacturer: 'JST'
+
+device_definition:
+    PA_side_entry:
+        series: 'PA'
+        mpn_format_string: 'SM{pincount:02}B-PASS'
+        orientation: 'H'
+        datasheet: 'https://www.jst-mfg.com/product/pdf/eng/ePA-F.pdf'
+        pinrange: ['list', [2,3,4,5,6,7,8,9,10,11,12,13,15]]
+        text_inside_pos: 1.5
+        pitch: 2
+        pad1_position: 'top-left' # 'top-left' | 'bottom-left' -> pin 2 always to the right of pin 1
+        mounting_pad_size: [1.8, 3.8]
+        # x position mounting inner mounting pad edge relative to nearest pad center
+        center_pad_to_mounting_pad_edge: 1.6
+        # y dimensions for pad given relative to mounting pad edge
+        rel_pad_y_outside_edge: 7.85
+        rel_pad_y_inside_edge: 5.15
+        pad_size_x: 1
+        # y position for body edge relative to mounting pad edge (positive -> body extends outside bounding box)
+        rel_body_edge_y: 2.8
+        body_size_y: 8.9
+        # x body edge relative to nearest pin
+        rel_body_edge_x: 3 #(8-2)/2
+
+#    PH_top_entry:
+#        series: 'PH'
+#        mpn_format_string: 'B{pincount:d}B-PH-SM4-TB'
+#        orientation: 'V'
+#        datasheet: 'http://www.jst-mfg.com/product/pdf/eng/ePH.pdf'
+#        pinrange: ['range', [2, 17]]
+#        text_inside_pos: -1
+#        pitch: 2
+#        pad1_position: 'bottom-left' # 'top-left' | 'bottom-left' -> pin 2 always to the right of pin 1
+#        mounting_pad_size: [1.6, 3]
+#        # x position mounting inner mounting pad edge relative to nearest pad center
+#        center_pad_to_mounting_pad_edge: 1.6
+#        # y dimensions for pad given relative to mounting pad edge
+#        rel_pad_y_outside_edge: 6.5
+#        rel_pad_y_inside_edge: 1
+#        pad_size_x: 1
+#        # y position for body edge relative to mounting pad edge (positive -> body extends outside bounding box)
+#        rel_body_edge_y: 1
+#        body_size_y: 5
+#        # x body edge relative to nearest pin
+#        rel_body_edge_x: 2.975 #(7.95-2)/2
+#        additional_drawing:
+#            -
+#                layer: 'F.Fab'
+#                # thickness: 0.1 #optional parameter. If not given: take fab_line_width and silk_line_width from config file. Needed if layer not silk or fab!
+#                reference_point: ['center', -2.5] # [x,y]: x = 'left' | 'center' | 'right' | value; y = 'top' | 'center' | 'bottom' | value; named values are relative to body
+#                rectangle:
+#                    size: [0.5, 0.5] # centered around reference_point
+#                    # start: [-0.25, -0.25] #releative to reference_point
+#                    # end: [0.25, 0.25] #relative to reference_point
+#                # polygone:
+#                #     - [-0.25,-0.25]
+#                #     - [-0.25,0.25]
+#                #     - [0.25,0.25]
+#                #     - [0.25,-0.25]
+#                #     - [-0.25,-0.25]
+#                repeat:
+#                    spacing: ['pitch', 0] # x,y= 'pitch' | value
+#                    reference_is: 'center' # 'center' | 'first' | 'last'
+#                    count: 'pincount' # 'pincount' | value


### PR DESCRIPTION
This adds the script for a subset of the JST-PA connectors using the smd_single_row_plus_mounting_pad script. I plan to also add a script for at least the SM()B-PASS-1 variants with locating features. 