### PR TITLE
Connector Wuerth: Add WR-PHD Bottom Entry series

### DIFF
--- a/scripts/Connector_Wuerth_WR-PHD/wuerth_wr_phd_bottom_entry.py
+++ b/scripts/Connector_Wuerth_WR-PHD/wuerth_wr_phd_bottom_entry.py
@@ -36,9 +36,9 @@ def generate_footprint(params, part_params, mpn, configuration):
     # Pads
     if params['type'] == 'SMD':
         kicad_mod.append(PadArray(initial=1, start=[params['pitch']/2+params['holes']['offset'], -params['pitch']*(part_params['pins']//2-1)/2], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2, 
-            size=[params['pads']['x'], params['pads']['y']], type=Pad.TYPE_SMT, shape=Pad.SHAPE_RECT, layers=['F.Cu', 'F.Mask']))
+            size=[params['pads']['x'], params['pads']['y']], type=Pad.TYPE_SMT, shape=Pad.SHAPE_RECT, layers=['F.Cu', 'F.Paste', 'F.Mask']))
         kicad_mod.append(PadArray(initial=2, start=[-params['pitch']/2-params['holes']['offset'], -params['pitch']*(part_params['pins']//2-1)/2], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2,
-            size=[params['pads']['x'], params['pads']['y']], type=Pad.TYPE_SMT, shape=Pad.SHAPE_RECT, layers=['F.Cu', 'F.Mask']))
+            size=[params['pads']['x'], params['pads']['y']], type=Pad.TYPE_SMT, shape=Pad.SHAPE_RECT, layers=['F.Cu', 'F.Paste', 'F.Mask']))
     else:
         kicad_mod.append(PadArray(initial=1, start=[0, 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2, 
             size=[params['pads']['diameter'], params['pads']['diameter']], drill=params['pads']['drill'], type=Pad.TYPE_THT, tht_pad1_shape=Pad.SHAPE_RECT, shape=Pad.SHAPE_OVAL, layers=['*.Cu', '*.Mask']))

--- a/scripts/Connector_Wuerth_WR-PHD/wuerth_wr_phd_bottom_entry.py
+++ b/scripts/Connector_Wuerth_WR-PHD/wuerth_wr_phd_bottom_entry.py
@@ -29,6 +29,10 @@ def generate_footprint(params, part_params, mpn, configuration):
     kicad_mod.setDescription("Connector Wuerth, WR-PHD {pitch}mm Dual Socket Header Bottom Entry {type}, Wuerth electronics {mpn} ({datasheet}), generated with kicad-footprint-generator".format(
         pitch=params['pitch'], type=params['type'], mpn=mpn, datasheet=part_params['datasheet']))
         
+    # Keywords
+    kicad_mod.setTags("Connector Wuerth WR-PHD {pitch}mm {mpn}".format(
+        pitch=params['pitch'], mpn=mpn))
+        
     # Pads
     if params['type'] == 'SMD':
         kicad_mod.append(PadArray(initial=1, start=[0, 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2, 

--- a/scripts/Connector_Wuerth_WR-PHD/wuerth_wr_phd_bottom_entry.py
+++ b/scripts/Connector_Wuerth_WR-PHD/wuerth_wr_phd_bottom_entry.py
@@ -35,14 +35,14 @@ def generate_footprint(params, part_params, mpn, configuration):
         
     # Pads
     if params['type'] == 'SMD':
-        kicad_mod.append(PadArray(initial=1, start=[params['pitch']/2+params['holes']['offset'], -params['pitch']*(part_params['pins']//2-1)/2], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2, 
+        kicad_mod.append(PadArray(initial=1, start=[-params['pitch']/2-params['holes']['offset'], -params['pitch']*(part_params['pins']//2-1)/2], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2, 
             size=[params['pads']['x'], params['pads']['y']], type=Pad.TYPE_SMT, shape=Pad.SHAPE_RECT, layers=['F.Cu', 'F.Paste', 'F.Mask']))
-        kicad_mod.append(PadArray(initial=2, start=[-params['pitch']/2-params['holes']['offset'], -params['pitch']*(part_params['pins']//2-1)/2], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2,
+        kicad_mod.append(PadArray(initial=2, start=[params['pitch']/2+params['holes']['offset'], -params['pitch']*(part_params['pins']//2-1)/2], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2,
             size=[params['pads']['x'], params['pads']['y']], type=Pad.TYPE_SMT, shape=Pad.SHAPE_RECT, layers=['F.Cu', 'F.Paste', 'F.Mask']))
     else:
         kicad_mod.append(PadArray(initial=1, start=[0, 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2, 
             size=[params['pads']['diameter'], params['pads']['diameter']], drill=params['pads']['drill'], type=Pad.TYPE_THT, tht_pad1_shape=Pad.SHAPE_RECT, shape=Pad.SHAPE_OVAL, layers=['*.Cu', '*.Mask']))
-        kicad_mod.append(PadArray(initial=2, start=[-params['pitch']-2*params['holes']['offset'], 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2,
+        kicad_mod.append(PadArray(initial=2, start=[params['pitch']+2*params['holes']['offset'], 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2,
             size=[params['pads']['diameter'], params['pads']['diameter']], drill=params['pads']['drill'], type=Pad.TYPE_THT, tht_pad1_shape=Pad.SHAPE_RECT, shape=Pad.SHAPE_OVAL, layers=['*.Cu', '*.Mask']))
     
     # Bottom entry holes
@@ -52,9 +52,9 @@ def generate_footprint(params, part_params, mpn, configuration):
         kicad_mod.append(PadArray(initial="", start=[-params['pitch']/2, -params['pitch']*(part_params['pins']//2-1)/2], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment="",
             size=params['holes']['drill'], drill=params['holes']['drill'], type=Pad.TYPE_NPTH, shape=Pad.SHAPE_CIRCLE, layers=Pad.LAYERS_NPTH))
     else:
-        kicad_mod.append(PadArray(initial="", start=[-params['holes']['offset'], 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment="",
+        kicad_mod.append(PadArray(initial="", start=[params['holes']['offset'], 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment="",
             size=params['holes']['drill'], drill=params['holes']['drill'], type=Pad.TYPE_NPTH, shape=Pad.SHAPE_CIRCLE, layers=Pad.LAYERS_NPTH))
-        kicad_mod.append(PadArray(initial="", start=[-params['pitch']-params['holes']['offset'], 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment="",
+        kicad_mod.append(PadArray(initial="", start=[params['pitch']+params['holes']['offset'], 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment="",
             size=params['holes']['drill'], drill=params['holes']['drill'], type=Pad.TYPE_NPTH, shape=Pad.SHAPE_CIRCLE, layers=Pad.LAYERS_NPTH))
     
     # Add fab layer
@@ -62,8 +62,8 @@ def generate_footprint(params, part_params, mpn, configuration):
         body_top_left = [-params['width']/2, -params['top']-params['pitch']*(part_params['pins']//2-1)/2]
         body_bottom_right = [params['width']/2, params['top']+params['pitch']*(part_params['pins']//2-1)/2]
     else:
-        body_top_left = [(params['width']-params['pitch'])/2-params['width']-params['holes']['offset'], -params['top']]
-        body_bottom_right = [(params['width']-params['pitch'])/2-params['holes']['offset'], params['top']+params['pitch']*(part_params['pins']//2-1)]
+        body_top_left = [(-params['width']+params['pitch'])/2+params['holes']['offset'], -params['top']]
+        body_bottom_right = [(-params['width']+params['pitch'])/2+params['width']+params['holes']['offset'], params['top']+params['pitch']*(part_params['pins']//2-1)]
     kicad_mod.append(RectLine(start=body_top_left, end=body_bottom_right, layer='F.Fab', width=configuration['fab_line_width']))
     
     # Add silkscreen layer
@@ -73,7 +73,7 @@ def generate_footprint(params, part_params, mpn, configuration):
     kicad_mod.append(Line(start=[silk_top_left[0], silk_top_left[1]], end=[silk_bottom_right[0], silk_top_left[1]], layer='F.SilkS', width=configuration['silk_line_width']))
     kicad_mod.append(Line(start=[silk_top_left[0], silk_top_left[1]], end=[silk_top_left[0], silk_top_left[1] + 1.27/2], layer='F.SilkS', width=configuration['silk_line_width']))
     kicad_mod.append(Line(start=[silk_bottom_right[0], silk_top_left[1]], end=[silk_bottom_right[0], silk_top_left[1] + 1.27/2], layer='F.SilkS', width=configuration['silk_line_width']))
-    kicad_mod.append(Line(start=[silk_bottom_right[0], silk_top_left[1] + 1.27/2], end=[silk_bottom_right[0] + 1.27/2, silk_top_left[1] + 1.27/2], layer='F.SilkS', width=configuration['silk_line_width']))
+    kicad_mod.append(Line(start=[silk_top_left[0], silk_top_left[1] + 1.27/2], end=[silk_top_left[0] - 1.27/2, silk_top_left[1] + 1.27/2], layer='F.SilkS', width=configuration['silk_line_width']))
     # -> Dashes between the pads
     for x in range(0, part_params['pins']//2-1):
         if params['type'] == 'SMD':
@@ -88,20 +88,20 @@ def generate_footprint(params, part_params, mpn, configuration):
     kicad_mod.append(Line(start=[silk_top_left[0], silk_bottom_right[1]], end=[silk_bottom_right[0], silk_bottom_right[1]], layer='F.SilkS', width=configuration['silk_line_width']))
     
     # Add courtyard layer
-    courtyard_top_left = [body_top_left[0] + configuration['courtyard_offset']['connector'], body_top_left[1] - configuration['courtyard_offset']['connector']]
+    courtyard_top_left = [body_top_left[0] - configuration['courtyard_offset']['connector'], body_top_left[1] - configuration['courtyard_offset']['connector']]
     if params['type'] == 'SMD':
-        if courtyard_top_left[0] < 0 + params['pitch']/2 + params['holes']['offset'] + params['pads']['x']/2 + configuration['courtyard_offset']['connector']:
-            courtyard_top_left[0] = 0 + params['pitch']/2 + params['holes']['offset'] + params['pads']['x']/2 + configuration['courtyard_offset']['connector']
+        if courtyard_top_left[0] > 0 - params['pitch']/2 - params['holes']['offset'] - params['pads']['x']/2 - configuration['courtyard_offset']['connector']:
+            courtyard_top_left[0] = 0 - params['pitch']/2 - params['holes']['offset'] - params['pads']['x']/2 - configuration['courtyard_offset']['connector']
     else:
-        if courtyard_top_left[0] < 0 + params['pads']['diameter']/2 + configuration['courtyard_offset']['connector']:
-            courtyard_top_left[0] = 0 + params['pads']['diameter']/2 + configuration['courtyard_offset']['connector']
-    courtyard_bottom_right = [body_bottom_right[0] - configuration['courtyard_offset']['connector'], body_bottom_right[1] + configuration['courtyard_offset']['connector']]
+        if courtyard_top_left[0] > 0 - params['pads']['diameter']/2 - configuration['courtyard_offset']['connector']:
+            courtyard_top_left[0] = 0 - params['pads']['diameter']/2 - configuration['courtyard_offset']['connector']
+    courtyard_bottom_right = [body_bottom_right[0] + configuration['courtyard_offset']['connector'], body_bottom_right[1] + configuration['courtyard_offset']['connector']]
     if params['type'] == 'SMD':
-        if courtyard_bottom_right[0] > -params['pitch']/2 - params['holes']['offset'] - params['pads']['x']/2 - configuration['courtyard_offset']['connector']:
-            courtyard_bottom_right[0] = -params['pitch']/2 - params['holes']['offset'] - params['pads']['x']/2 - configuration['courtyard_offset']['connector']
+        if courtyard_bottom_right[0] < params['pitch']/2 + params['holes']['offset'] + params['pads']['x']/2 + configuration['courtyard_offset']['connector']:
+            courtyard_bottom_right[0] = params['pitch']/2 + params['holes']['offset'] + params['pads']['x']/2 + configuration['courtyard_offset']['connector']
     else:
-        if courtyard_bottom_right[0] > -params['pitch']-2*params['holes']['offset'] - params['pads']['diameter']/2 - configuration['courtyard_offset']['connector']:
-            courtyard_bottom_right[0] = -params['pitch']-2*params['holes']['offset'] - params['pads']['diameter']/2 - configuration['courtyard_offset']['connector']
+        if courtyard_bottom_right[0] < params['pitch'] + 2*params['holes']['offset'] + params['pads']['diameter']/2 + configuration['courtyard_offset']['connector']:
+            courtyard_bottom_right[0] = params['pitch'] + 2*params['holes']['offset'] + params['pads']['diameter']/2 + configuration['courtyard_offset']['connector']
     kicad_mod.append(RectLine(start=courtyard_top_left, end=courtyard_bottom_right, layer='F.CrtYd', width=configuration['courtyard_line_width']))
     
     # Add texts

--- a/scripts/Connector_Wuerth_WR-PHD/wuerth_wr_phd_bottom_entry.py
+++ b/scripts/Connector_Wuerth_WR-PHD/wuerth_wr_phd_bottom_entry.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+sys.path.append(os.path.join(sys.path[0], "..", ".."))
+import argparse
+import yaml
+from KicadModTree import *
+
+# Load parent path of tools
+sys.path.append(os.path.join(sys.path[0], "..", "tools"))
+from footprint_text_fields import addTextFields
+
+# Function used to generate footprint
+def generate_footprint(params, part_params, mpn, configuration):
+
+    # Build footprint name
+    fp_name = "Connector_Wuerth_{series_prefix}_{type}_{rows}x{pins:02d}_P{pitch}_{orientation}_{mpn}".format(
+        series_prefix=params['series_prefix'], type=params['type'], rows=part_params['rows'], pins=part_params['pins']//2, pitch=params['pitch'], orientation=params['orientation'], mpn=mpn)
+
+    # Create footprint
+    kicad_mod = Footprint(fp_name)
+    
+    # Set SMD attribute if required
+    if params['type'] == 'SMD':
+        kicad_mod.setAttribute('smd')
+
+    # Description
+    kicad_mod.setDescription("Connector Wuerth, WR-PHD {pitch}mm Dual Socket Header Bottom Entry {type}, Wuerth electronics {mpn} ({datasheet}), generated with kicad-footprint-generator".format(
+        pitch=params['pitch'], type=params['type'], mpn=mpn, datasheet=part_params['datasheet']))
+        
+    # Pads
+    if params['type'] == 'SMD':
+        kicad_mod.append(PadArray(initial=1, start=[0, 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2, 
+            size=[params['pads']['x'], params['pads']['y']], type=Pad.TYPE_SMT, shape=Pad.SHAPE_RECT, layers=['F.Cu', 'F.Mask']))
+        kicad_mod.append(PadArray(initial=2, start=[-params['pitch']-2*params['holes']['offset'], 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2,
+            size=[params['pads']['x'], params['pads']['y']], type=Pad.TYPE_SMT, shape=Pad.SHAPE_RECT, layers=['F.Cu', 'F.Mask']))
+    else:
+        kicad_mod.append(PadArray(initial=1, start=[0, 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2, 
+            size=[params['pads']['diameter'], params['pads']['diameter']], drill=params['pads']['drill'], type=Pad.TYPE_THT, tht_pad1_shape=Pad.SHAPE_RECT, shape=Pad.SHAPE_OVAL, layers=['*.Cu', '*.Mask']))
+        kicad_mod.append(PadArray(initial=2, start=[-params['pitch']-2*params['holes']['offset'], 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment=2,
+            size=[params['pads']['diameter'], params['pads']['diameter']], drill=params['pads']['drill'], type=Pad.TYPE_THT, tht_pad1_shape=Pad.SHAPE_RECT, shape=Pad.SHAPE_OVAL, layers=['*.Cu', '*.Mask']))
+    
+    # Bottom entry holes
+    kicad_mod.append(PadArray(initial="", start=[-params['holes']['offset'], 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment="",
+        size=params['holes']['drill'], drill=params['holes']['drill'], type=Pad.TYPE_NPTH, shape=Pad.SHAPE_CIRCLE, layers=Pad.LAYERS_NPTH))
+    kicad_mod.append(PadArray(initial="", start=[-params['pitch']-params['holes']['offset'], 0], y_spacing=params['pitch'], pincount=part_params['pins']//2, increment="",
+        size=params['holes']['drill'], drill=params['holes']['drill'], type=Pad.TYPE_NPTH, shape=Pad.SHAPE_CIRCLE, layers=Pad.LAYERS_NPTH))
+    
+    # Add fab layer
+    body_top_left = [(params['width']-params['pitch'])/2-params['holes']['offset'], -params['top']]
+    body_bottom_right = [(params['width']-params['pitch'])/2-params['width']-params['holes']['offset'], params['top']+params['pitch']*(part_params['pins']//2-1)]
+    kicad_mod.append(RectLine(start=body_top_left, end=body_bottom_right, layer='F.Fab', width=configuration['fab_line_width']))
+    
+    # Add silkscreen layer
+    silk_top_right = [body_top_left[0] + configuration['silk_fab_offset'], body_top_left[1] - configuration['silk_fab_offset']]
+    silk_bottom_left = [body_bottom_right[0] - configuration['silk_fab_offset'], body_bottom_right[1] + configuration['silk_fab_offset']]
+    # -> Top part
+    kicad_mod.append(Line(start=[silk_top_right[0], silk_top_right[1]], end=[silk_bottom_left[0], silk_top_right[1]], layer='F.SilkS', width=configuration['silk_line_width']))
+    kicad_mod.append(Line(start=[silk_top_right[0], silk_top_right[1]], end=[silk_top_right[0], silk_top_right[1] + 1.27/2], layer='F.SilkS', width=configuration['silk_line_width']))
+    kicad_mod.append(Line(start=[silk_bottom_left[0], silk_top_right[1]], end=[silk_bottom_left[0], silk_top_right[1] + 1.27/2], layer='F.SilkS', width=configuration['silk_line_width']))
+    kicad_mod.append(Line(start=[silk_top_right[0], silk_top_right[1] + 1.27/2], end=[silk_top_right[0] + 1.27/2, silk_top_right[1] + 1.27/2], layer='F.SilkS', width=configuration['silk_line_width']))
+    # -> Dashes between the pads
+    for x in range(0, part_params['pins']//2-1):
+        kicad_mod.append(Line(start=[silk_bottom_left[0], 3*params['pitch']/8 + x * params['pitch']], end=[silk_bottom_left[0], 3*params['pitch']/8 + params['pitch']/4 + x * params['pitch']], layer='F.SilkS', width=configuration['silk_line_width']))
+        kicad_mod.append(Line(start=[silk_top_right[0], 3*params['pitch']/8 + x * params['pitch']], end=[silk_top_right[0], 3*params['pitch']/8 + params['pitch']/4 + x * params['pitch']], layer='F.SilkS', width=configuration['silk_line_width']))
+    # -> Bottom part
+    kicad_mod.append(Line(start=[silk_bottom_left[0], silk_bottom_left[1]], end=[silk_bottom_left[0], silk_bottom_left[1] - 1.27/2], layer='F.SilkS', width=configuration['silk_line_width']))
+    kicad_mod.append(Line(start=[silk_top_right[0], silk_bottom_left[1]], end=[silk_top_right[0], silk_bottom_left[1] - 1.27/2], layer='F.SilkS', width=configuration['silk_line_width']))
+    kicad_mod.append(Line(start=[silk_top_right[0], silk_bottom_left[1]], end=[silk_bottom_left[0], silk_bottom_left[1]], layer='F.SilkS', width=configuration['silk_line_width']))
+    
+    # Add courtyard layer
+    courtyard_top_left = [body_top_left[0] + configuration['courtyard_offset']['connector'], body_top_left[1] - configuration['courtyard_offset']['connector']]
+    if params['type'] == 'SMD':
+        if courtyard_top_left[0] < 0 + params['pads']['x']/2 + configuration['courtyard_offset']['connector']:
+            courtyard_top_left[0] = 0 + params['pads']['x']/2 + configuration['courtyard_offset']['connector']
+    else:
+        if courtyard_top_left[0] < 0 + params['pads']['diameter']/2 + configuration['courtyard_offset']['connector']:
+            courtyard_top_left[0] = 0 + params['pads']['diameter']/2 + configuration['courtyard_offset']['connector']
+    courtyard_bottom_right = [body_bottom_right[0] - configuration['courtyard_offset']['connector'], body_bottom_right[1] + configuration['courtyard_offset']['connector']]
+    if params['type'] == 'SMD':
+        if courtyard_bottom_right[0] > -params['pitch']-2*params['holes']['offset'] - params['pads']['x']/2 - configuration['courtyard_offset']['connector']:
+            courtyard_bottom_right[0] = -params['pitch']-2*params['holes']['offset'] - params['pads']['x']/2 - configuration['courtyard_offset']['connector']
+    else:
+        if courtyard_bottom_right[0] > -params['pitch']-2*params['holes']['offset'] - params['pads']['diameter']/2 - configuration['courtyard_offset']['connector']:
+            courtyard_bottom_right[0] = -params['pitch']-2*params['holes']['offset'] - params['pads']['diameter']/2 - configuration['courtyard_offset']['connector']
+    kicad_mod.append(RectLine(start=courtyard_top_left, end=courtyard_bottom_right, layer='F.CrtYd', width=configuration['courtyard_line_width']))
+    
+    # Add texts
+    body_edge={'left': body_top_left[0], 'right': body_bottom_right[0], 'top': body_top_left[1], 'bottom': body_bottom_right[1]}
+    addTextFields(kicad_mod=kicad_mod, configuration=configuration, body_edges=body_edge, fp_name=fp_name, text_y_inside_position='top',
+        courtyard={'top': body_edge['top'] - configuration['courtyard_offset']['connector'], 'bottom': body_edge['bottom'] + configuration['courtyard_offset']['connector'] + 0.2})
+
+    # 3D model definition
+    model3d_path_prefix = configuration.get('3d_model_prefix', '${KISYS3DMOD}/')
+    model_name = "{model3d_path_prefix:s}Connector_Wuerth_{series_prefix}_Bottom-Entry.3dshapes/{fp_name:s}.wrl".format(
+        model3d_path_prefix=model3d_path_prefix, series_prefix=params['series_prefix'], fp_name=fp_name)
+    kicad_mod.append(Model(filename=model_name))
+
+    # Create output directory
+    output_dir = 'Connector_Wuerth_{series_prefix}_Bottom-Entry.pretty/'.format(series_prefix=params['series_prefix'])
+    if not os.path.isdir(output_dir):
+        os.makedirs(output_dir)
+    filename =  '{output_dir:s}{fp_name:s}.kicad_mod'.format(output_dir=output_dir, fp_name=fp_name)
+
+    # Create footprint
+    file_handler = KicadFileHandler(kicad_mod)
+    file_handler.writeFile(filename)
+
+if __name__ == "__main__":
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(description='use config .yaml files to create footprints.')
+    parser.add_argument('--global_config', type=str, nargs='?', help='the config file defining how the footprint will look like. (KLC)', default='../tools/global_config_files/config_KLCv3.0.yaml')
+    parser.add_argument('--params', type=str, nargs='?', help='the part definition file', default='./wuerth_wr_phd_bottom_entry.yaml')
+    args = parser.parse_args()
+
+    # Load configuration
+    with open(args.global_config, 'r') as config_stream:
+        try:
+            configuration = yaml.safe_load(config_stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+
+    # Load yaml file for this library
+    with open(args.params, 'r') as params_stream:
+        try:
+            params = yaml.safe_load(params_stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+
+    # Create each part
+    for series in params:
+        for mpn in params[series]['parts']:
+            generate_footprint(params[series], params[series]['parts'][mpn], mpn, configuration)

--- a/scripts/Connector_Wuerth_WR-PHD/wuerth_wr_phd_bottom_entry.yaml
+++ b/scripts/Connector_Wuerth_WR-PHD/wuerth_wr_phd_bottom_entry.yaml
@@ -1,0 +1,195 @@
+standard:
+  series_prefix: WR-PHD
+  type: Standard
+  orientation: Vertical
+  pitch: 2.54
+  width: 5.08
+  height: 5.0
+  top: 1.52
+  pads:
+    diameter: 1.3
+    drill: 1
+  holes:
+    offset: 1.27
+    drill: 1.2
+  parts:
+    61300425721:
+      datasheet: https://katalog.we-online.de/em/datasheet/61300425721.pdf
+      rows: 2
+      pins: 4
+    61300625721:
+      datasheet: https://katalog.we-online.de/em/datasheet/61300625721.pdf
+      rows: 2
+      pins: 6
+    61300825721:
+      datasheet: https://katalog.we-online.de/em/datasheet/61300825721.pdf
+      rows: 2
+      pins: 8
+    61301025721:
+      datasheet: https://katalog.we-online.de/em/datasheet/61301025721.pdf
+      rows: 2
+      pins: 10
+    61301225721:
+      datasheet: https://katalog.we-online.de/em/datasheet/61301225721.pdf
+      rows: 2
+      pins: 12
+    61301625721:
+      datasheet: https://katalog.we-online.de/em/datasheet/61301625721.pdf
+      rows: 2
+      pins: 16
+    61302025721:
+      datasheet: https://katalog.we-online.de/em/datasheet/61302025721.pdf
+      rows: 2
+      pins: 20
+    61302425721:
+      datasheet: https://katalog.we-online.de/em/datasheet/61302425721.pdf
+      rows: 2
+      pins: 24
+    61302625721:
+      datasheet: https://katalog.we-online.de/em/datasheet/61302625721.pdf
+      rows: 2
+      pins: 26
+    61303225721:
+      datasheet: https://katalog.we-online.de/em/datasheet/61303225721.pdf
+      rows: 2
+      pins: 32
+    61303425721:
+      datasheet: https://katalog.we-online.de/em/datasheet/61303425721.pdf
+      rows: 2
+      pins: 34
+      
+large:
+  series_prefix: WR-PHD
+  type: Large
+  orientation: Vertical
+  pitch: 2.54
+  width: 5.08
+  height: 5.0
+  top: 1.52
+  pads:
+    diameter: 1.7
+    drill: 1
+  holes:
+    offset: 2.54
+    drill: 1.2
+  parts:
+    613004216921:
+      datasheet: https://katalog.we-online.de/em/datasheet/613004216921.pdf
+      rows: 2
+      pins: 4
+    613006216921:
+      datasheet: https://katalog.we-online.de/em/datasheet/613006216921.pdf
+      rows: 2
+      pins: 6
+    613008216921:
+      datasheet: https://katalog.we-online.de/em/datasheet/613008216921.pdf
+      rows: 2
+      pins: 8
+    613010216921:
+      datasheet: https://katalog.we-online.de/em/datasheet/613010216921.pdf
+      rows: 2
+      pins: 10
+    613012216921:
+      datasheet: https://katalog.we-online.de/em/datasheet/613012216921.pdf
+      rows: 2
+      pins: 12
+    613016216921:
+      datasheet: https://katalog.we-online.de/em/datasheet/613016216921.pdf
+      rows: 2
+      pins: 16
+    613018216921:
+      datasheet: https://katalog.we-online.de/em/datasheet/613018216921.pdf
+      rows: 2
+      pins: 18
+    613020216921:
+      datasheet: https://katalog.we-online.de/em/datasheet/613020216921.pdf
+      rows: 2
+      pins: 20
+    613022216921:
+      datasheet: https://katalog.we-online.de/em/datasheet/613022216921.pdf
+      rows: 2
+      pins: 22
+    613024216921:
+      datasheet: https://katalog.we-online.de/em/datasheet/613024216921.pdf
+      rows: 2
+      pins: 24
+    613026216921:
+      datasheet: https://katalog.we-online.de/em/datasheet/613026216921.pdf
+      rows: 2
+      pins: 26
+    613032216921:
+      datasheet: https://katalog.we-online.de/em/datasheet/613032216921.pdf
+      rows: 2
+      pins: 32
+    613034216921:
+      datasheet: https://katalog.we-online.de/em/datasheet/613034216921.pdf
+      rows: 2
+      pins: 34
+      
+smd:
+  series_prefix: WR-PHD
+  type: SMD
+  orientation: Vertical
+  pitch: 2.54
+  width: 5.0
+  height: 3.7
+  top: 1.27
+  pads:
+    x: 1.8
+    y: 0.9
+  holes:
+    offset: 1.93
+    drill: 1.1
+  parts:
+    610004243021:
+      datasheet: https://katalog.we-online.de/em/datasheet/610004243021.pdf
+      rows: 2
+      pins: 4
+    610006243021:
+      datasheet: https://katalog.we-online.de/em/datasheet/610006243021.pdf
+      rows: 2
+      pins: 6
+    610008243021:
+      datasheet: https://katalog.we-online.de/em/datasheet/610008243021.pdf
+      rows: 2
+      pins: 8
+    610010243021:
+      datasheet: https://katalog.we-online.de/em/datasheet/610010243021.pdf
+      rows: 2
+      pins: 10
+    610012243021:
+      datasheet: https://katalog.we-online.de/em/datasheet/610012243021.pdf
+      rows: 2
+      pins: 12
+    610016243021:
+      datasheet: https://katalog.we-online.de/em/datasheet/610016243021.pdf
+      rows: 2
+      pins: 16
+    610018243021:
+      datasheet: https://katalog.we-online.de/em/datasheet/610018243021.pdf
+      rows: 2
+      pins: 18
+    610020243021:
+      datasheet: https://katalog.we-online.de/em/datasheet/610020243021.pdf
+      rows: 2
+      pins: 20
+    610022243021:
+      datasheet: https://katalog.we-online.de/em/datasheet/610022243021.pdf
+      rows: 2
+      pins: 22
+    610024243021:
+      datasheet: https://katalog.we-online.de/em/datasheet/610024243021.pdf
+      rows: 2
+      pins: 24
+    610026243021:
+      datasheet: https://katalog.we-online.de/em/datasheet/610026243021.pdf
+      rows: 2
+      pins: 26
+    610032243021:
+      datasheet: https://katalog.we-online.de/em/datasheet/610032243021.pdf
+      rows: 2
+      pins: 32
+    610034243021:
+      datasheet: https://katalog.we-online.de/em/datasheet/610034243021.pdf
+      rows: 2
+      pins: 34


### PR DESCRIPTION
Add WR-PHD Bottom Entry series:
- Standard: https://www.we-online.com/catalog/en/PHD_2_54_DUAL_SOCKET_HEADER_BOTTOM_ENTRY_6130XX25721/
- Large: https://www.we-online.com/catalog/en/PHD_2_54_DUAL_SOCKET_HEADER_BOTTOM_ENTRY_LARGE_6130XX216921/
- SMD: https://www.we-online.com/catalog/en/PHD_2_54_SMT_DUAL_SOCKET_HEADER_BOTTOM_ENTRY_6100XX243021/

All the current references available are created (scripted, footprint + 3D model). The screenshots below shows several references (Standard, Large and SMD).

Footprint PR: https://github.com/KiCad/kicad-footprints/pull/2459
Footprint generator PR: https://github.com/pointhi/kicad-footprint-generator/pull/613
Packages 3D PR: https://github.com/KiCad/kicad-packages3D/pull/728
Packages 3D generator PR: https://github.com/easyw/kicad-3d-models-in-freecad/pull/393 and https://github.com/easyw/kicad-3d-models-in-freecad/pull/399

![fp_standard](https://user-images.githubusercontent.com/16516760/92533625-2a96c800-f233-11ea-92c9-940a10eb4abe.PNG)
![3d_standard](https://user-images.githubusercontent.com/16516760/92535526-b4489480-f237-11ea-8c55-e0c707d3eb80.PNG)

![fp_large](https://user-images.githubusercontent.com/16516760/92533634-2f5b7c00-f233-11ea-9cdd-ea7cbfe04366.PNG)
![3d_large](https://user-images.githubusercontent.com/16516760/92535532-b90d4880-f237-11ea-98b8-4c5a3a1744c4.PNG)

![fp_smd](https://user-images.githubusercontent.com/16516760/92533648-33879980-f233-11ea-9901-2e3297824a1d.PNG)
![3d_smd](https://user-images.githubusercontent.com/16516760/92535537-bc083900-f237-11ea-88a4-0a4a51979041.PNG)