### PR TITLE
Add SO-16_3.9x9.9mm_P1.27mm for Nexperia 74HC165D,653

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/so.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/so.yaml
@@ -26,6 +26,18 @@ SO-14_5.3x10.2mm_P1.27mm:
   num_pins_x: 0
   num_pins_y: 7
 
+SO-16_3.9x9.9mm_P1.27mm:
+  size_source: 'https://assets.nexperia.com/documents/data-sheet/74HC_HCT165.pdf#page=13'
+  body_size_x: 3.80 .. 4.00
+  body_size_y: 9.8 .. 10.00
+  overall_height: 1.75
+  overall_size_x: 5.80 .. 6.20
+  lead_width: 0.36 .. 0.49
+  lead_len: 0.40 .. 1.00
+  pitch: 1.27
+  num_pins_x: 0
+  num_pins_y: 8
+
 SO-16_5.3x10.2mm_P1.27mm:
   size_source: 'https://www.ti.com/lit/ml/msop002a/msop002a.pdf'
   body_size_x: 5.00 .. 5.60


### PR DESCRIPTION
Add 16-pin SO from Nexperia 74HC165D,653.

Datasheet: https://assets.nexperia.com/documents/data-sheet/74HC_HCT165.pdf#page=13

kicad-symbols: https://github.com/KiCad/kicad-symbols/pull/2794
kicad-footprints: https://github.com/KiCad/kicad-footprints/pull/2314, https://github.com/KiCad/kicad-footprints/pull/2315
kicad-footprint-generator: https://github.com/pointhi/kicad-footprint-generator/pull/570, https://github.com/pointhi/kicad-footprint-generator/pull/571

Screencaps:

![SO-16_3 9x9 9mm_P1](https://user-images.githubusercontent.com/12487802/84098982-34a7f100-a9ce-11ea-82a9-fa5221f81914.png)

![image](https://user-images.githubusercontent.com/12487802/84099030-51442900-a9ce-11ea-811e-c9d0d8da2c16.png)