### PR TITLE
Delete readme.md to avoid overlap with Readme.md that causes issues w…

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/readme.md
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/readme.md
@@ -1,4 +1,0 @@
-DFN and QFN packages
---------------------
-It is preferred to use `ipc_dfn_qfn_generator.py` (which uses the definitions within the `size_definitions` folder)
-over the older `qfn.py` generator which uses the definitions in `qfn.yml`.


### PR DESCRIPTION
…ith case-insensitive filesystems

OSX APFS filesystems are case insensitive. On these systems git doesn't have any way to handle this file and Readme.md at the same time and this so lets remove this one to avoid the conflict.