### PR TITLE
MP2303 footprint added

### DIFF
--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/soic.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/soic.yaml
@@ -351,7 +351,7 @@ SOIC-8-1EP_3.9x4.9mm_P1.27mm_EP2.514x3.2mm:
 
     
        
-SOIC-8-1EP_3.9x4.9mm_P1.27mm_EP2.56x3.45mm:
+SOIC-8-1EP_3.9x4.9mm_P1.27mm_EP2.62x3.51mm:
   size_source: 'https://www.monolithicpower.com/en/documentview/productdocument/index/version/2/document_type/Datasheet/lang/en/sku/MP2303A/document_id/494#page=14'
   body_size_x:
     nominal: 3.9

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/soic.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/soic.yaml
@@ -354,19 +354,20 @@ SOIC-8-1EP_3.9x4.9mm_P1.27mm_EP2.514x3.2mm:
 SOIC-8-1EP_3.9x4.9mm_P1.27mm_EP2.62x3.51mm:
   size_source: 'https://www.monolithicpower.com/en/documentview/productdocument/index/version/2/document_type/Datasheet/lang/en/sku/MP2303A/document_id/494#page=14'
   body_size_x:
-    nominal: 3.9
-    tolerance: 0.1
+    minimum: 3.8
+    maximum: 4.0
   body_size_y:
-    nominal: 4.9
-    tolerance: 0.1
+    minimum: 4.8
+    maximum: 5.0
   overall_height:
+    minimum: 1.3
     maximum: 1.7
 
   overall_size_x:
-    nominal: 6.0
-    tolerance: 0.2
+    minimum: 5.8
+    maximum: 6.2
   lead_len:
-    minimum: 0.4
+    minimum: 0.41
     maximum: 1.27
   lead_width:
     minimum: 0.33
@@ -378,13 +379,11 @@ SOIC-8-1EP_3.9x4.9mm_P1.27mm_EP2.62x3.51mm:
 
   EP_size_x:
     minimum: 2.26
-    nominal: 2.56
-    maximum: 2.62
+    maximum: 2.56
 
   EP_size_y:
     minimum: 3.15
-    nominal: 3.45
-    maximum: 3.51
+    maximum: 3.45
 
   EP_size_x_overwrite: 2.62
   EP_size_y_overwrite: 3.51

--- a/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/soic.yaml
+++ b/scripts/Packages/Package_Gullwing__QFP_SOIC_SO/size_definitions/soic.yaml
@@ -349,6 +349,64 @@ SOIC-8-1EP_3.9x4.9mm_P1.27mm_EP2.514x3.2mm:
     # bottom_pad_size:
     paste_avoid_via: False
 
+    
+       
+SOIC-8-1EP_3.9x4.9mm_P1.27mm_EP2.56x3.45mm:
+  size_source: 'https://www.monolithicpower.com/en/documentview/productdocument/index/version/2/document_type/Datasheet/lang/en/sku/MP2303A/document_id/494#page=14'
+  body_size_x:
+    nominal: 3.9
+    tolerance: 0.1
+  body_size_y:
+    nominal: 4.9
+    tolerance: 0.1
+  overall_height:
+    maximum: 1.7
+
+  overall_size_x:
+    nominal: 6.0
+    tolerance: 0.2
+  lead_len:
+    minimum: 0.4
+    maximum: 1.27
+  lead_width:
+    minimum: 0.33
+    maximum: 0.51
+
+  pitch: 1.27
+  num_pins_x: 0
+  num_pins_y: 4
+
+  EP_size_x:
+    minimum: 2.26
+    nominal: 2.56
+    maximum: 2.62
+
+  EP_size_y:
+    minimum: 3.15
+    nominal: 3.45
+    maximum: 3.51
+
+  EP_size_x_overwrite: 2.62
+  EP_size_y_overwrite: 3.51
+
+  # EP_paste_coverage: 0.65
+  EP_num_paste_pads: [2, 2]
+
+  thermal_vias:
+    count: [2, 3]
+    drill: 0.2
+    # min_annular_ring: 0.15
+    paste_via_clearance: 0.1
+    EP_num_paste_pads: [2, 2]
+    # paste_between_vias: 1
+    # paste_rings_outside: 1
+    EP_paste_coverage: 0.7
+    grid: [1.4, 1.0]
+    # bottom_pad_size:
+    paste_avoid_via: False
+
+    
+    
 SOIC-8_5.23x5.23mm_P1.27mm:
   size_source: 'http://www.winbond.com/resource-files/w25q32jv%20revg%2003272018%20plus.pdf#page=68'
   body_size_x:


### PR DESCRIPTION
MP2303 footprint.
Documentation:
https://www.monolithicpower.com/en/documentview/productdocument/index/version/2/document_type/Datasheet/lang/en/sku/MP2303A/document_id/494

Footprint is here:
https://github.com/KiCad/kicad-footprints/pull/2502

Symbol is here:
https://github.com/KiCad/kicad-symbols/pull/2060
