### PR TITLE
Add WQFN-20-1EP_3x3mm_P0.4mm_EP1.7x1.7mm_ThermalVias

### DIFF
--- a/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/wqfn.yaml
+++ b/scripts/Packages/Package_NoLead__DFN_QFN_LGA_SON/size_definitions/qfn/wqfn.yaml
@@ -377,3 +377,45 @@ WQFN-42-1EP_3.5x9mm_P0.5mm_EP2.05x7.55mm:
   pitch: 0.5
   num_pins_x: 4
   num_pins_y: 17
+
+WQFN-20-1EP_3x3mm_P0.4mm_EP1.7x1.7mm_ThermalVias:
+  device_type: 'WQFN'
+  #manufacturer: 'man'
+  #part_number: 'mpn'
+  size_source: 'https://www.ti.com/lit/ds/symlink/ts3ds10224.pdf#page=29'
+  ipc_class: 'qfn' # 'qfn_pull_back'
+  body_size_x:
+    minimum: 2.9
+    maximum: 3.1
+  body_size_y:
+    minimum: 2.9
+    maximum: 3.1
+  overall_height:
+    minimum: 0.7
+    maximum: 0.8
+
+  lead_width:
+    minimum: 0.15
+    maximum: 0.25
+  lead_len:
+    minimum: 0.3
+    maximum: 0.5
+
+  EP_size_x:
+    nominal: 1.8
+    tolerance: 0.1
+  EP_size_y:
+    nominal: 1.8
+    tolerance: 0.1
+  EP_num_paste_pads: [2, 2]
+
+  thermal_vias:
+    count: [2, 2]
+    grid: [1, 1]
+    drill: 0.3
+    paste_via_clearance: 0.1
+    paste_avoid_via: False
+
+  pitch: 0.4
+  num_pins_x: 5
+  num_pins_y: 5


### PR DESCRIPTION
As suggested in https://github.com/KiCad/kicad-footprints/pull/2111 I tried to create the footprint, by adding the necessary data into the YAML file.

I couldn't find a documentation of all the available properties, so there are some deviations from the suggested land pattern. There should be five thermal vias, but currently I only could implement four.

The EP should be 1.8x1.8 mm according to the data sheet, but when I check the footprint in the GUI it is only 1.7x1.7 mm. Maybe someone can give me a hint here.