### PR TITLE
Add VQFN-32-1EP_5x5mm_P0.5mm_EP3.15x3.15mm

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/vqfn.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/vqfn.yaml
@@ -584,10 +584,7 @@ VQFN-32-1EP_5x5mm_P0.5mm_EP3.15x3.15mm:
     maximum: 0.5
 
   EP_size_x: 3.15 +/- 0.1
-  EP_size_y:
-    minimum: 2.95
-    nominal: 3.15
-    maximum: 3.25
+  EP_size_y: 3.15 +/- 0.1
   EP_num_paste_pads: [2, 2]
 
   thermal_vias:

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/vqfn.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/vqfn.yaml
@@ -565,14 +565,8 @@ VQFN-32-1EP_5x5mm_P0.5mm_EP3.15x3.15mm:
   device_type: 'VQFN'
   size_source: 'https://www.ti.com/lit/ds/slvs589d/slvs589d.pdf#page=33'
   ipc_class: 'qfn'
-  body_size_x:
-    minimum: 4.85
-    nominal: 5
-    maximum: 5.15
-  body_size_y:
-    minimum: 4.85
-    nominal: 5
-    maximum: 5.15
+  body_size_x: 5.0 +/- 0.15
+  body_size_y: 5.0 +/- 0.15
   overall_height:
     minimum: 0.8
     maximum: 1

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/vqfn.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/vqfn.yaml
@@ -584,7 +584,6 @@ VQFN-32-1EP_5x5mm_P0.5mm_EP3.15x3.15mm:
   thermal_vias:
     count: [3, 3]
     drill: 0.2
-    grid: [1.0, 1.0]
     paste_avoid_via: False
 
   pitch: 0.5

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/vqfn.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/vqfn.yaml
@@ -583,10 +583,7 @@ VQFN-32-1EP_5x5mm_P0.5mm_EP3.15x3.15mm:
     minimum: 0.3
     maximum: 0.5
 
-  EP_size_x:
-    minimum: 2.95
-    nominal: 3.15
-    maximum: 3.25
+  EP_size_x: 3.15 +/- 0.1
   EP_size_y:
     minimum: 2.95
     nominal: 3.15
@@ -596,9 +593,7 @@ VQFN-32-1EP_5x5mm_P0.5mm_EP3.15x3.15mm:
   thermal_vias:
     count: [3, 3]
     drill: 0.2
-    paste_via_clearance: 0.1
-    EP_paste_coverage: 0.7
-    grid: [1.2, 1.2]
+    grid: [1.0, 1.0]
     paste_avoid_via: False
 
   pitch: 0.5

--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/vqfn.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/vqfn.yaml
@@ -561,6 +561,50 @@ VQFN-32-1EP_5x5mm_P0.5mm_EP3.1x3.1mm:
   #suffix: '_Pad{pad_x:.2f}x{pad_y:.2f}mm_HandSolder'
   #include_suffix_in_3dpath: 'False'
 
+VQFN-32-1EP_5x5mm_P0.5mm_EP3.15x3.15mm:
+  device_type: 'VQFN'
+  size_source: 'https://www.ti.com/lit/ds/slvs589d/slvs589d.pdf#page=33'
+  ipc_class: 'qfn'
+  body_size_x:
+    minimum: 4.85
+    nominal: 5
+    maximum: 5.15
+  body_size_y:
+    minimum: 4.85
+    nominal: 5
+    maximum: 5.15
+  overall_height:
+    minimum: 0.8
+    maximum: 1
+  lead_width:
+    minimum: 0.18
+    maximum: 0.3
+  lead_len:
+    minimum: 0.3
+    maximum: 0.5
+
+  EP_size_x:
+    minimum: 2.95
+    nominal: 3.15
+    maximum: 3.25
+  EP_size_y:
+    minimum: 2.95
+    nominal: 3.15
+    maximum: 3.25
+  EP_num_paste_pads: [2, 2]
+
+  thermal_vias:
+    count: [3, 3]
+    drill: 0.2
+    paste_via_clearance: 0.1
+    EP_paste_coverage: 0.7
+    grid: [1.2, 1.2]
+    paste_avoid_via: False
+
+  pitch: 0.5
+  num_pins_x: 8
+  num_pins_y: 8
+
 VQFN-32-1EP_5x5mm_P0.5mm_EP3.5x3.5mm:
   device_type: 'VQFN'
   #manufacturer: 'man'


### PR DESCRIPTION
This is for the VQFN-32 with a nominal 3.15x3.15mm EP.

It's used in this TI part:
https://www.ti.com/lit/ds/slvs589d/slvs589d.pdf#page=33

I used VQFN-32-1EP_5x5mm_P0.5mm_EP3.1x3.1mm as a basis, updating from the datasheet and removing commented lines. However I'm not sure if the conventions have changed since that part was defined.

Apologies if I made some incorrect assumptions (or indeed if the whole part is redundant).

![image](https://user-images.githubusercontent.com/203419/92748742-5aea7d80-f37d-11ea-85ca-d9ef445c9732.png)

![image](https://user-images.githubusercontent.com/203419/94345177-fb969980-001b-11eb-8716-c76b3c1c2aba.png)

![image](https://user-images.githubusercontent.com/203419/92748782-650c7c00-f37d-11ea-9e2c-30b43b069b29.png)

![image](https://user-images.githubusercontent.com/203419/94742707-0def3b00-036e-11eb-9a3f-8a55616b939e.png)
