### PR TITLE
Convert SSOP-10_3.9x4.9mm_P1.00mm to generator, and add SOP-10_3.9x4.9mm_P1mm and NSOP-16_3.9x9.9mm_P1.27mm

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/nsop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/nsop.yaml
@@ -3,21 +3,15 @@ FileHeader:
   device_type: 'NSOP'
 
 NSOP-16_3.9x9.9mm_P1.27mm:
-  size_source: 'JEDEC MS-012AC, https://www.holtek.com/documents/10179/11842/HT42B534-xv110.pdf'
-  body_size_x: # from JEDEC
-    nominal: 3.9
-    tolerance: 0.1
-  body_size_y:
-    minimum: 9.8
-    maximum: 10
+  size_source: 'JEDEC MS-012AC, https://www.holtek.com/documents/10179/11842/HT42B534-xv110.pdf#page=15'
+  body_size_x: 3.90
+  body_size_y: 9.90
   overall_height:
     maximum: 1.75
 
-  overall_size_x: # from JEDEC (agrees with linked datasheet)
-    nominal: 6
-    tolerance: 0.2
-  lead_len:
-    minimum: 0.4
+  overall_size_x: 6
+  lead_len: # from JEDEC (agrees with linked datasheet)
+    minimum: 0.40
     maximum: 1.27
   lead_width: # from JEDEC (agrees with linked datasheet)
     minimum: 0.31

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/nsop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/nsop.yaml
@@ -1,0 +1,28 @@
+FileHeader:
+  library_Suffix: 'SO'
+  device_type: 'NSOP'
+
+NSOP-16_3.9x9.9mm_P1.27mm:
+  size_source: 'JEDEC MS-012AC, https://www.holtek.com/documents/10179/11842/HT42B534-xv110.pdf'
+  body_size_x: # from JEDEC
+    nominal: 3.9
+    tolerance: 0.1
+  body_size_y:
+    minimum: 9.8
+    maximum: 10
+  overall_height:
+    maximum: 1.75
+
+  overall_size_x: # from JEDEC (agrees with linked datasheet)
+    nominal: 6
+    tolerance: 0.2
+  lead_len:
+    minimum: 0.4
+    maximum: 1.27
+  lead_width: # from JEDEC (agrees with linked datasheet)
+    minimum: 0.31
+    maximum: 0.51
+
+  pitch: 1.27
+  num_pins_x: 0
+  num_pins_y: 8

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/soic.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/soic.yaml
@@ -432,7 +432,7 @@ SOIC-8_7.5x5.85mm_P1.27mm:
 
 SOIC-14_3.9x8.7mm_P1.27mm:
   #round to two significant digits to comply with old name
-  custom_name_format: SOIC-{pincount:d}_{size_x:.2g}x{size_y:.2g}mm_P{pitch:g}mm
+  custom_name_format: SOIC-{pincount:s}_{size_x:.2g}x{size_y:.2g}mm_P{pitch:g}mm
   size_source: 'JEDEC MS-012AB, https://www.analog.com/media/en/package-pcb-resources/package/pkg_pdf/soic_narrow-r/r_14.pdf'
   body_size_x: # from JEDEC
     nominal: 3.9
@@ -458,7 +458,7 @@ SOIC-14_3.9x8.7mm_P1.27mm:
   num_pins_y: 7
 
 SOIC-14W_7.5x9.0mm_P1.27mm:
-  custom_name_format: SOIC-{pincount:d}W_{size_x:g}x{size_y:g}mm_P{pitch:g}mm
+  custom_name_format: SOIC-{pincount:s}W_{size_x:g}x{size_y:g}mm_P{pitch:g}mm
   size_source: 'JEDEC MS-013AF, https://www.analog.com/media/en/package-pcb-resources/package/54614177245586rw_14.pdf'
   body_size_x: # from JEDEC (agrees with linked datasheet)
     nominal: 7.5
@@ -533,7 +533,7 @@ SOIC-16_4.55x10.3mm_P1.27mm:
   num_pins_y: 8
 
 SOIC-16W_7.5x10.3mm_P1.27mm:
-  custom_name_format: SOIC-{pincount:d}W_{size_x:g}x{size_y:g}mm_P{pitch:g}mm
+  custom_name_format: SOIC-{pincount:s}W_{size_x:g}x{size_y:g}mm_P{pitch:g}mm
   size_source: 'JEDEC MS-013AA, https://www.analog.com/media/en/package-pcb-resources/package/pkg_pdf/soic_wide-rw/rw_16.pdf'
   body_size_x: # from JEDEC (agrees with linked datasheet)
     nominal: 7.5
@@ -561,7 +561,7 @@ SOIC-16W_7.5x10.3mm_P1.27mm:
 
 SOIC-16W_7.5x12.8mm_P1.27mm:
   #round to two significant digits to comply with old name
-  custom_name_format: SOIC-{pincount:d}W_{size_x:.2g}x{size_y:.3g}mm_P{pitch:g}mm
+  custom_name_format: SOIC-{pincount:s}W_{size_x:.2g}x{size_y:.3g}mm_P{pitch:g}mm
   size_source: 'https://www.analog.com/media/en/package-pcb-resources/package/pkg_pdf/ri_soic_ic/ri_16_1.pdf'
   body_size_x:
     minimum: 7.4
@@ -589,7 +589,7 @@ SOIC-16W_7.5x12.8mm_P1.27mm:
 
 SOIC-18W_7.5x11.6mm_P1.27mm:
   #round to two significant digits to comply with old name
-  custom_name_format: SOIC-{pincount:d}W_{size_x:.2g}x{size_y:.3g}mm_P{pitch:g}mm
+  custom_name_format: SOIC-{pincount:s}W_{size_x:.2g}x{size_y:.3g}mm_P{pitch:g}mm
   size_source: 'JEDEC MS-013AB, https://www.analog.com/media/en/package-pcb-resources/package/33254132129439rw_18.pdf'
   body_size_x: # from JEDEC (agrees with linked datasheet)
     nominal: 7.5
@@ -617,7 +617,7 @@ SOIC-18W_7.5x11.6mm_P1.27mm:
 
 SOIC-20W_7.5x12.8mm_P1.27mm:
   #round to two significant digits to comply with old name
-  custom_name_format: SOIC-{pincount:d}W_{size_x:.2g}x{size_y:.3g}mm_P{pitch:g}mm
+  custom_name_format: SOIC-{pincount:s}W_{size_x:.2g}x{size_y:.3g}mm_P{pitch:g}mm
   size_source: 'JEDEC MS-013AC, https://www.analog.com/media/en/package-pcb-resources/package/233848rw_20.pdf'
   body_size_x: # from JEDEC (agrees with linked datasheet)
     nominal: 7.5
@@ -645,7 +645,7 @@ SOIC-20W_7.5x12.8mm_P1.27mm:
 
 SOIC-24W_7.5x15.4mm_P1.27mm:
   #round to two significant digits to comply with old name
-  custom_name_format: SOIC-{pincount:d}W_{size_x:.2g}x{size_y:.3g}mm_P{pitch:g}mm
+  custom_name_format: SOIC-{pincount:s}W_{size_x:.2g}x{size_y:.3g}mm_P{pitch:g}mm
   size_source: 'JEDEC MS-013AD, https://www.analog.com/media/en/package-pcb-resources/package/pkg_pdf/soic_wide-rw/RW_24.pdf'
   body_size_x: # from JEDEC (agrees with linked datasheet)
     nominal: 7.5
@@ -673,7 +673,7 @@ SOIC-24W_7.5x15.4mm_P1.27mm:
 
 SOIC-28W_7.5x17.9mm_P1.27mm:
   #round to two significant digits to comply with old name
-  custom_name_format: SOIC-{pincount:d}W_{size_x:.2g}x{size_y:.3g}mm_P{pitch:g}mm
+  custom_name_format: SOIC-{pincount:s}W_{size_x:.2g}x{size_y:.3g}mm_P{pitch:g}mm
   size_source: 'JEDEC MS-013AE, https://www.analog.com/media/en/package-pcb-resources/package/35833120341221rw_28.pdf'
   body_size_x: # from JEDEC (agrees with linked datasheet)
     nominal: 7.5
@@ -701,7 +701,7 @@ SOIC-28W_7.5x17.9mm_P1.27mm:
 
 SOIC-28W_7.5x18.7mm_P1.27mm:
   #round to two significant digits to comply with old name
-  custom_name_format: SOIC-{pincount:d}W_{size_x:.2g}x{size_y:.3g}mm_P{pitch:g}mm
+  custom_name_format: SOIC-{pincount:s}W_{size_x:.2g}x{size_y:.3g}mm_P{pitch:g}mm
   size_source: 'https://www.akm.com/akm/en/file/datasheet/AK5394AVS.pdf#page=23'
   body_size_x:
     nominal: 7.5

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
@@ -199,6 +199,34 @@ SOP-8_6.62x9.15mm_P2.54mm:
   num_pins_x: 0
   num_pins_y: 4
 
+SOP-10_3.9x4.9mm_P1mm:
+  size_source: 'https://www.holtek.com/documents/10179/11842/HT42B534-xv110.pdf'
+  body_size_x:
+    minimum: 3.80
+    maximum: 4.00
+  body_size_y:
+    minimum: 4.80
+    maximum: 5.00
+  overall_height:
+    maximum: 1.75
+
+  overall_size_x:
+    minimum: 5.90
+    maximum: 6.10
+  lead_width:
+    minimum: 0.30
+    maximum: 0.45
+  lead_len:
+    # the Holtek datasheet seems to have invalid values for this measurement
+    # (it claims a maximum of 1.27, which seems too big)
+    # so use alternate source http://www.st.com/resource/en/datasheet/viper01.pdf
+    minimum: 0.40
+    maximum: 0.90
+
+  pitch: 1.00
+  num_pins_x: 0
+  num_pins_y: 5
+
 SOP-16_4.4.55x10.3mm_P1.27mm:
   size_source: 'https://toshiba.semicon-storage.com/info/docget.jsp?did=12855&prodName=TLP290-4'
   body_size_x:

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/sop.yaml
@@ -200,28 +200,19 @@ SOP-8_6.62x9.15mm_P2.54mm:
   num_pins_y: 4
 
 SOP-10_3.9x4.9mm_P1mm:
-  size_source: 'https://www.holtek.com/documents/10179/11842/HT42B534-xv110.pdf'
-  body_size_x:
-    minimum: 3.80
-    maximum: 4.00
-  body_size_y:
-    minimum: 4.80
-    maximum: 5.00
+  size_source: 'https://www.holtek.com/documents/10179/11842/HT42B534-xv110.pdf#page=13'
+  body_size_x: 3.90
+  body_size_y: 4.90
   overall_height:
     maximum: 1.75
 
-  overall_size_x:
-    minimum: 5.90
-    maximum: 6.10
+  overall_size_x: 6.00
   lead_width:
     minimum: 0.30
     maximum: 0.45
   lead_len:
-    # the Holtek datasheet seems to have invalid values for this measurement
-    # (it claims a maximum of 1.27, which seems too big)
-    # so use alternate source http://www.st.com/resource/en/datasheet/viper01.pdf
     minimum: 0.40
-    maximum: 0.90
+    maximum: 1.27
 
   pitch: 1.00
   num_pins_x: 0

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/ssop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/ssop.yaml
@@ -86,10 +86,7 @@ SSOP-8_5.25x5.24mm_P1.27mm:
   num_pins_x: 0
   num_pins_y: 4
 
-SSOP-10_3.9x4.9mm_P1.00mm:
-  #round pitch to two significant digits to comply with old name
-  custom_name_format: "SSOP-10_3.9x4.9mm_P1.00mm"
-
+SSOP-10_3.9x4.9mm_P1mm:
   size_source: 'http://www.st.com/resource/en/datasheet/viper01.pdf'
   body_size_x:
     minimum: 3.80

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/ssop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/ssop.yaml
@@ -86,6 +86,34 @@ SSOP-8_5.25x5.24mm_P1.27mm:
   num_pins_x: 0
   num_pins_y: 4
 
+SSOP-10_3.9x4.9mm_P1.00mm:
+  #round pitch to two significant digits to comply with old name
+  custom_name_format: "SSOP-10_3.9x4.9mm_P1.00mm"
+
+  size_source: 'http://www.st.com/resource/en/datasheet/viper01.pdf'
+  body_size_x:
+    minimum: 3.80
+    maximum: 4.00
+  body_size_y:
+    minimum: 4.80
+    maximum: 5.00
+  overall_height:
+    maximum: 1.75
+
+  overall_size_x:
+    minimum: 5.80
+    maximum: 6.20
+  lead_width:
+    minimum: 0.31
+    maximum: 0.51
+  lead_len:
+    minimum: 0.40
+    maximum: 0.90
+
+  pitch: 1.00
+  num_pins_x: 0
+  num_pins_y: 5
+
 SSOP-32_11.3x20.5mm_P1.27mm:
   size_source: 'http://www.issi.com/WW/pdf/61-64C5128AL.pdf'
   body_size_x:

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/ssop.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/ssop.yaml
@@ -87,18 +87,21 @@ SSOP-8_5.25x5.24mm_P1.27mm:
   num_pins_y: 4
 
 SSOP-10_3.9x4.9mm_P1mm:
-  size_source: 'http://www.st.com/resource/en/datasheet/viper01.pdf'
+  size_source: 'http://www.st.com/resource/en/datasheet/viper01.pdf#page=28'
   body_size_x:
     minimum: 3.80
+    nominal: 3.90
     maximum: 4.00
   body_size_y:
     minimum: 4.80
+    nominal: 4.90
     maximum: 5.00
   overall_height:
     maximum: 1.75
 
   overall_size_x:
     minimum: 5.80
+    nominal: 6
     maximum: 6.20
   lead_width:
     minimum: 0.31


### PR DESCRIPTION
This PR converts the existing SSOP-10_3.9x4.9mm_P1.00mm footprint to be automatically generated. (the name is overridden, so that it stays as P1.00mm rather than P1mm for compatibility).

This also adds some duplicate symbols:
* Package_SO:SSOP-10_3.9x4.9mm_P1.00mm -> Package_SO:SOP-10_3.9x4.9mm_P1mm
* Package_SO:SOIC-16_3.9x9.9mm_P1.27mm -> Package_SO:NSOP-16_3.9x9.9mm_P1.27mm

(See KiCad/kicad-footprints#2432 for explanation/justification)