### PR TITLE
manage.sh - Switch from pip to pip3 to be explicit that we want pip3

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -12,12 +12,12 @@ KICADMODTREE_DIR="$BASE_DIR/KicadModTree"
 ACTION=$1
 
 update_packages() {
-    pip install --upgrade -r "$BASE_DIR/requirements.txt"
+    pip3 install --upgrade -r "$BASE_DIR/requirements.txt"
 }
 
 update_dev_packages() {
 	update_packages
-    pip install --upgrade -r "$BASE_DIR/requirements-dev.txt"
+    pip3 install --upgrade -r "$BASE_DIR/requirements-dev.txt"
 }
 
 pep8_check() {


### PR DESCRIPTION
Fixes dependency installation with homebrew and no 'pip' symlink.