### PR TITLE
Add 205338 series SMT RA header for Molex Pico-Lock (2mm pitch) family

### DIFF
--- a/scripts/Connector/Connector_SMD_single_row_plus_mounting_pad/conn_molex.yaml
+++ b/scripts/Connector/Connector_SMD_single_row_plus_mounting_pad/conn_molex.yaml
@@ -340,6 +340,33 @@ device_definition:
             #width_end: 4.5
             end_from_body_side: 1.95
 
+    PicoLock_2mm_205338_side_entry:
+        series: 'Pico-Lock'
+        mpn_format_string: '205338-{pincount:04d}'
+        orientation: 'H'
+        datasheet: 'https://www.molex.com/pdm_docs/sd/2053380002_sd.pdf'
+        pinrange: ['list', [2,4,6,8,10]]
+        text_inside_pos: 'center'
+        pitch: 2
+        pad1_position: 'bottom-left' # 'top-left' | 'bottom-left' -> pin 2 always to the right of pin 1
+        mounting_pad_size: [1.67, 2.9]
+        # x position mounting inner mounting pad edge relative to nearest pad center
+        center_pad_to_mounting_pad_edge: 2.22
+        # y dimensions for pad given relative to mounting pad edge
+        rel_pad_y_outside_edge: 8.15
+        rel_pad_y_inside_edge: 6.7
+        pad_size_x: 1.1
+        # y position for body edge relative to mounting pad edge (positive -> body extends outside bounding box)
+        rel_body_edge_y: 0.08
+        body_size_y: 7.6
+        rel_body_edge_x: 2.975
+        edge_modifier_mount_pad_side:
+            # depth measured from 3D cad model, top of connector
+            depth: 2 # > 0: cutout, < 0: protrusion
+            # Measured from 3D cad model, bottom of connector
+            start_from_body_side: 1.775
+            end_from_body_side: 1.775
+
     CLIKmate_top_entry:
         series: 'CLIK-Mate'
         mpn_format_string: '502382-{pincount:02d}70'


### PR DESCRIPTION
This PR adds the PCB headers for the 2mm pitch version of the Molex Pico-Lock family.

Currently the section "PicoLock_side_entry" in conn_molex.yaml covers only the 1.5mm pitch versions.

For the values I started with the existing PicoLock_side_entry values then updated them using a combination of:
* The datasheet ([here](https://www.molex.com/pdm_docs/sd/2053380002_sd.pdf))
* The Molex 3D model for the 2-circuit and 4-circuit connector ([4ckt version here](https://www.molex.com/pdm_docs/stp/205338-0004_stp.zip))

I then made some minor manual adjustments to the outline so that it fit more evenly around the edge of the connector when the 3D model was added.

See the below images of 3D model superimposed on the footprint, deliberately intersecting to show alignment. Note that the top and bottom of the connector are different sizes so the body outline covers the extent. The lower image shows the model flipped so that the bottom of the connector can be compared to the outline.

![datasheet](https://user-images.githubusercontent.com/203419/93001491-4518bc00-f527-11ea-9382-f74ba6dfe2b2.png)

![4ckt-footprint](https://user-images.githubusercontent.com/203419/93001487-3e8a4480-f527-11ea-962f-b6d40e36f52d.png)

![4ckt-fp-3d](https://user-images.githubusercontent.com/203419/93001497-4d70f700-f527-11ea-9095-92ed2f11027d.png)