### PR TITLE
Add SIP Generator with Yaml config files

### DIFF
--- a/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.py
+++ b/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.py
@@ -87,8 +87,8 @@ def create_footprint(name, configuration, **kwargs):
         }
 
     pitch = kwargs['pitch'] # pin pitch
-    pins  = kwargs['pins']  # amount of pins in package (including missing ones)
-    missing_pins = kwargs['missing_pins'] if 'missing_pins' in kwargs else [] # list of pin numbers that are missing
+    pins  = kwargs['pins']  # amount of pins in package (including hidden ones)
+    hidden_pins = kwargs['hidden_pins'] if 'hidden_pins' in kwargs else [] # list of pin numbers that are physically abscent but pins are counted
 
     library     = kwargs['library']
     description = kwargs['description']
@@ -129,7 +129,7 @@ def create_footprint(name, configuration, **kwargs):
                     description=description,
                     tags=tags,
                     lib_name=library,
-                    missing_pins=missing_pins)
+                    missing_pins=hidden_pins)
 
 
 if __name__ == "__main__":

--- a/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.py
+++ b/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import argparse
+import math
+import yaml
+
+sys.path.append(os.path.join(sys.path[0], "..", "..", ".."))  # load parent path of KicadModTree
+sys.path.append(os.path.join(sys.path[0], "..", "..", "tools"))  # load parent path of tools
+
+from ipc_pad_size_calculators import *
+from footprint_scripts_sip import makeSIPVertical
+
+
+# TODO BOTH FUNCTIONS SHOULD ALREADY BE IMPLEMENTED SOMEWHERE!!!
+# Values are taken from
+# https://www.pcb-3d.com/tutorials/how-to-calculate-pth-hole-and-pad-diameter-sizes-according-to-ipc-7251-ipc-2222-and-ipc-2221-standards/
+def ipc_calc_min_drill_size(pin_diameter, ipc_density):
+    if ipc_density == "A":
+        return pin_diameter.maximum + 0.25
+    elif ipc_density == "B":
+        return pin_diameter.maximum + 0.20
+    elif ipc_density == "C":
+        return pin_diameter.maximum + 0.15
+    else:
+        sys.exit("ERROR: Invalid IPC density level: " + ipc_density)
+
+def ipc_calc_pad_diameter(min_drill_diameter, ipc_density):
+    if ipc_density == "A":
+        return min_drill_diameter + 0.1 + 0.6
+    elif ipc_density == "B":
+        return min_drill_diameter + 0.1 + 0.5
+    elif ipc_density == "C":
+        return min_drill_diameter + 0.1 + 0.4
+    else:
+        sys.exit("ERROR: Invalid IPC density level: " + ipc_density)
+
+
+def create_footprint(name, configuration, **kwargs):
+
+    # ensure all provided dimensions are fully toleranced
+    package = {
+        'length': TolerancedSize.fromYaml(kwargs['package'], base_name='length'),
+        'width':  TolerancedSize.fromYaml(kwargs['package'], base_name='width'),
+        'height': TolerancedSize.fromYaml(kwargs['package'], base_name='height'),
+    }
+
+    top_offset  = kwargs['top_offset']   # offset from pin 1 to the upper package edge
+    left_offset = kwargs['left_offset']  # offset from pin 1 to the left package edge
+
+    # parse pin
+    pin = kwargs['pin']
+    if 'length' in pin and 'width' in pin and not 'diameter' in pin or not 'length' in pin and not 'width' in pin and 'diameter':
+        if 'diameter' in pin:
+            pin_diameter = TolerancedSize.fromYaml(pin, base_name='diameter')
+        else:
+            pin_length   = TolerancedSize.fromYaml(pin, base_name='length')
+            pin_width    = TolerancedSize.fromYaml(pin, base_name='width')
+            # calculate diameter of rectangular pin
+            min_dia = math.sqrt(pin_length.minimum**2 + pin_width.minimum**2)
+            nom_dia = math.sqrt(pin_length.nominal**2 + pin_width.nominal**2)
+            max_dia = math.sqrt(pin_length.maximum**2 + pin_width.maximum**2)
+            pin_diameter = TolerancedSize(minimum=min_dia, nominal=nom_dia, maximum=max_dia)
+    else:
+        sys.exit("ERROR: Do only specify ('length' and 'width') or 'diameter' for pins but not all 3!")
+
+    if 'ddrill' in kwargs:
+        ddrill = kwargs['ddrill']
+    else:
+        ddrill = ipc_calc_min_drill_size(pin_diameter, configuration['ipc_density'])
+
+    if 'pad' in kwargs:
+        pad = kwargs['pad']
+        if 'length' in pad and 'width' in pad:
+            pad = {
+                'length': TolerancedSize.fromYaml(pad, base_name='length').nominal,
+                'width':  TolerancedSize.fromYaml(pad, base_name='width').nominal
+            }
+        else:
+            sys.exit("ERROR: You need to specify either both 'pad_length' and 'pad_width' or none of them to use IPC standard sizes!")
+    else: # use IPC drill size
+        pad = {
+            'length': ipc_calc_pad_diameter(ddrill, configuration['ipc_density']),
+            'width':  ipc_calc_pad_diameter(ddrill, configuration['ipc_density'])
+        }
+
+    pitch = kwargs['pitch'] # pin pitch
+    pins  = kwargs['pins']  # amount of pins in package (including missing ones)
+    missing_pins = kwargs['missing_pins'] if 'missing_pins' in kwargs else [] # list of pin numbers that are missing
+
+    library     = kwargs['library']
+    description = kwargs['description']
+    datasheet   = kwargs['datasheet'] # link to datasheet
+    revision    = kwargs['revision']  # revision of the datasheet
+
+    tags = kwargs['tags']
+    if tags:
+        tags = "SIP-{0}".format(pins) + " " + tags
+    else:
+        tags = "SIP-{0}".format(pins)
+
+    if datasheet:
+        if not "#page=" in datasheet:
+            print("WARNING: You should state the PDF page where the footprint is specified.")
+            print("E.g. https://www.page.com/datasheet.pdf#page=3")
+        if not datasheet.startswith("https"):
+            print("WARNING: Datasheet links should use the HTTPS protocol.")
+        description += ", " + datasheet
+    if revision:
+        description += " " + revision
+
+    description += " (Generated with " + os.path.basename(__file__) + ")"
+
+    # TODO Remove those print lines
+    print(description)
+    print(tags)
+
+    makeSIPVertical(pins=pins, rm=pitch, ddrill=ddrill,
+                    pad=[pad['length'], pad['width']],
+                    package_size=[package['length'].nominal, package['width'].nominal, package['height'].nominal],
+                    left_offset=left_offset, top_offset=top_offset,
+                    footprint_name=name,
+                    description=description,
+                    tags=tags,
+                    lib_name=library,
+                    missing_pins=missing_pins)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Parse *.kicad_mod.yml file(s) and create matching footprints')
+    parser.add_argument('files', metavar='file', type=str, nargs='+', help='yml-files to parse')
+    parser.add_argument('--ipc_density', type=str, nargs='?', help='the IPC density', default='nominal')
+
+    args = parser.parse_args()
+
+    # TODO Here I overwrite the configuration with B as the configuration passes "nominal"
+    # and I don't know what this means...
+    configuration = {
+        # 'ipc_density': args.ipc_density
+        'ipc_density': "B"
+    }
+
+    for filepath in args.files:
+        with open(filepath, 'r') as stream:
+            try:
+                yaml_parsed = yaml.safe_load(stream)
+                for footprint in yaml_parsed:
+                    print("generate {name}.kicad_mod".format(name=footprint))
+                    create_footprint(footprint, configuration, **yaml_parsed.get(footprint))
+
+            except yaml.YAMLError as exc:
+                print(exc)

--- a/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.py
+++ b/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.py
@@ -11,6 +11,7 @@ sys.path.append(os.path.join(sys.path[0], "..", "..", "tools"))  # load parent p
 
 from ipc_pad_size_calculators import *
 from footprint_scripts_sip import makeSIPVertical
+from footprint_global_properties import crt_offset
 
 
 # TODO BOTH FUNCTIONS SHOULD ALREADY BE IMPLEMENTED SOMEWHERE!!!
@@ -108,13 +109,17 @@ def create_footprint(name, configuration, **kwargs):
             print("WARNING: Datasheet links should use the HTTPS protocol.")
         description += ", " + datasheet
     if revision:
-        description += " " + revision
+        description += " Rev. " + revision
 
     description += " (Generated with " + os.path.basename(__file__) + ")"
 
     # TODO Remove those print lines
     print(description)
     print(tags)
+
+    # TODO: Move this check into makeSIPVertical and modify parameters to take a TolerancedSize
+    if (package['length'].maximum - package['length'].nominal > 2 * crt_offset) or (package['width'].maximum - package['width'].nominal > 2 * crt_offset):
+        print("ERROR: Your footprint has too high tolerances. This can't be handeld by makeSIPVertical!")
 
     makeSIPVertical(pins=pins, rm=pitch, ddrill=ddrill,
                     pad=[pad['length'], pad['width']],

--- a/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.py
+++ b/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.py
@@ -52,7 +52,7 @@ def create_footprint(name, configuration, **kwargs):
 
     # parse pin
     pin = kwargs['pin']
-    if 'length' in pin and 'width' in pin and not 'diameter' in pin or not 'length' in pin and not 'width' in pin and 'diameter':
+    if 'length' in pin and 'width' in pin and not 'diameter' in pin or not 'length' in pin and not 'width' in pin and 'diameter' in pin:
         if 'diameter' in pin:
             pin_diameter = TolerancedSize.fromYaml(pin, base_name='diameter')
         else:

--- a/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.yaml
+++ b/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.yaml
@@ -14,7 +14,7 @@ test_Converter_DCDC_TRACO_TBA_1-xxxx_THT:
   pitch: 2.54
   pins: 7
   hidden_pins: [3, 5, 7]
-  pin:
+  pin: # specify either (length and width) or diameter
     length:
       nominal: 0.5
       tolerance: 0.01
@@ -24,8 +24,8 @@ test_Converter_DCDC_TRACO_TBA_1-xxxx_THT:
 #     diameter:
 #       nominal: 0.8
 #       tolerance: 0.05
-#   ddrill: 1.0
-#   pad:
+#   ddrill: 1.0 # only specify to override IPC value
+#   pad: # only specify to override IPC value
 #     length:
 #       nominal: 0.5
 #       tolerance: 0.01
@@ -38,7 +38,7 @@ test_Converter_DCDC_TRACO_TBA_1-xxxx_THT:
   datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1_datasheet.pdf#page=3"
   revision: "April 27, 2020"
 
-Converter_DCDC_TRACO_TMV_05xxS_TMV_12xxS_THT:
+test_normal:
   package:
     length:
       nominal: 19.5
@@ -61,6 +61,91 @@ Converter_DCDC_TRACO_TMV_05xxS_TMV_12xxS_THT:
     width:
       nominal: 0.25
       tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMV 5V/12V Input Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
+  
+test_use_pin_diameter:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 6.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.375
+  left_offset: 2.3
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4, 6]
+  pin:
+    diameter:
+      nominal: 0.5
+      tolerance: 0.1
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMV 5V/12V Input Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
+  
+test_override_drill_use_IPC_pad:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 6.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.375
+  left_offset: 2.3
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4, 6]
+  ddrill: 0.333
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMV 5V/12V Input Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
+  
+test_override_pad_use_IPC_drill:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 6.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.375
+  left_offset: 2.3
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4, 6]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  pad: # only specify to override IPC value
+    length:
+      nominal: 0.5
+      tolerance: 0.01
+    width:
+      nominal: 0.25
+      tolerance: 0.01
   library: "Converter_DCDC"
   tags: "DC/DC Converter"
   description: "Traco TMV 5V/12V Input Single Output"

--- a/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.yaml
+++ b/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.yaml
@@ -1,40 +1,39 @@
-# Example:
-# Converter_DCDC_TRACO_TBA_1-xxxx_THT:
-#   package:
-#     length:
-#       nominal: 19.5
-#       tolerance: 0.35
-#     width:
-#       nominal: 6
-#       tolerance: 0.35
-#     height:
-#       nominal: 9.5
-#       tolerance: 0.35
-#   top_offset: 1.35
-#   left_offset: 2.4
-#   pitch: 2.54
-#   pins: 7
-#   missing_pins: [3, 5, 7]
-#   pin:
+test_Converter_DCDC_TRACO_TBA_1-xxxx_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.35
+    width:
+      nominal: 6
+      tolerance: 0.35
+    height:
+      nominal: 9.5
+      tolerance: 0.35
+  top_offset: 1.35
+  left_offset: 2.4
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 5, 7]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.01
+    width:
+      nominal: 0.25
+      tolerance: 0.01
+#     diameter:
+#       nominal: 0.8
+#       tolerance: 0.05
+#   ddrill: 1.0
+#   pad:
 #     length:
 #       nominal: 0.5
 #       tolerance: 0.01
 #     width:
 #       nominal: 0.25
 #       tolerance: 0.01
-# #   diameter:
-# #     nominal: 0.8
-# #     tolerance: 0.05
-# # ddrill: 1.0
-# # pad:
-# #   length:
-# #     nominal: 0.5
-# #     tolerance: 0.01
-# #   width:
-# #     nominal: 0.25
-# #     tolerance: 0.01
-#   library: "Converter_DCDC"
-#   tags: "DC/DC Converter"
-#   description: "Traco TBA 1 Series"
-#   datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1_datasheet.pdf#page=3"
-#   revision: "April 27, 2020"
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TBA 1 Series"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1_datasheet.pdf#page=3"
+  revision: "April 27, 2020"

--- a/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.yaml
+++ b/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.yaml
@@ -33,3 +33,8 @@
 # #   width:
 # #     nominal: 0.25
 # #     tolerance: 0.01
+#   library: "Converter_DCDC"
+#   tags: "DC/DC Converter"
+#   description: "Traco TBA 1 Series"
+#   datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1_datasheet.pdf#page=3"
+#   revision: "April 27, 2020"

--- a/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.yaml
+++ b/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.yaml
@@ -37,3 +37,32 @@ test_Converter_DCDC_TRACO_TBA_1-xxxx_THT:
   description: "Traco TBA 1 Series"
   datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1_datasheet.pdf#page=3"
   revision: "April 27, 2020"
+
+Converter_DCDC_TRACO_TMV_05xxS_TMV_12xxS_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 6.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.375
+  left_offset: 2.3
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4, 6]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMV 5V/12V Input Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
+  revision: "October 23, 2018"

--- a/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.yaml
+++ b/scripts/Packages/Package_SIP_THT/Package_SIP_Vertical_THT.yaml
@@ -1,0 +1,35 @@
+# Example:
+# Converter_DCDC_TRACO_TBA_1-xxxx_THT:
+#   package:
+#     length:
+#       nominal: 19.5
+#       tolerance: 0.35
+#     width:
+#       nominal: 6
+#       tolerance: 0.35
+#     height:
+#       nominal: 9.5
+#       tolerance: 0.35
+#   top_offset: 1.35
+#   left_offset: 2.4
+#   pitch: 2.54
+#   pins: 7
+#   missing_pins: [3, 5, 7]
+#   pin:
+#     length:
+#       nominal: 0.5
+#       tolerance: 0.01
+#     width:
+#       nominal: 0.25
+#       tolerance: 0.01
+# #   diameter:
+# #     nominal: 0.8
+# #     tolerance: 0.05
+# # ddrill: 1.0
+# # pad:
+# #   length:
+# #     nominal: 0.5
+# #     tolerance: 0.01
+# #   width:
+# #     nominal: 0.25
+# #     tolerance: 0.01

--- a/scripts/Packages/Package_SIP_THT/size_definitions/test_sip_vertical_tht.yaml
+++ b/scripts/Packages/Package_SIP_THT/size_definitions/test_sip_vertical_tht.yaml
@@ -1,4 +1,6 @@
-test_Converter_DCDC_TRACO_TBA_1-xxxx_THT:
+# a typical part with all possible configuration options. The ones that are
+# not necessary are commented out
+all_config_options:
   package:
     length:
       nominal: 19.5
@@ -24,8 +26,8 @@ test_Converter_DCDC_TRACO_TBA_1-xxxx_THT:
 #     diameter:
 #       nominal: 0.8
 #       tolerance: 0.05
-#   ddrill: 1.0 # only specify to override IPC value
-#   pad: # only specify to override IPC value
+#   ddrill: 1.0 # specify only to override IPC value
+#   pad: # specify only to override IPC value
 #     length:
 #       nominal: 0.5
 #       tolerance: 0.01
@@ -38,7 +40,8 @@ test_Converter_DCDC_TRACO_TBA_1-xxxx_THT:
   datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1_datasheet.pdf#page=3"
   revision: "April 27, 2020"
 
-test_normal:
+# this represents the typical configuration
+normal:
   package:
     length:
       nominal: 19.5
@@ -66,8 +69,9 @@ test_normal:
   description: "Traco TMV 5V/12V Input Single Output"
   datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
   revision: "October 23, 2018"
-  
-test_use_pin_diameter:
+
+# use the pin diameter and calculate drill and pad sizes from IPC
+use_pin_diameter:
   package:
     length:
       nominal: 19.5
@@ -92,8 +96,9 @@ test_use_pin_diameter:
   description: "Traco TMV 5V/12V Input Single Output"
   datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
   revision: "October 23, 2018"
-  
-test_override_drill_use_IPC_pad:
+
+# use specified drill size and IPC pad sizes
+override_drill_use_IPC_pad:
   package:
     length:
       nominal: 19.5
@@ -115,8 +120,9 @@ test_override_drill_use_IPC_pad:
   description: "Traco TMV 5V/12V Input Single Output"
   datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
   revision: "October 23, 2018"
-  
-test_override_pad_use_IPC_drill:
+
+# use specifed pad sizes and IPC drill size
+override_pad_use_IPC_drill:
   package:
     length:
       nominal: 19.5
@@ -139,7 +145,7 @@ test_override_pad_use_IPC_drill:
     width:
       nominal: 0.25
       tolerance: 0.05
-  pad: # only specify to override IPC value
+  pad: # specify only to override IPC value
     length:
       nominal: 0.5
       tolerance: 0.01

--- a/scripts/Packages/Package_SIP_THT/size_definitions/test_traco_parts_tht.yaml
+++ b/scripts/Packages/Package_SIP_THT/size_definitions/test_traco_parts_tht.yaml
@@ -1,0 +1,1387 @@
+Converter_DCDC_TRACO_TBA_1-xxxx_THT:
+    package:
+      length:
+        nominal: 11.68
+        tolerance: 0.35
+      width:
+        nominal: 6
+        tolerance: 0.35
+      height:
+        nominal: 9.65
+        tolerance: 0.35
+    top_offset: 4.65
+    left_offset: 2.03
+    pitch: 2.54
+    pins: 4
+    pin:
+      length:
+        nominal: 0.5
+      #   tolerance: 0.35
+      width:
+        nominal: 0.25
+      #   tolerance: 0.35
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TBA 1"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1_datasheet.pdf#page=3"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TBA_1-xx1xE_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.35
+      width:
+        nominal: 6
+        tolerance: 0.35
+      height:
+        nominal: 9.5
+        tolerance: 0.35
+    top_offset: 1.35
+    left_offset: 2.4
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 5, 7]
+    pin:
+      length:
+        nominal: 0.5
+      #   tolerance: 0.35
+      width:
+        nominal: 0.25
+      #   tolerance: 0.35
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TBA 1E Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1e_datasheet.pdf#page=3"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TBA_1-xx2xE_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.35
+      width:
+        nominal: 6
+        tolerance: 0.35
+      height:
+        nominal: 9.5
+        tolerance: 0.35
+    top_offset: 1.35
+    left_offset: 2.4
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 7]
+    pin:
+      length:
+        nominal: 0.5
+      #   tolerance: 0.35
+      width:
+        nominal: 0.25
+      #   tolerance: 0.35
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TBA 1E Dual Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1e_datasheet.pdf#page=3"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TBA_1-xx1xHI_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.35
+      width:
+        nominal: 6
+        tolerance: 0.35
+      height:
+        nominal: 9.5
+        tolerance: 0.35
+    top_offset: 1.35
+    left_offset: 2.4
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 4, 6]
+    pin:
+      length:
+        nominal: 0.5
+      #   tolerance: 0.35
+      width:
+        nominal: 0.25
+      #   tolerance: 0.35
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TBA 1HI Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1hi_datasheet.pdf#page=3"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TBA_1-xx2xHI_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.35
+      width:
+        nominal: 6
+        tolerance: 0.35
+      height:
+        nominal: 9.5
+        tolerance: 0.35
+    top_offset: 1.35
+    left_offset: 2.4
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 4]
+    pin:
+      length:
+        nominal: 0.5
+      #   tolerance: 0.35
+      width:
+        nominal: 0.25
+      #   tolerance: 0.35
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TBA 1HI Dual Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1hi_datasheet.pdf#page=3"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TBA_2-xx1x_THT:
+    package:
+      length:
+        nominal: 19.55
+        tolerance: 0.35
+      width:
+        nominal: 7.6
+        tolerance: 0.35
+      height:
+        nominal: 10.2
+        tolerance: 0.35
+    top_offset: 1.35
+    left_offset: 2.4
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 5, 7]
+    pin:
+      length:
+        nominal: 0.5
+      #   tolerance: 0.35
+      width:
+        nominal: 0.25
+      #   tolerance: 0.35
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TBA 2 Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba2_datasheet.pdf#page=3"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TBA_2-xx2x_THT:
+    package:
+      length:
+        nominal: 19.55
+        tolerance: 0.35
+      width:
+        nominal: 7.6
+        tolerance: 0.35
+      height:
+        nominal: 10.2
+        tolerance: 0.35
+    top_offset: 1.35
+    left_offset: 2.4
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 7]
+    pin:
+      length:
+        nominal: 0.5
+      #   tolerance: 0.35
+      width:
+        nominal: 0.25
+      #   tolerance: 0.35
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TBA 2 Dual Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba2_datasheet.pdf#page=3"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TMA_05xxS_TMA_12xxS_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 6.1
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.175
+    left_offset: 2.4
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 5, 7]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMA 5V/12V Input Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+    revision: "October 23, 2018"
+
+  Converter_DCDC_TRACO_TMA_05xxD_TMA_12xxD_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 6.1
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.175
+    left_offset: 2.4
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 7]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMA 5V/12V Input Dual Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+    revision: "October 23, 2018"
+
+  Converter_DCDC_TRACO_TMA_15xxS_TMA_24xxS_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 7.1
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.175
+    left_offset: 2.4
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 5, 7]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMA 15V/24V Input Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+    revision: "October 23, 2018"
+
+  Converter_DCDC_TRACO_TMA_15xxD_TMA_24xxD_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 7.1
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.175
+    left_offset: 2.4
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 7]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMA 15V/24V Input Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+    revision: "October 23, 2018"
+
+  Converter_DCDC_TRACO_TMAP_xxxxS_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.5
+      width:
+        nominal: 7.1
+        tolerance: 0.5
+      height:
+        nominal: 10.2
+        tolerance: 0.5
+    top_offset: 1.925
+    left_offset: 2.1
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 5, 7]
+    pin:
+      length:
+        nominal: 0.5
+        # tolerance: 0.5
+      width:
+        nominal: 0.25
+        # tolerance: 0.25
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMAP Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmap_datasheet.pdf#page=4"
+    revision: "August 14, 2020"
+
+  Converter_DCDC_TRACO_TMAP_xxxxD_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.5
+      width:
+        nominal: 7.1
+        tolerance: 0.5
+      height:
+        nominal: 10.2
+        tolerance: 0.5
+    top_offset: 1.925
+    left_offset: 2.1
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 7]
+    pin:
+      length:
+        nominal: 0.5
+        # tolerance: 0.5
+      width:
+        nominal: 0.25
+        # tolerance: 0.25
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMAP Dual Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmap_datasheet.pdf#page=4"
+    revision: "August 14, 2020"
+
+  Converter_DCDC_TRACO_TME_03xxS_TME_05xxS_TME_12xxS_THT:
+    package:
+      length:
+        nominal: 11.5
+        tolerance: 0.25
+      width:
+        nominal: 6.1
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 4.325
+    left_offset: 1.9
+    pitch: 2.54
+    pins: 4
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TME 3.3V/5V/12V Input Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tme_datasheet.pdf#page=3"
+    revision: "October 23, 2018"
+
+  Converter_DCDC_TRACO_TME_24xxS_THT:
+    package:
+      length:
+        nominal: 11.5
+        tolerance: 0.25
+      width:
+        nominal: 7.1
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 5.325
+    left_offset: 1.9
+    pitch: 2.54
+    pins: 4
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TME 24V Input Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tme_datasheet.pdf#page=3"
+    revision: "October 23, 2018"
+
+  Converter_DCDC_TRACO_TMR_1-xx1x_THT:
+    package:
+      length:
+        nominal: 17
+        tolerance: 0.5
+      width:
+        nominal: 7.62
+        tolerance: 0.5
+      height:
+        nominal: 11
+        tolerance: 0.5
+    top_offset: 2.375
+    left_offset: 2.15
+    pitch: 2.54
+    pins: 6
+    hidden_pins: [3, 5]
+    pin:
+      length:
+        nominal: 0.5
+        # tolerance: 0.5
+      width:
+        nominal: 0.25
+        # tolerance: 0.5
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMR 1 Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr1_datasheet.pdf#page=4"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TMR_1-xx2x_THT:
+    package:
+      length:
+        nominal: 17
+        tolerance: 0.5
+      width:
+        nominal: 7.62
+        tolerance: 0.5
+      height:
+        nominal: 11
+        tolerance: 0.5
+    top_offset: 2.375
+    left_offset: 2.15
+    pitch: 2.54
+    pins: 6
+    hidden_pins: [3]
+    pin:
+      length:
+        nominal: 0.5
+        # tolerance: 0.5
+      width:
+        nominal: 0.25
+        # tolerance: 0.5
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMR 1 Dual Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr1_datasheet.pdf#page=4"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TMV_05xxS_TMV_12xxS_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 6.1
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.375
+    left_offset: 2.3
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 4, 6]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMV 5V/12V Input Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
+    revision: "October 23, 2018"
+
+  Converter_DCDC_TRACO_TMV_24xxS_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 7.1
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.375
+    left_offset: 2.3
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 4, 6]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMV 24V Input Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
+    revision: "October 23, 2018"
+
+  Converter_DCDC_TRACO_TMV_05xxD_TMV_12xxD_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 6.1
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.375
+    left_offset: 2.3
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 4]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMV 5V/12V Input Dual Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
+    revision: "October 23, 2018"
+
+  Converter_DCDC_TRACO_TMV_24xxD_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 7.1
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.375
+    left_offset: 2.3
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 4]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMV 24V Input Dual Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
+    revision: "October 23, 2018"
+
+  Converter_DCDC_TRACO_TMV_xxxx_EN_THT:
+    package:
+      length:
+        nominal: 22
+        tolerance: 0.5
+      width:
+        nominal: 7.5
+        tolerance: 0.5
+      height:
+        nominal: 12.5
+        tolerance: 0.5
+    top_offset: 1.875
+    left_offset: 3.5
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 4, 6]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMV-EN Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_en_datasheet.pdf#page=3"
+    revision: "February 18, 2020"
+
+  Converter_DCDC_TRACO_TMV_xxxxD_EN_THT:
+    package:
+      length:
+        nominal: 22
+        tolerance: 0.5
+      width:
+        nominal: 7.5
+        tolerance: 0.5
+      height:
+        nominal: 12.5
+        tolerance: 0.5
+    top_offset: 1.875
+    left_offset: 3.5
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 4]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMV-EN Dual Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_en_datasheet.pdf#page=3"
+    revision: "February 18, 2020"
+
+  Converter_DCDC_TRACO_TMV_xxxxSHI_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.5
+      width:
+        nominal: 7.5
+        tolerance: 0.5
+      height:
+        nominal: 10.2
+        tolerance: 0.5
+    top_offset: 1.675
+    left_offset: 2.3
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 4, 6]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMV-HI Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_hi_datasheet.pdf#page=4"
+    revision: "August 27, 2020"
+
+  Converter_DCDC_TRACO_TMV_xxxxDHI_TMV_xxxx9HI_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.5
+      width:
+        nominal: 7.5
+        tolerance: 0.5
+      height:
+        nominal: 10.2
+        tolerance: 0.5
+    top_offset: 1.675
+    left_offset: 2.3
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 4]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMV-HI Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_hi_datasheet.pdf#page=4"
+    revision: "August 27, 2020"
+
+  Converter_DCDC_TRACO_TRV_1-xx1xM_THT:
+    package:
+      length:
+        nominal: 19.6
+        tolerance: 0.5
+      width:
+        nominal: 9.9
+        tolerance: 0.5
+      height:
+        nominal: 12.5
+        tolerance: 0.5
+    top_offset: 2.3
+    left_offset: 1.8
+    pitch: 2
+    pins: 9
+    hidden_pins: [3, 4, 5, 6, 8]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.1
+      width:
+        nominal: 0.25
+        tolerance: 0.1
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TRV 1M Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/trv1m_datasheet.pdf#page=4"
+    revision: "August 24, 2020"
+
+  Converter_DCDC_TRACO_TRV_1-xx2xM_THT:
+    package:
+      length:
+        nominal: 19.6
+        tolerance: 0.5
+      width:
+        nominal: 9.9
+        tolerance: 0.5
+      height:
+        nominal: 12.5
+        tolerance: 0.5
+    top_offset: 2.3
+    left_offset: 1.8
+    pitch: 2
+    pins: 9
+    hidden_pins: [3, 4, 5, 6]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.1
+      width:
+        nominal: 0.25
+        tolerance: 0.1
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TRV 1M Dual Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/trv1m_datasheet.pdf#page=4"
+    revision: "August 24, 2020"
+
+  Converter_DCDC_TRACO_TEC_2-xxxx_TEC_2-xxxxWI_TEC_3-xxxx_TEC_3-xxxxWI_THT:
+    package:
+      length:
+        nominal: 21.8
+        tolerance: 0.5
+      width:
+        nominal: 9.1
+        tolerance: 0.5
+      height:
+        nominal: 11.2
+        tolerance: 0.5
+    top_offset: 3.325
+    left_offset: 2.02
+    pitch: 2.54
+    pins: 8
+    hidden_pins: [4]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.1
+      width:
+        nominal: 0.25
+        tolerance: 0.1
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TEC 2, TEC 2WI, TEC 3, TEC 3WI"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tec2_datasheet.pdf#page=4"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TMH_xxxxS_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 7.5
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.375
+    left_offset: 2.3
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 5, 7]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMH Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmh_datasheet.pdf#page=3"
+    revision: "October 23, 2018"
+
+  Converter_DCDC_TRACO_TMH_xxxxD_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 7.5
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.375
+    left_offset: 2.3
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 7]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMH Dual Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmh_datasheet.pdf#page=3"
+    revision: "October 23, 2018"
+
+  Converter_DCDC_TRACO_TMR_xxxx_TMR_3-xxxxWI_THT:
+    package:
+      length:
+        nominal: 21.8
+        tolerance: 0.5
+      width:
+        nominal: 9.2
+        tolerance: 0.5
+      height:
+        nominal: 11.1
+        tolerance: 0.5
+    top_offset: 3.325
+    left_offset: 2
+    pitch: 2.54
+    pins: 8
+    hidden_pins: [4]
+    pin:
+      length:
+        nominal: 0.5
+        # tolerance: 0.5
+      width:
+        nominal: 0.25
+        # tolerance: 0.5
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMR 2, TMR 3WI"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr2_datasheet.pdf#page=4"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TMR_2-xxxxE_THT:
+    package:
+      length:
+        nominal: 21.8
+        tolerance: 0.5
+      width:
+        nominal: 9.3
+        tolerance: 0.5
+      height:
+        nominal: 11.2
+        tolerance: 0.5
+    top_offset: 2.575
+    left_offset: 2
+    pitch: 2.54
+    pins: 8
+    hidden_pins: [3]
+    pin:
+      length:
+        nominal: 0.5
+        # tolerance: 0.5
+      width:
+        nominal: 0.25
+        # tolerance: 0.5
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMR 2E"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr2e_datasheet.pdf#page=4"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TMR_2-xxxxWI_THT:
+    package:
+      length:
+        nominal: 25.95
+        tolerance: 0.5
+      width:
+        nominal: 9.25
+        tolerance: 0.5
+      height:
+        nominal: 12.45
+        tolerance: 0.5
+    top_offset: 2.375
+    left_offset: 2
+    pitch: 2.54
+    pins: 9
+    hidden_pins: [4, 5]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMR 2WI"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr2wi_datasheet.pdf#page=4"
+    revision: "April 27, 2020"
+
+    Converter_DCDC_TRACO_TMV_2-xxxxSHI_THT:
+      package:
+        length:
+          nominal: 19.5
+          tolerance: 0.5
+        width:
+          nominal: 7.1
+          tolerance: 0.5
+        height:
+          nominal: 10.2
+          tolerance: 0.5
+      top_offset: 1.675
+      left_offset: 2.3
+      pitch: 2.54
+      pins: 7
+      hidden_pins: [3, 4, 6]
+      pin:
+        length:
+          nominal: 0.5
+          tolerance: 0.05
+        width:
+          nominal: 0.25
+          tolerance: 0.05
+      library: "Converter_DCDC"
+      tags: "DC/DC Converter"
+      description: "Traco TMV 2HI Single Output"
+      datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv2hi_datasheet.pdf#page=4"
+      revision: "August 27, 2020"
+
+  Converter_DCDC_TRACO_TMV_2-xxxxDHI_TMV_2-xxxx9HI_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.5
+      width:
+        nominal: 7.1
+        tolerance: 0.5
+      height:
+        nominal: 10.2
+        tolerance: 0.5
+    top_offset: 1.675
+    left_offset: 2.3
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 4]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMV 2HI Dual Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv2hi_datasheet.pdf#page=4"
+    revision: "August 27, 2020"
+
+  Converter_DCDC_TRACO_TMR 3-xxxx_THT:
+    package:
+      length:
+        nominal: 21.8
+        tolerance: 0.5
+      width:
+        nominal: 9.2
+        tolerance: 0.5
+      height:
+        nominal: 11.1
+        tolerance: 0.5
+    top_offset: 3.325
+    left_offset: 2
+    pitch: 2.54
+    pins: 8
+    hidden_pins: [4]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.1
+      width:
+        nominal: 0.25
+        tolerance: 0.1
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMR 3"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr3_datasheet.pdf#page=4"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TMR_3-xxxxE_TMR_3-xxxxWIE_THT:
+    package:
+      length:
+        nominal: 21.8
+        tolerance: 0.5
+      width:
+        nominal: 9.3
+        tolerance: 0.5
+      height:
+        nominal: 11.2
+        tolerance: 0.5
+    top_offset: 2.575
+    left_offset: 2
+    pitch: 2.54
+    pins: 8
+    hidden_pins: [4]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.1
+      width:
+        nominal: 0.25
+        tolerance: 0.1
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMR 3E, TMR 3WIE"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr3e_datasheet.pdf#page=4"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TMR_3-xxxxHI_THT:
+    package:
+      length:
+        nominal: 21.8
+        tolerance: 0.5
+      width:
+        nominal: 9.2
+        tolerance: 0.5
+      height:
+        nominal: 11.1
+        tolerance: 0.5
+    top_offset: 3.325
+    left_offset: 2
+    pitch: 2.54
+    pins: 8
+    hidden_pins: [4, 5]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.1
+      width:
+        nominal: 0.25
+        tolerance: 0.1
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMR 3HI"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr3hi_datasheet.pdf#page=4"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TRA_3-xxxx_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 7.6
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.175
+    left_offset: 2.55
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 5, 7]
+    pin:
+      length:
+        nominal: 0.5
+        # tolerance: 0.05
+      width:
+        nominal: 0.25
+        # tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TRA 3"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tra3_datasheet.pdf#page=3"
+    revision: "December 13, 2017"
+
+  Converter_DCDC_TRACO_TMR_6-xxxx_TMR_6-xxxxWI_THT:
+    package:
+      length:
+        nominal: 21.8
+        tolerance: 0.5
+      width:
+        nominal: 9.1
+        tolerance: 0.5
+      height:
+        nominal: 11.2
+        tolerance: 0.5
+    top_offset: 3.325
+    left_offset: 2
+    pitch: 2.54
+    pins: 8
+    hidden_pins: [4]
+    pin:
+      length:
+        nominal: 0.5
+        # tolerance: 0.5
+      width:
+        nominal: 0.25
+        # tolerance: 0.5
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMR 6, TMR 6WI"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr6_datasheet.pdf#page=4"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TMR_9-xxxxWI_Option_Plastic_Package_THT:
+    package:
+      length:
+        nominal: 21.8
+        tolerance: 0.5
+      width:
+        nominal: 9.1
+        tolerance: 0.5
+      height:
+        nominal: 11.2
+        tolerance: 0.5
+    top_offset: 3.325
+    left_offset: 2
+    pitch: 2.54
+    pins: 8
+    hidden_pins: [4, 5]
+    pin:
+      length:
+        nominal: 0.5
+        # tolerance: 0.5
+      width:
+        nominal: 0.25
+        # tolerance: 0.5
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMR 9WI Plastic Package Option"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr9wi_datasheet.pdf#page=5"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TMA_05xxS_TMA_12xxS_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 6.1
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.175
+    left_offset: 2.1
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 5, 7]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMA 5V/12V Input Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+    revision: "August 14, 2020"
+
+  Converter_DCDC_TRACO_TMA_15xxS_TMA_24xxS_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 7.1
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.175
+    left_offset: 2.1
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 5, 7]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMA 15V/24V Input Single Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+    revision: "August 14, 2020"
+
+  Converter_DCDC_TRACO_TMA_05xxD_TMA_12xxD_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 6.1
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.175
+    left_offset: 2.1
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 7]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMA 5V/12V Input Dual Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+    revision: "August 14, 2020"
+
+  Converter_DCDC_TRACO_TMA_15xxD_TMA_24xxD_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.25
+      width:
+        nominal: 7.1
+        tolerance: 0.25
+      height:
+        nominal: 10.2
+        tolerance: 0.25
+    top_offset: 1.175
+    left_offset: 2.1
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 7]
+    pin:
+      length:
+        nominal: 0.5
+        tolerance: 0.05
+      width:
+        nominal: 0.25
+        tolerance: 0.05
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TMA 15V/24V Input Dual Output"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+    revision: "August 14, 2020"
+
+  Converter_DCDC_TRACO_TEA_1-0505_THT:
+    package:
+      length:
+        nominal: 11.68
+        tolerance: 0.35
+      width:
+        nominal: 6
+        tolerance: 0.35
+      height:
+        nominal: 9.65
+        tolerance: 0.35
+    top_offset: 5.1
+    left_offset: 2.03
+    pitch: 2.54
+    pins: 4
+    pin:
+      length:
+        nominal: 0.5
+        # tolerance: 0.35
+      width:
+        nominal: 0.25
+        # tolerance: 0.35
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TEA 1"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tea1_datasheet.pdf#page=3"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TEA_1-0505E_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.35
+      width:
+        nominal: 6
+        tolerance: 0.35
+      height:
+        nominal: 9.5
+        tolerance: 0.35
+    top_offset: 0.9
+    left_offset: 2.4
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 5, 7]
+    pin:
+      length:
+        nominal: 0.5
+        # tolerance: 0.35
+      width:
+        nominal: 0.25
+        # tolerance: 0.35
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TEA 1E"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tea1e_datasheet.pdf#page=3"
+    revision: "April 27, 2020"
+
+  Converter_DCDC_TRACO_TEA_1-0505HI_THT:
+    package:
+      length:
+        nominal: 19.5
+        tolerance: 0.35
+      width:
+        nominal: 6
+        tolerance: 0.35
+      height:
+        nominal: 9.5
+        tolerance: 0.35
+    top_offset: 0.9
+    left_offset: 2.4
+    pitch: 2.54
+    pins: 7
+    hidden_pins: [3, 4, 6]
+    pin:
+      length:
+        nominal: 0.5
+        # tolerance: 0.35
+      width:
+        nominal: 0.25
+        # tolerance: 0.35
+    library: "Converter_DCDC"
+    tags: "DC/DC Converter"
+    description: "Traco TEA 1HI"
+    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tea1hi_datasheet.pdf#page=3"
+    revision: "April 27, 2020"

--- a/scripts/Packages/Package_SIP_THT/size_definitions/test_traco_parts_tht.yaml
+++ b/scripts/Packages/Package_SIP_THT/size_definitions/test_traco_parts_tht.yaml
@@ -1,987 +1,958 @@
 Converter_DCDC_TRACO_TBA_1-xxxx_THT:
-    package:
-      length:
-        nominal: 11.68
-        tolerance: 0.35
-      width:
-        nominal: 6
-        tolerance: 0.35
-      height:
-        nominal: 9.65
-        tolerance: 0.35
-    top_offset: 4.65
-    left_offset: 2.03
-    pitch: 2.54
-    pins: 4
-    pin:
-      length:
-        nominal: 0.5
-      #   tolerance: 0.35
-      width:
-        nominal: 0.25
-      #   tolerance: 0.35
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TBA 1"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1_datasheet.pdf#page=3"
-    revision: "April 27, 2020"
+  package:
+    length:
+      nominal: 11.68
+      tolerance: 0.35
+    width:
+      nominal: 6
+      tolerance: 0.35
+    height:
+      nominal: 9.65
+      tolerance: 0.35
+  top_offset: 4.65
+  left_offset: 2.03
+  pitch: 2.54
+  pins: 4
+  pin:
+    length:
+      nominal: 0.5
+    #   tolerance: 0.35
+    width:
+      nominal: 0.25
+    #   tolerance: 0.35
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TBA 1"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1_datasheet.pdf#page=3"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TBA_1-xx1xE_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.35
-      width:
-        nominal: 6
-        tolerance: 0.35
-      height:
-        nominal: 9.5
-        tolerance: 0.35
-    top_offset: 1.35
-    left_offset: 2.4
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 5, 7]
-    pin:
-      length:
-        nominal: 0.5
-      #   tolerance: 0.35
-      width:
-        nominal: 0.25
-      #   tolerance: 0.35
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TBA 1E Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1e_datasheet.pdf#page=3"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TBA_1-xx1xE_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.35
+    width:
+      nominal: 6
+      tolerance: 0.35
+    height:
+      nominal: 9.5
+      tolerance: 0.35
+  top_offset: 1.35
+  left_offset: 2.4
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 5, 7]
+  pin:
+    length:
+      nominal: 0.5
+    #   tolerance: 0.35
+    width:
+      nominal: 0.25
+    #   tolerance: 0.35
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TBA 1E Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1e_datasheet.pdf#page=3"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TBA_1-xx2xE_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.35
-      width:
-        nominal: 6
-        tolerance: 0.35
-      height:
-        nominal: 9.5
-        tolerance: 0.35
-    top_offset: 1.35
-    left_offset: 2.4
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 7]
-    pin:
-      length:
-        nominal: 0.5
-      #   tolerance: 0.35
-      width:
-        nominal: 0.25
-      #   tolerance: 0.35
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TBA 1E Dual Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1e_datasheet.pdf#page=3"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TBA_1-xx2xE_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.35
+    width:
+      nominal: 6
+      tolerance: 0.35
+    height:
+      nominal: 9.5
+      tolerance: 0.35
+  top_offset: 1.35
+  left_offset: 2.4
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 7]
+  pin:
+    length:
+      nominal: 0.5
+    #   tolerance: 0.35
+    width:
+      nominal: 0.25
+    #   tolerance: 0.35
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TBA 1E Dual Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1e_datasheet.pdf#page=3"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TBA_1-xx1xHI_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.35
-      width:
-        nominal: 6
-        tolerance: 0.35
-      height:
-        nominal: 9.5
-        tolerance: 0.35
-    top_offset: 1.35
-    left_offset: 2.4
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 4, 6]
-    pin:
-      length:
-        nominal: 0.5
-      #   tolerance: 0.35
-      width:
-        nominal: 0.25
-      #   tolerance: 0.35
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TBA 1HI Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1hi_datasheet.pdf#page=3"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TBA_1-xx1xHI_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.35
+    width:
+      nominal: 6
+      tolerance: 0.35
+    height:
+      nominal: 9.5
+      tolerance: 0.35
+  top_offset: 1.35
+  left_offset: 2.4
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4, 6]
+  pin:
+    length:
+      nominal: 0.5
+    #   tolerance: 0.35
+    width:
+      nominal: 0.25
+    #   tolerance: 0.35
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TBA 1HI Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1hi_datasheet.pdf#page=3"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TBA_1-xx2xHI_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.35
-      width:
-        nominal: 6
-        tolerance: 0.35
-      height:
-        nominal: 9.5
-        tolerance: 0.35
-    top_offset: 1.35
-    left_offset: 2.4
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 4]
-    pin:
-      length:
-        nominal: 0.5
-      #   tolerance: 0.35
-      width:
-        nominal: 0.25
-      #   tolerance: 0.35
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TBA 1HI Dual Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1hi_datasheet.pdf#page=3"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TBA_1-xx2xHI_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.35
+    width:
+      nominal: 6
+      tolerance: 0.35
+    height:
+      nominal: 9.5
+      tolerance: 0.35
+  top_offset: 1.35
+  left_offset: 2.4
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4]
+  pin:
+    length:
+      nominal: 0.5
+    #   tolerance: 0.35
+    width:
+      nominal: 0.25
+    #   tolerance: 0.35
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TBA 1HI Dual Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba1hi_datasheet.pdf#page=3"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TBA_2-xx1x_THT:
-    package:
-      length:
-        nominal: 19.55
-        tolerance: 0.35
-      width:
-        nominal: 7.6
-        tolerance: 0.35
-      height:
-        nominal: 10.2
-        tolerance: 0.35
-    top_offset: 1.35
-    left_offset: 2.4
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 5, 7]
-    pin:
-      length:
-        nominal: 0.5
-      #   tolerance: 0.35
-      width:
-        nominal: 0.25
-      #   tolerance: 0.35
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TBA 2 Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba2_datasheet.pdf#page=3"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TBA_2-xx1x_THT:
+  package:
+    length:
+      nominal: 19.55
+      tolerance: 0.35
+    width:
+      nominal: 7.6
+      tolerance: 0.35
+    height:
+      nominal: 10.2
+      tolerance: 0.35
+  top_offset: 1.35
+  left_offset: 2.4
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 5, 7]
+  pin:
+    length:
+      nominal: 0.5
+    #   tolerance: 0.35
+    width:
+      nominal: 0.25
+    #   tolerance: 0.35
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TBA 2 Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba2_datasheet.pdf#page=3"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TBA_2-xx2x_THT:
-    package:
-      length:
-        nominal: 19.55
-        tolerance: 0.35
-      width:
-        nominal: 7.6
-        tolerance: 0.35
-      height:
-        nominal: 10.2
-        tolerance: 0.35
-    top_offset: 1.35
-    left_offset: 2.4
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 7]
-    pin:
-      length:
-        nominal: 0.5
-      #   tolerance: 0.35
-      width:
-        nominal: 0.25
-      #   tolerance: 0.35
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TBA 2 Dual Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba2_datasheet.pdf#page=3"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TBA_2-xx2x_THT:
+  package:
+    length:
+      nominal: 19.55
+      tolerance: 0.35
+    width:
+      nominal: 7.6
+      tolerance: 0.35
+    height:
+      nominal: 10.2
+      tolerance: 0.35
+  top_offset: 1.35
+  left_offset: 2.4
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 7]
+  pin:
+    length:
+      nominal: 0.5
+    #   tolerance: 0.35
+    width:
+      nominal: 0.25
+    #   tolerance: 0.35
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TBA 2 Dual Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tba2_datasheet.pdf#page=3"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TMA_05xxS_TMA_12xxS_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 6.1
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.175
-    left_offset: 2.4
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 5, 7]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMA 5V/12V Input Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
-    revision: "October 23, 2018"
+Converter_DCDC_TRACO_TMA_05xxS_TMA_12xxS_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 6.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.175
+  left_offset: 2.4
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 5, 7]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMA 5V/12V Input Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
 
-  Converter_DCDC_TRACO_TMA_05xxD_TMA_12xxD_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 6.1
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.175
-    left_offset: 2.4
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 7]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMA 5V/12V Input Dual Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
-    revision: "October 23, 2018"
+Converter_DCDC_TRACO_TMA_05xxD_TMA_12xxD_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 6.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.175
+  left_offset: 2.4
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 7]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMA 5V/12V Input Dual Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
 
-  Converter_DCDC_TRACO_TMA_15xxS_TMA_24xxS_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 7.1
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.175
-    left_offset: 2.4
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 5, 7]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMA 15V/24V Input Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
-    revision: "October 23, 2018"
+Converter_DCDC_TRACO_TMA_15xxS_TMA_24xxS_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 7.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.175
+  left_offset: 2.4
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 5, 7]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMA 15V/24V Input Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
 
-  Converter_DCDC_TRACO_TMA_15xxD_TMA_24xxD_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 7.1
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.175
-    left_offset: 2.4
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 7]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMA 15V/24V Input Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
-    revision: "October 23, 2018"
+Converter_DCDC_TRACO_TMA_15xxD_TMA_24xxD_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 7.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.175
+  left_offset: 2.4
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 7]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMA 15V/24V Input Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
 
-  Converter_DCDC_TRACO_TMAP_xxxxS_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.5
-      width:
-        nominal: 7.1
-        tolerance: 0.5
-      height:
-        nominal: 10.2
-        tolerance: 0.5
-    top_offset: 1.925
-    left_offset: 2.1
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 5, 7]
-    pin:
-      length:
-        nominal: 0.5
-        # tolerance: 0.5
-      width:
-        nominal: 0.25
-        # tolerance: 0.25
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMAP Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmap_datasheet.pdf#page=4"
-    revision: "August 14, 2020"
+Converter_DCDC_TRACO_TMAP_xxxxS_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.5
+    width:
+      nominal: 7.1
+      tolerance: 0.5
+    height:
+      nominal: 10.2
+      tolerance: 0.5
+  top_offset: 1.925
+  left_offset: 2.1
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 5, 7]
+  pin:
+    length:
+      nominal: 0.5
+      # tolerance: 0.5
+    width:
+      nominal: 0.25
+      # tolerance: 0.25
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMAP Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmap_datasheet.pdf#page=4"
+  revision: "August 14, 2020"
 
-  Converter_DCDC_TRACO_TMAP_xxxxD_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.5
-      width:
-        nominal: 7.1
-        tolerance: 0.5
-      height:
-        nominal: 10.2
-        tolerance: 0.5
-    top_offset: 1.925
-    left_offset: 2.1
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 7]
-    pin:
-      length:
-        nominal: 0.5
-        # tolerance: 0.5
-      width:
-        nominal: 0.25
-        # tolerance: 0.25
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMAP Dual Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmap_datasheet.pdf#page=4"
-    revision: "August 14, 2020"
+Converter_DCDC_TRACO_TMAP_xxxxD_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.5
+    width:
+      nominal: 7.1
+      tolerance: 0.5
+    height:
+      nominal: 10.2
+      tolerance: 0.5
+  top_offset: 1.925
+  left_offset: 2.1
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 7]
+  pin:
+    length:
+      nominal: 0.5
+      # tolerance: 0.5
+    width:
+      nominal: 0.25
+      # tolerance: 0.25
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMAP Dual Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmap_datasheet.pdf#page=4"
+  revision: "August 14, 2020"
 
-  Converter_DCDC_TRACO_TME_03xxS_TME_05xxS_TME_12xxS_THT:
-    package:
-      length:
-        nominal: 11.5
-        tolerance: 0.25
-      width:
-        nominal: 6.1
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 4.325
-    left_offset: 1.9
-    pitch: 2.54
-    pins: 4
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TME 3.3V/5V/12V Input Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tme_datasheet.pdf#page=3"
-    revision: "October 23, 2018"
+Converter_DCDC_TRACO_TME_03xxS_TME_05xxS_TME_12xxS_THT:
+  package:
+    length:
+      nominal: 11.5
+      tolerance: 0.25
+    width:
+      nominal: 6.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 4.325
+  left_offset: 1.9
+  pitch: 2.54
+  pins: 4
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TME 3.3V/5V/12V Input Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tme_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
 
-  Converter_DCDC_TRACO_TME_24xxS_THT:
-    package:
-      length:
-        nominal: 11.5
-        tolerance: 0.25
-      width:
-        nominal: 7.1
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 5.325
-    left_offset: 1.9
-    pitch: 2.54
-    pins: 4
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TME 24V Input Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tme_datasheet.pdf#page=3"
-    revision: "October 23, 2018"
+Converter_DCDC_TRACO_TME_24xxS_THT:
+  package:
+    length:
+      nominal: 11.5
+      tolerance: 0.25
+    width:
+      nominal: 7.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 5.325
+  left_offset: 1.9
+  pitch: 2.54
+  pins: 4
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TME 24V Input Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tme_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
 
-  Converter_DCDC_TRACO_TMR_1-xx1x_THT:
-    package:
-      length:
-        nominal: 17
-        tolerance: 0.5
-      width:
-        nominal: 7.62
-        tolerance: 0.5
-      height:
-        nominal: 11
-        tolerance: 0.5
-    top_offset: 2.375
-    left_offset: 2.15
-    pitch: 2.54
-    pins: 6
-    hidden_pins: [3, 5]
-    pin:
-      length:
-        nominal: 0.5
-        # tolerance: 0.5
-      width:
-        nominal: 0.25
-        # tolerance: 0.5
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMR 1 Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr1_datasheet.pdf#page=4"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TMR_1-xx1x_THT:
+  package:
+    length:
+      nominal: 17
+      tolerance: 0.5
+    width:
+      nominal: 7.62
+      tolerance: 0.5
+    height:
+      nominal: 11
+      tolerance: 0.5
+  top_offset: 2.375
+  left_offset: 2.15
+  pitch: 2.54
+  pins: 6
+  hidden_pins: [3, 5]
+  pin:
+    length:
+      nominal: 0.5
+      # tolerance: 0.5
+    width:
+      nominal: 0.25
+      # tolerance: 0.5
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMR 1 Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr1_datasheet.pdf#page=4"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TMR_1-xx2x_THT:
-    package:
-      length:
-        nominal: 17
-        tolerance: 0.5
-      width:
-        nominal: 7.62
-        tolerance: 0.5
-      height:
-        nominal: 11
-        tolerance: 0.5
-    top_offset: 2.375
-    left_offset: 2.15
-    pitch: 2.54
-    pins: 6
-    hidden_pins: [3]
-    pin:
-      length:
-        nominal: 0.5
-        # tolerance: 0.5
-      width:
-        nominal: 0.25
-        # tolerance: 0.5
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMR 1 Dual Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr1_datasheet.pdf#page=4"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TMR_1-xx2x_THT:
+  package:
+    length:
+      nominal: 17
+      tolerance: 0.5
+    width:
+      nominal: 7.62
+      tolerance: 0.5
+    height:
+      nominal: 11
+      tolerance: 0.5
+  top_offset: 2.375
+  left_offset: 2.15
+  pitch: 2.54
+  pins: 6
+  hidden_pins: [3]
+  pin:
+    length:
+      nominal: 0.5
+      # tolerance: 0.5
+    width:
+      nominal: 0.25
+      # tolerance: 0.5
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMR 1 Dual Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr1_datasheet.pdf#page=4"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TMV_05xxS_TMV_12xxS_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 6.1
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.375
-    left_offset: 2.3
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 4, 6]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMV 5V/12V Input Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
-    revision: "October 23, 2018"
+Converter_DCDC_TRACO_TMV_05xxS_TMV_12xxS_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 6.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.375
+  left_offset: 2.3
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4, 6]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMV 5V/12V Input Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
 
-  Converter_DCDC_TRACO_TMV_24xxS_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 7.1
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.375
-    left_offset: 2.3
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 4, 6]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMV 24V Input Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
-    revision: "October 23, 2018"
+Converter_DCDC_TRACO_TMV_24xxS_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 7.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.375
+  left_offset: 2.3
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4, 6]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMV 24V Input Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
 
-  Converter_DCDC_TRACO_TMV_05xxD_TMV_12xxD_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 6.1
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.375
-    left_offset: 2.3
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 4]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMV 5V/12V Input Dual Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
-    revision: "October 23, 2018"
+Converter_DCDC_TRACO_TMV_05xxD_TMV_12xxD_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 6.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.375
+  left_offset: 2.3
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMV 5V/12V Input Dual Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
 
-  Converter_DCDC_TRACO_TMV_24xxD_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 7.1
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.375
-    left_offset: 2.3
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 4]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMV 24V Input Dual Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
-    revision: "October 23, 2018"
+Converter_DCDC_TRACO_TMV_24xxD_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 7.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.375
+  left_offset: 2.3
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMV 24V Input Dual Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
 
-  Converter_DCDC_TRACO_TMV_xxxx_EN_THT:
-    package:
-      length:
-        nominal: 22
-        tolerance: 0.5
-      width:
-        nominal: 7.5
-        tolerance: 0.5
-      height:
-        nominal: 12.5
-        tolerance: 0.5
-    top_offset: 1.875
-    left_offset: 3.5
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 4, 6]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMV-EN Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_en_datasheet.pdf#page=3"
-    revision: "February 18, 2020"
+Converter_DCDC_TRACO_TMV_xxxx_EN_THT:
+  package:
+    length:
+      nominal: 22
+      tolerance: 0.5
+    width:
+      nominal: 7.5
+      tolerance: 0.5
+    height:
+      nominal: 12.5
+      tolerance: 0.5
+  top_offset: 1.875
+  left_offset: 3.5
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4, 6]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMV-EN Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_en_datasheet.pdf#page=3"
+  revision: "February 18, 2020"
 
-  Converter_DCDC_TRACO_TMV_xxxxD_EN_THT:
-    package:
-      length:
-        nominal: 22
-        tolerance: 0.5
-      width:
-        nominal: 7.5
-        tolerance: 0.5
-      height:
-        nominal: 12.5
-        tolerance: 0.5
-    top_offset: 1.875
-    left_offset: 3.5
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 4]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMV-EN Dual Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_en_datasheet.pdf#page=3"
-    revision: "February 18, 2020"
+Converter_DCDC_TRACO_TMV_xxxxD_EN_THT:
+  package:
+    length:
+      nominal: 22
+      tolerance: 0.5
+    width:
+      nominal: 7.5
+      tolerance: 0.5
+    height:
+      nominal: 12.5
+      tolerance: 0.5
+  top_offset: 1.875
+  left_offset: 3.5
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMV-EN Dual Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_en_datasheet.pdf#page=3"
+  revision: "February 18, 2020"
 
-  Converter_DCDC_TRACO_TMV_xxxxSHI_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.5
-      width:
-        nominal: 7.5
-        tolerance: 0.5
-      height:
-        nominal: 10.2
-        tolerance: 0.5
-    top_offset: 1.675
-    left_offset: 2.3
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 4, 6]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMV-HI Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_hi_datasheet.pdf#page=4"
-    revision: "August 27, 2020"
+Converter_DCDC_TRACO_TMV_xxxxSHI_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.5
+    width:
+      nominal: 7.5
+      tolerance: 0.5
+    height:
+      nominal: 10.2
+      tolerance: 0.5
+  top_offset: 1.675
+  left_offset: 2.3
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4, 6]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMV-HI Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_hi_datasheet.pdf#page=4"
+  revision: "August 27, 2020"
 
-  Converter_DCDC_TRACO_TMV_xxxxDHI_TMV_xxxx9HI_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.5
-      width:
-        nominal: 7.5
-        tolerance: 0.5
-      height:
-        nominal: 10.2
-        tolerance: 0.5
-    top_offset: 1.675
-    left_offset: 2.3
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 4]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMV-HI Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_hi_datasheet.pdf#page=4"
-    revision: "August 27, 2020"
+Converter_DCDC_TRACO_TMV_xxxxDHI_TMV_xxxx9HI_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.5
+    width:
+      nominal: 7.5
+      tolerance: 0.5
+    height:
+      nominal: 10.2
+      tolerance: 0.5
+  top_offset: 1.675
+  left_offset: 2.3
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMV-HI Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv_hi_datasheet.pdf#page=4"
+  revision: "August 27, 2020"
 
-  Converter_DCDC_TRACO_TRV_1-xx1xM_THT:
-    package:
-      length:
-        nominal: 19.6
-        tolerance: 0.5
-      width:
-        nominal: 9.9
-        tolerance: 0.5
-      height:
-        nominal: 12.5
-        tolerance: 0.5
-    top_offset: 2.3
-    left_offset: 1.8
-    pitch: 2
-    pins: 9
-    hidden_pins: [3, 4, 5, 6, 8]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.1
-      width:
-        nominal: 0.25
-        tolerance: 0.1
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TRV 1M Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/trv1m_datasheet.pdf#page=4"
-    revision: "August 24, 2020"
+Converter_DCDC_TRACO_TRV_1-xx1xM_THT:
+  package:
+    length:
+      nominal: 19.6
+      tolerance: 0.5
+    width:
+      nominal: 9.9
+      tolerance: 0.5
+    height:
+      nominal: 12.5
+      tolerance: 0.5
+  top_offset: 2.3
+  left_offset: 1.8
+  pitch: 2
+  pins: 9
+  hidden_pins: [3, 4, 5, 6, 8]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.1
+    width:
+      nominal: 0.25
+      tolerance: 0.1
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TRV 1M Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/trv1m_datasheet.pdf#page=4"
+  revision: "August 24, 2020"
 
-  Converter_DCDC_TRACO_TRV_1-xx2xM_THT:
-    package:
-      length:
-        nominal: 19.6
-        tolerance: 0.5
-      width:
-        nominal: 9.9
-        tolerance: 0.5
-      height:
-        nominal: 12.5
-        tolerance: 0.5
-    top_offset: 2.3
-    left_offset: 1.8
-    pitch: 2
-    pins: 9
-    hidden_pins: [3, 4, 5, 6]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.1
-      width:
-        nominal: 0.25
-        tolerance: 0.1
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TRV 1M Dual Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/trv1m_datasheet.pdf#page=4"
-    revision: "August 24, 2020"
+Converter_DCDC_TRACO_TRV_1-xx2xM_THT:
+  package:
+    length:
+      nominal: 19.6
+      tolerance: 0.5
+    width:
+      nominal: 9.9
+      tolerance: 0.5
+    height:
+      nominal: 12.5
+      tolerance: 0.5
+  top_offset: 2.3
+  left_offset: 1.8
+  pitch: 2
+  pins: 9
+  hidden_pins: [3, 4, 5, 6]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.1
+    width:
+      nominal: 0.25
+      tolerance: 0.1
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TRV 1M Dual Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/trv1m_datasheet.pdf#page=4"
+  revision: "August 24, 2020"
 
-  Converter_DCDC_TRACO_TEC_2-xxxx_TEC_2-xxxxWI_TEC_3-xxxx_TEC_3-xxxxWI_THT:
-    package:
-      length:
-        nominal: 21.8
-        tolerance: 0.5
-      width:
-        nominal: 9.1
-        tolerance: 0.5
-      height:
-        nominal: 11.2
-        tolerance: 0.5
-    top_offset: 3.325
-    left_offset: 2.02
-    pitch: 2.54
-    pins: 8
-    hidden_pins: [4]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.1
-      width:
-        nominal: 0.25
-        tolerance: 0.1
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TEC 2, TEC 2WI, TEC 3, TEC 3WI"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tec2_datasheet.pdf#page=4"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TEC_2-xxxx_TEC_2-xxxxWI_TEC_3-xxxx_TEC_3-xxxxWI_THT:
+  package:
+    length:
+      nominal: 21.8
+      tolerance: 0.5
+    width:
+      nominal: 9.1
+      tolerance: 0.5
+    height:
+      nominal: 11.2
+      tolerance: 0.5
+  top_offset: 3.325
+  left_offset: 2.02
+  pitch: 2.54
+  pins: 8
+  hidden_pins: [4]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.1
+    width:
+      nominal: 0.25
+      tolerance: 0.1
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TEC 2, TEC 2WI, TEC 3, TEC 3WI"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tec2_datasheet.pdf#page=4"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TMH_xxxxS_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 7.5
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.375
-    left_offset: 2.3
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 5, 7]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMH Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmh_datasheet.pdf#page=3"
-    revision: "October 23, 2018"
+Converter_DCDC_TRACO_TMH_xxxxS_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 7.5
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.375
+  left_offset: 2.3
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 5, 7]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMH Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmh_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
 
-  Converter_DCDC_TRACO_TMH_xxxxD_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 7.5
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.375
-    left_offset: 2.3
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 7]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMH Dual Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmh_datasheet.pdf#page=3"
-    revision: "October 23, 2018"
+Converter_DCDC_TRACO_TMH_xxxxD_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 7.5
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.375
+  left_offset: 2.3
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 7]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMH Dual Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmh_datasheet.pdf#page=3"
+  revision: "October 23, 2018"
 
-  Converter_DCDC_TRACO_TMR_xxxx_TMR_3-xxxxWI_THT:
-    package:
-      length:
-        nominal: 21.8
-        tolerance: 0.5
-      width:
-        nominal: 9.2
-        tolerance: 0.5
-      height:
-        nominal: 11.1
-        tolerance: 0.5
-    top_offset: 3.325
-    left_offset: 2
-    pitch: 2.54
-    pins: 8
-    hidden_pins: [4]
-    pin:
-      length:
-        nominal: 0.5
-        # tolerance: 0.5
-      width:
-        nominal: 0.25
-        # tolerance: 0.5
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMR 2, TMR 3WI"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr2_datasheet.pdf#page=4"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TMR_xxxx_TMR_3-xxxxWI_THT:
+  package:
+    length:
+      nominal: 21.8
+      tolerance: 0.5
+    width:
+      nominal: 9.2
+      tolerance: 0.5
+    height:
+      nominal: 11.1
+      tolerance: 0.5
+  top_offset: 3.325
+  left_offset: 2
+  pitch: 2.54
+  pins: 8
+  hidden_pins: [4]
+  pin:
+    length:
+      nominal: 0.5
+      # tolerance: 0.5
+    width:
+      nominal: 0.25
+      # tolerance: 0.5
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMR 2, TMR 3WI"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr2_datasheet.pdf#page=4"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TMR_2-xxxxE_THT:
-    package:
-      length:
-        nominal: 21.8
-        tolerance: 0.5
-      width:
-        nominal: 9.3
-        tolerance: 0.5
-      height:
-        nominal: 11.2
-        tolerance: 0.5
-    top_offset: 2.575
-    left_offset: 2
-    pitch: 2.54
-    pins: 8
-    hidden_pins: [3]
-    pin:
-      length:
-        nominal: 0.5
-        # tolerance: 0.5
-      width:
-        nominal: 0.25
-        # tolerance: 0.5
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMR 2E"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr2e_datasheet.pdf#page=4"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TMR_2-xxxxE_THT:
+  package:
+    length:
+      nominal: 21.8
+      tolerance: 0.5
+    width:
+      nominal: 9.3
+      tolerance: 0.5
+    height:
+      nominal: 11.2
+      tolerance: 0.5
+  top_offset: 2.575
+  left_offset: 2
+  pitch: 2.54
+  pins: 8
+  hidden_pins: [3]
+  pin:
+    length:
+      nominal: 0.5
+      # tolerance: 0.5
+    width:
+      nominal: 0.25
+      # tolerance: 0.5
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMR 2E"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr2e_datasheet.pdf#page=4"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TMR_2-xxxxWI_THT:
-    package:
-      length:
-        nominal: 25.95
-        tolerance: 0.5
-      width:
-        nominal: 9.25
-        tolerance: 0.5
-      height:
-        nominal: 12.45
-        tolerance: 0.5
-    top_offset: 2.375
-    left_offset: 2
-    pitch: 2.54
-    pins: 9
-    hidden_pins: [4, 5]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMR 2WI"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr2wi_datasheet.pdf#page=4"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TMR_2-xxxxWI_THT:
+  package:
+    length:
+      nominal: 25.95
+      tolerance: 0.5
+    width:
+      nominal: 9.25
+      tolerance: 0.5
+    height:
+      nominal: 12.45
+      tolerance: 0.5
+  top_offset: 2.375
+  left_offset: 2
+  pitch: 2.54
+  pins: 9
+  hidden_pins: [4, 5]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMR 2WI"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr2wi_datasheet.pdf#page=4"
+  revision: "April 27, 2020"
 
-    Converter_DCDC_TRACO_TMV_2-xxxxSHI_THT:
-      package:
-        length:
-          nominal: 19.5
-          tolerance: 0.5
-        width:
-          nominal: 7.1
-          tolerance: 0.5
-        height:
-          nominal: 10.2
-          tolerance: 0.5
-      top_offset: 1.675
-      left_offset: 2.3
-      pitch: 2.54
-      pins: 7
-      hidden_pins: [3, 4, 6]
-      pin:
-        length:
-          nominal: 0.5
-          tolerance: 0.05
-        width:
-          nominal: 0.25
-          tolerance: 0.05
-      library: "Converter_DCDC"
-      tags: "DC/DC Converter"
-      description: "Traco TMV 2HI Single Output"
-      datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv2hi_datasheet.pdf#page=4"
-      revision: "August 27, 2020"
-
-  Converter_DCDC_TRACO_TMV_2-xxxxDHI_TMV_2-xxxx9HI_THT:
+  Converter_DCDC_TRACO_TMV_2-xxxxSHI_THT:
     package:
       length:
         nominal: 19.5
@@ -996,7 +967,7 @@ Converter_DCDC_TRACO_TBA_1-xxxx_THT:
     left_offset: 2.3
     pitch: 2.54
     pins: 7
-    hidden_pins: [3, 4]
+    hidden_pins: [3, 4, 6]
     pin:
       length:
         nominal: 0.5
@@ -1006,382 +977,411 @@ Converter_DCDC_TRACO_TBA_1-xxxx_THT:
         tolerance: 0.05
     library: "Converter_DCDC"
     tags: "DC/DC Converter"
-    description: "Traco TMV 2HI Dual Output"
+    description: "Traco TMV 2HI Single Output"
     datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv2hi_datasheet.pdf#page=4"
     revision: "August 27, 2020"
 
-  Converter_DCDC_TRACO_TMR 3-xxxx_THT:
-    package:
-      length:
-        nominal: 21.8
-        tolerance: 0.5
-      width:
-        nominal: 9.2
-        tolerance: 0.5
-      height:
-        nominal: 11.1
-        tolerance: 0.5
-    top_offset: 3.325
-    left_offset: 2
-    pitch: 2.54
-    pins: 8
-    hidden_pins: [4]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.1
-      width:
-        nominal: 0.25
-        tolerance: 0.1
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMR 3"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr3_datasheet.pdf#page=4"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TMV_2-xxxxDHI_TMV_2-xxxx9HI_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.5
+    width:
+      nominal: 7.1
+      tolerance: 0.5
+    height:
+      nominal: 10.2
+      tolerance: 0.5
+  top_offset: 1.675
+  left_offset: 2.3
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMV 2HI Dual Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmv2hi_datasheet.pdf#page=4"
+  revision: "August 27, 2020"
 
-  Converter_DCDC_TRACO_TMR_3-xxxxE_TMR_3-xxxxWIE_THT:
-    package:
-      length:
-        nominal: 21.8
-        tolerance: 0.5
-      width:
-        nominal: 9.3
-        tolerance: 0.5
-      height:
-        nominal: 11.2
-        tolerance: 0.5
-    top_offset: 2.575
-    left_offset: 2
-    pitch: 2.54
-    pins: 8
-    hidden_pins: [4]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.1
-      width:
-        nominal: 0.25
-        tolerance: 0.1
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMR 3E, TMR 3WIE"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr3e_datasheet.pdf#page=4"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TMR 3-xxxx_THT:
+  package:
+    length:
+      nominal: 21.8
+      tolerance: 0.5
+    width:
+      nominal: 9.2
+      tolerance: 0.5
+    height:
+      nominal: 11.1
+      tolerance: 0.5
+  top_offset: 3.325
+  left_offset: 2
+  pitch: 2.54
+  pins: 8
+  hidden_pins: [4]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.1
+    width:
+      nominal: 0.25
+      tolerance: 0.1
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMR 3"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr3_datasheet.pdf#page=4"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TMR_3-xxxxHI_THT:
-    package:
-      length:
-        nominal: 21.8
-        tolerance: 0.5
-      width:
-        nominal: 9.2
-        tolerance: 0.5
-      height:
-        nominal: 11.1
-        tolerance: 0.5
-    top_offset: 3.325
-    left_offset: 2
-    pitch: 2.54
-    pins: 8
-    hidden_pins: [4, 5]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.1
-      width:
-        nominal: 0.25
-        tolerance: 0.1
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMR 3HI"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr3hi_datasheet.pdf#page=4"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TMR_3-xxxxE_TMR_3-xxxxWIE_THT:
+  package:
+    length:
+      nominal: 21.8
+      tolerance: 0.5
+    width:
+      nominal: 9.3
+      tolerance: 0.5
+    height:
+      nominal: 11.2
+      tolerance: 0.5
+  top_offset: 2.575
+  left_offset: 2
+  pitch: 2.54
+  pins: 8
+  hidden_pins: [4]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.1
+    width:
+      nominal: 0.25
+      tolerance: 0.1
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMR 3E, TMR 3WIE"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr3e_datasheet.pdf#page=4"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TRA_3-xxxx_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 7.6
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.175
-    left_offset: 2.55
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 5, 7]
-    pin:
-      length:
-        nominal: 0.5
-        # tolerance: 0.05
-      width:
-        nominal: 0.25
-        # tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TRA 3"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tra3_datasheet.pdf#page=3"
-    revision: "December 13, 2017"
+Converter_DCDC_TRACO_TMR_3-xxxxHI_THT:
+  package:
+    length:
+      nominal: 21.8
+      tolerance: 0.5
+    width:
+      nominal: 9.2
+      tolerance: 0.5
+    height:
+      nominal: 11.1
+      tolerance: 0.5
+  top_offset: 3.325
+  left_offset: 2
+  pitch: 2.54
+  pins: 8
+  hidden_pins: [4, 5]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.1
+    width:
+      nominal: 0.25
+      tolerance: 0.1
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMR 3HI"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr3hi_datasheet.pdf#page=4"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TMR_6-xxxx_TMR_6-xxxxWI_THT:
-    package:
-      length:
-        nominal: 21.8
-        tolerance: 0.5
-      width:
-        nominal: 9.1
-        tolerance: 0.5
-      height:
-        nominal: 11.2
-        tolerance: 0.5
-    top_offset: 3.325
-    left_offset: 2
-    pitch: 2.54
-    pins: 8
-    hidden_pins: [4]
-    pin:
-      length:
-        nominal: 0.5
-        # tolerance: 0.5
-      width:
-        nominal: 0.25
-        # tolerance: 0.5
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMR 6, TMR 6WI"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr6_datasheet.pdf#page=4"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TRA_3-xxxx_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 7.6
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.175
+  left_offset: 2.55
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 5, 7]
+  pin:
+    length:
+      nominal: 0.5
+      # tolerance: 0.05
+    width:
+      nominal: 0.25
+      # tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TRA 3"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tra3_datasheet.pdf#page=3"
+  revision: "December 13, 2017"
 
-  Converter_DCDC_TRACO_TMR_9-xxxxWI_Option_Plastic_Package_THT:
-    package:
-      length:
-        nominal: 21.8
-        tolerance: 0.5
-      width:
-        nominal: 9.1
-        tolerance: 0.5
-      height:
-        nominal: 11.2
-        tolerance: 0.5
-    top_offset: 3.325
-    left_offset: 2
-    pitch: 2.54
-    pins: 8
-    hidden_pins: [4, 5]
-    pin:
-      length:
-        nominal: 0.5
-        # tolerance: 0.5
-      width:
-        nominal: 0.25
-        # tolerance: 0.5
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMR 9WI Plastic Package Option"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr9wi_datasheet.pdf#page=5"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TMR_6-xxxx_TMR_6-xxxxWI_THT:
+  package:
+    length:
+      nominal: 21.8
+      tolerance: 0.5
+    width:
+      nominal: 9.1
+      tolerance: 0.5
+    height:
+      nominal: 11.2
+      tolerance: 0.5
+  top_offset: 3.325
+  left_offset: 2
+  pitch: 2.54
+  pins: 8
+  hidden_pins: [4]
+  pin:
+    length:
+      nominal: 0.5
+      # tolerance: 0.5
+    width:
+      nominal: 0.25
+      # tolerance: 0.5
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMR 6, TMR 6WI"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr6_datasheet.pdf#page=4"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TMA_05xxS_TMA_12xxS_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 6.1
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.175
-    left_offset: 2.1
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 5, 7]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMA 5V/12V Input Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
-    revision: "August 14, 2020"
+Converter_DCDC_TRACO_TMR_9-xxxxWI_Option_Plastic_Package_THT:
+  package:
+    length:
+      nominal: 21.8
+      tolerance: 0.5
+    width:
+      nominal: 9.1
+      tolerance: 0.5
+    height:
+      nominal: 11.2
+      tolerance: 0.5
+  top_offset: 3.325
+  left_offset: 2
+  pitch: 2.54
+  pins: 8
+  hidden_pins: [4, 5]
+  pin:
+    length:
+      nominal: 0.5
+      # tolerance: 0.5
+    width:
+      nominal: 0.25
+      # tolerance: 0.5
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMR 9WI Plastic Package Option"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tmr9wi_datasheet.pdf#page=5"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TMA_15xxS_TMA_24xxS_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 7.1
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.175
-    left_offset: 2.1
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 5, 7]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMA 15V/24V Input Single Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
-    revision: "August 14, 2020"
+Converter_DCDC_TRACO_TMA_05xxS_TMA_12xxS_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 6.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.175
+  left_offset: 2.1
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 5, 7]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMA 5V/12V Input Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+  revision: "August 14, 2020"
 
-  Converter_DCDC_TRACO_TMA_05xxD_TMA_12xxD_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 6.1
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.175
-    left_offset: 2.1
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 7]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMA 5V/12V Input Dual Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
-    revision: "August 14, 2020"
+Converter_DCDC_TRACO_TMA_15xxS_TMA_24xxS_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 7.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.175
+  left_offset: 2.1
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 5, 7]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMA 15V/24V Input Single Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+  revision: "August 14, 2020"
 
-  Converter_DCDC_TRACO_TMA_15xxD_TMA_24xxD_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.25
-      width:
-        nominal: 7.1
-        tolerance: 0.25
-      height:
-        nominal: 10.2
-        tolerance: 0.25
-    top_offset: 1.175
-    left_offset: 2.1
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 7]
-    pin:
-      length:
-        nominal: 0.5
-        tolerance: 0.05
-      width:
-        nominal: 0.25
-        tolerance: 0.05
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TMA 15V/24V Input Dual Output"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
-    revision: "August 14, 2020"
+Converter_DCDC_TRACO_TMA_05xxD_TMA_12xxD_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 6.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.175
+  left_offset: 2.1
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 7]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMA 5V/12V Input Dual Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+  revision: "August 14, 2020"
 
-  Converter_DCDC_TRACO_TEA_1-0505_THT:
-    package:
-      length:
-        nominal: 11.68
-        tolerance: 0.35
-      width:
-        nominal: 6
-        tolerance: 0.35
-      height:
-        nominal: 9.65
-        tolerance: 0.35
-    top_offset: 5.1
-    left_offset: 2.03
-    pitch: 2.54
-    pins: 4
-    pin:
-      length:
-        nominal: 0.5
-        # tolerance: 0.35
-      width:
-        nominal: 0.25
-        # tolerance: 0.35
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TEA 1"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tea1_datasheet.pdf#page=3"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TMA_15xxD_TMA_24xxD_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.25
+    width:
+      nominal: 7.1
+      tolerance: 0.25
+    height:
+      nominal: 10.2
+      tolerance: 0.25
+  top_offset: 1.175
+  left_offset: 2.1
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 7]
+  pin:
+    length:
+      nominal: 0.5
+      tolerance: 0.05
+    width:
+      nominal: 0.25
+      tolerance: 0.05
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TMA 15V/24V Input Dual Output"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tma_datasheet.pdf#page=3"
+  revision: "August 14, 2020"
 
-  Converter_DCDC_TRACO_TEA_1-0505E_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.35
-      width:
-        nominal: 6
-        tolerance: 0.35
-      height:
-        nominal: 9.5
-        tolerance: 0.35
-    top_offset: 0.9
-    left_offset: 2.4
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 5, 7]
-    pin:
-      length:
-        nominal: 0.5
-        # tolerance: 0.35
-      width:
-        nominal: 0.25
-        # tolerance: 0.35
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TEA 1E"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tea1e_datasheet.pdf#page=3"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TEA_1-0505_THT:
+  package:
+    length:
+      nominal: 11.68
+      tolerance: 0.35
+    width:
+      nominal: 6
+      tolerance: 0.35
+    height:
+      nominal: 9.65
+      tolerance: 0.35
+  top_offset: 5.1
+  left_offset: 2.03
+  pitch: 2.54
+  pins: 4
+  pin:
+    length:
+      nominal: 0.5
+      # tolerance: 0.35
+    width:
+      nominal: 0.25
+      # tolerance: 0.35
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TEA 1"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tea1_datasheet.pdf#page=3"
+  revision: "April 27, 2020"
 
-  Converter_DCDC_TRACO_TEA_1-0505HI_THT:
-    package:
-      length:
-        nominal: 19.5
-        tolerance: 0.35
-      width:
-        nominal: 6
-        tolerance: 0.35
-      height:
-        nominal: 9.5
-        tolerance: 0.35
-    top_offset: 0.9
-    left_offset: 2.4
-    pitch: 2.54
-    pins: 7
-    hidden_pins: [3, 4, 6]
-    pin:
-      length:
-        nominal: 0.5
-        # tolerance: 0.35
-      width:
-        nominal: 0.25
-        # tolerance: 0.35
-    library: "Converter_DCDC"
-    tags: "DC/DC Converter"
-    description: "Traco TEA 1HI"
-    datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tea1hi_datasheet.pdf#page=3"
-    revision: "April 27, 2020"
+Converter_DCDC_TRACO_TEA_1-0505E_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.35
+    width:
+      nominal: 6
+      tolerance: 0.35
+    height:
+      nominal: 9.5
+      tolerance: 0.35
+  top_offset: 0.9
+  left_offset: 2.4
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 5, 7]
+  pin:
+    length:
+      nominal: 0.5
+      # tolerance: 0.35
+    width:
+      nominal: 0.25
+      # tolerance: 0.35
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TEA 1E"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tea1e_datasheet.pdf#page=3"
+  revision: "April 27, 2020"
+
+Converter_DCDC_TRACO_TEA_1-0505HI_THT:
+  package:
+    length:
+      nominal: 19.5
+      tolerance: 0.35
+    width:
+      nominal: 6
+      tolerance: 0.35
+    height:
+      nominal: 9.5
+      tolerance: 0.35
+  top_offset: 0.9
+  left_offset: 2.4
+  pitch: 2.54
+  pins: 7
+  hidden_pins: [3, 4, 6]
+  pin:
+    length:
+      nominal: 0.5
+      # tolerance: 0.35
+    width:
+      nominal: 0.25
+      # tolerance: 0.35
+  library: "Converter_DCDC"
+  tags: "DC/DC Converter"
+  description: "Traco TEA 1HI"
+  datasheet: "https://www.tracopower.com/sites/default/files/products/datasheets/tea1hi_datasheet.pdf#page=3"
+  revision: "April 27, 2020"


### PR DESCRIPTION
This wraps the `makeSIPVertical` such that it can be used with Yaml files.

In the beginning of the script I defined 2 functions to calculate the drill diameter and pad sizes according to IPC. I wonder if these functions are already implemented somewhere in the repo? I haven't found any, yet. If there is no existing implementation maybe you can take a look at these functions and [How to calculate PTH hole and pad diameter sizes according to IPC-7251, IPC-2222 and IPC-2221 standards?](https://www.pcb-3d.com/tutorials/how-to-calculate-pth-hole-and-pad-diameter-sizes-according-to-ipc-7251-ipc-2222-and-ipc-2221-standards/) which I used as a reference.

Any suggestions are appreciated :)

Todo:
- [ ] Move IPC drill and pad size calculations out of the script or replace by existing function calls
- [ ] Complete Todos in the code
- [ ] Add generator for horizontal parts
- [x] Rename "missing_pins" to "hidden_pins" (missing pins are counted) in generator script
- [ ] Rename "missing_pins" to "hidden_pins" (missing pins are counted) in `makeSIPVertical`/`makeSIPHorizontal`
- [ ] Add feature to specify "deleted_pins" (deleted pins are not counted)
- [ ] Take care of huge package size tolerances - requires modifications in `makeSIPVertical`

Required for https://github.com/pointhi/kicad-footprint-generator/pull/579