### PR TITLE
Fix pin numbering in 1.5mm pitch Pico-Lock connectors (504050 series)

### DIFF
--- a/scripts/Connector/Connector_SMD_single_row_plus_mounting_pad/conn_molex.yaml
+++ b/scripts/Connector/Connector_SMD_single_row_plus_mounting_pad/conn_molex.yaml
@@ -318,7 +318,7 @@ device_definition:
         pinrange: ['list', [4,5,6,7,8,10,12]]
         text_inside_pos: 'center'
         pitch: 1.5
-        pad1_position: 'bottom-left' # 'top-left' | 'bottom-left' -> pin 2 always to the right of pin 1
+        pad1_position: 'top-left' # 'top-left' | 'bottom-left' -> pin 2 always to the right of pin 1
         mounting_pad_size: [1.25, 1.8]
         # x position mounting inner mounting pad edge relative to nearest pad center
         center_pad_to_mounting_pad_edge: 1.98


### PR DESCRIPTION
The existing values produce reversed ordering for pad numbering when
compared against datasheet, and the physical circuit 1 indicator on the
connector itself.

Pad 1 is the right-most pad in the orientation shown on the datasheet
(insertion from top of diagram).

Because the smd_single_row_plus_mounting_pad.py script always
places pad 1 on the left, this patch changes the rotation of the generated
footprints by 180 degrees, fixing the pin numbering.

The connector family page is [here](https://www.molex.com/molex/search/deepSearch?pQuery=category%253A%2522PCB%2BHeaders%2522%2540orientation%253A%2522Right%2BAngle%2522%2540pitchmatinginterface%253A%25221.50mm%2522%2540productname%253A%2522Pico-Lock%2522), the datasheet [here](https://www.molex.com/pdm_docs/sd/5040500291_sd.pdf).

This fixes https://github.com/KiCad/kicad-footprints/issues/2465, PR submitted here: https://github.com/KiCad/kicad-footprints/pull/2466

![image](https://user-images.githubusercontent.com/203419/93018469-db9cba00-f5c7-11ea-8aac-2f4749d026f4.png)

![image](https://user-images.githubusercontent.com/203419/93022864-40194280-f5e3-11ea-8440-1cad7f78770d.png)

